### PR TITLE
Implemented polling for WISE instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ before_install:
 before_script:
 script:
 - mvn test
-- ./wise.sh run &
-- sleep 180
+- touch output.txt
+- ./wise.sh run > output.txt &
+- while ! grep "initialization completed" output.txt >/dev/null; do sleep 2; echo "polling for WISE server..."; done
 - npm test
 - npm run test-e2e
 notifications:


### PR DESCRIPTION
...instead of sleeping for an arbitrary amount of time during travis ci build. Fixes #1079.

The build succeeds here with this new method:
https://travis-ci.org/WISE-Community/WISE/builds/352507905

You can see the "polling for WISE server..." output near the middle of the build.