### PR TITLE
Moved actual check for password from ChangePasswordParametersValidator

### DIFF
--- a/src/main/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidator.java
+++ b/src/main/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidator.java
@@ -101,15 +101,13 @@ public class ChangePasswordParametersValidator implements Validator {
       userToCheckPasswordFor = params.getUser();
     }
 
-    if (!userToCheckPasswordFor.isAdmin()) {
-      String currentPassword = params.getPasswd0();
-      if (currentPassword != null) {
-        if (!userService.isPasswordCorrect(userToCheckPasswordFor, currentPassword)) {
-          errors.rejectValue("passwd0", "presentation.validators.ChangePasswordParametersValidator.errorIncorrectCurrentPassword");
-        }
-      } else {
-        errors.rejectValue("passwd0", "presentation.validators.ChangePasswordParametersValidator.errorCurrentPasswordMissing");
+    String currentPassword = params.getPasswd0();
+    if (currentPassword != null) {
+      if (!userService.isPasswordCorrect(userToCheckPasswordFor, currentPassword)) {
+        errors.rejectValue("passwd0", "presentation.validators.ChangePasswordParametersValidator.errorIncorrectCurrentPassword");
       }
+    } else {
+      errors.rejectValue("passwd0", "presentation.validators.ChangePasswordParametersValidator.errorCurrentPasswordMissing");
     }
   }
 

--- a/src/main/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidator.java
+++ b/src/main/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidator.java
@@ -25,13 +25,10 @@ package org.wise.portal.presentation.validators;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.dao.SystemWideSaltSource;
-import org.springframework.security.authentication.encoding.Md5PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
-import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.authentication.impl.BatchStudentChangePasswordParameters;
 import org.wise.portal.domain.authentication.impl.ChangePasswordParameters;
 import org.wise.portal.domain.user.User;
@@ -47,9 +44,6 @@ import org.wise.portal.service.user.UserService;
 public class ChangePasswordParametersValidator implements Validator {
 
   protected static final int MAX_PASSWORD_LENGTH = 20;
-
-  @Autowired
-  private SystemWideSaltSource systemSaltSource;
 
   @Autowired
   private UserService userService;
@@ -107,22 +101,10 @@ public class ChangePasswordParametersValidator implements Validator {
       userToCheckPasswordFor = params.getUser();
     }
 
-    try {
-      userToCheckPasswordFor = userService.retrieveById(userToCheckPasswordFor.getId());
-    } catch (ObjectNotFoundException e) {
-      errors.rejectValue("passwd0", "presentation.validators.ChangePasswordParametersValidator.errorIncorrectCurrentPassword");
-    } catch (Exception e) {
-      System.out.println("error");
-    }
     if (!userToCheckPasswordFor.isAdmin()) {
-      Md5PasswordEncoder encoder = new Md5PasswordEncoder();
       String currentPassword = params.getPasswd0();
       if (currentPassword != null) {
-        String hasedCurrentPassword = encoder.encodePassword(currentPassword, systemSaltSource.getSystemWideSalt());
-        String hashedActualCurrentPassword = userToCheckPasswordFor.getUserDetails().getPassword();
-        if (hasedCurrentPassword != null && hashedActualCurrentPassword != null &&
-            hasedCurrentPassword.equals(hashedActualCurrentPassword)) {
-        } else {
+        if (!userService.isPasswordCorrect(userToCheckPasswordFor, currentPassword)) {
           errors.rejectValue("passwd0", "presentation.validators.ChangePasswordParametersValidator.errorIncorrectCurrentPassword");
         }
       } else {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAccountController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAccountController.java
@@ -52,6 +52,7 @@ import org.wise.portal.presentation.validators.TeacherAccountFormValidator;
 import org.wise.portal.presentation.web.TeacherAccountForm;
 import org.wise.portal.presentation.web.controllers.ControllerUtil;
 import org.wise.portal.service.authentication.DuplicateUsernameException;
+import org.wise.portal.service.authentication.UserDetailsService;
 import org.wise.portal.service.mail.IMailFacade;
 import org.wise.portal.service.user.UserService;
 
@@ -109,14 +110,17 @@ public class TeacherAccountController {
       return "errors/accessdenied";
     } else {
       User signedInUser = ControllerUtil.getSignedInUser();
-      TeacherUserDetails teacherUserDetails = (TeacherUserDetails) signedInUser.getUserDetails();
-      TeacherAccountForm teacherAccountForm = new TeacherAccountForm(teacherUserDetails);
-      modelMap.addAttribute("teacherAccountForm", teacherAccountForm);
-      ChangePasswordParameters params = new ChangePasswordParameters();
-      params.setUser(signedInUser);
-      modelMap.addAttribute("changePasswordParameters", params);
-      populateModelMap(modelMap);
-      return "teacher/account";
+      if (signedInUser.isTeacher()) {
+        TeacherUserDetails teacherUserDetails = (TeacherUserDetails) signedInUser.getUserDetails();
+        TeacherAccountForm teacherAccountForm = new TeacherAccountForm(teacherUserDetails);
+        modelMap.addAttribute("teacherAccountForm", teacherAccountForm);
+        ChangePasswordParameters params = new ChangePasswordParameters();
+        params.setUser(signedInUser);
+        modelMap.addAttribute("changePasswordParameters", params);
+        populateModelMap(modelMap);
+        return "teacher/account";
+      }
+      return "errors/accessdenied";
     }
   }
 

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAccountController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAccountController.java
@@ -52,7 +52,6 @@ import org.wise.portal.presentation.validators.TeacherAccountFormValidator;
 import org.wise.portal.presentation.web.TeacherAccountForm;
 import org.wise.portal.presentation.web.controllers.ControllerUtil;
 import org.wise.portal.service.authentication.DuplicateUsernameException;
-import org.wise.portal.service.authentication.UserDetailsService;
 import org.wise.portal.service.mail.IMailFacade;
 import org.wise.portal.service.user.UserService;
 
@@ -114,9 +113,7 @@ public class TeacherAccountController {
         TeacherUserDetails teacherUserDetails = (TeacherUserDetails) signedInUser.getUserDetails();
         TeacherAccountForm teacherAccountForm = new TeacherAccountForm(teacherUserDetails);
         modelMap.addAttribute("teacherAccountForm", teacherAccountForm);
-        ChangePasswordParameters params = new ChangePasswordParameters();
-        params.setUser(signedInUser);
-        modelMap.addAttribute("changePasswordParameters", params);
+        setChangePasswordParametersInModelMap(modelMap, signedInUser);
         populateModelMap(modelMap);
         return "teacher/account";
       }
@@ -140,6 +137,12 @@ public class TeacherAccountController {
       e.printStackTrace();
     }
     return modelMap;
+  }
+
+  private void setChangePasswordParametersInModelMap(ModelMap modelMap, User user) {
+    ChangePasswordParameters params = new ChangePasswordParameters();
+    params.setUser(user);
+    modelMap.addAttribute("changePasswordParameters", params);
   }
 
   /**
@@ -207,6 +210,7 @@ public class TeacherAccountController {
     updateUserLocaleInSession(user, request);
     userService.updateUser(user);
     request.getSession().setAttribute(User.CURRENT_USER_SESSION_KEY, user);
+    setChangePasswordParametersInModelMap(modelMap, user);
     modelMap.put("accountInfoSavedMessage", "Changes saved!");
     populateModelMap(modelMap);
     return "teacher/account";
@@ -235,6 +239,7 @@ public class TeacherAccountController {
       User user = userService.retrieveById(params.getUser().getId());
       userService.updateUserPassword(user, params.getPasswd1());
       request.getSession().setAttribute(User.CURRENT_USER_SESSION_KEY, user);
+      setChangePasswordParametersInModelMap(modelMap, user);
       modelMap.put("passwordSavedMessage", "Password changes saved!");
       populateModelMap(modelMap);
       return "teacher/account";

--- a/src/main/webapp/portal/teacher/management/changepassword.jsp
+++ b/src/main/webapp/portal/teacher/management/changepassword.jsp
@@ -28,22 +28,20 @@
 					<div>
 						<form:form method="post" action="changepassword.html" commandName="changeStudentPasswordParameters" id="changestudentpassword" autocomplete='off'>
 						<table style="margin:0 auto;">
-							<sec:authorize access="!hasAnyRole('ROLE_ADMINISTRATOR')">
-								<tr>
-									<td><label for="changestudentpassword">
-										<c:choose>
-											<c:when test="${changeStudentPasswordParameters.teacherUser != null}">
-												<!-- teacher is changing the password for another user -->
-												(${changeStudentPasswordParameters.teacherUser.userDetails.username})
-											</c:when>
-											<c:otherwise>
-												<!-- user is changing their own password, don't show who should be typing their password -->
-											</c:otherwise>
-										</c:choose>
-										<spring:message code="changePassword_current" /></label></td>
-					      			<td><form:password path="passwd0" /></td>
-								</tr>
-							</sec:authorize>
+							<tr>
+								<td><label for="changestudentpassword">
+									<c:choose>
+										<c:when test="${changeStudentPasswordParameters.teacherUser != null}">
+											<!-- teacher is changing the password for another user -->
+											(${changeStudentPasswordParameters.teacherUser.userDetails.username})
+										</c:when>
+										<c:otherwise>
+											<!-- user is changing their own password, don't show who should be typing their password -->
+										</c:otherwise>
+									</c:choose>
+									<spring:message code="changePassword_current" /></label></td>
+				      			<td><form:password path="passwd0" /></td>
+							</tr>
 							<tr>
 							<td><label for="changestudentpassword">
 								<c:if test="${changeStudentPasswordParameters.teacherUser != null}">

--- a/src/test/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidatorTest.java
+++ b/src/test/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidatorTest.java
@@ -73,16 +73,14 @@ public class ChangePasswordParametersValidatorTest extends TestCase {
   private UserServiceImpl userService;
 
   @Before
-  public void setUp() throws ObjectNotFoundException {
+  public void setUp() {
     params = new ChangePasswordParameters();
     Long teacherId = new Long(1);
-    EasyMock.expect(teacherUser.isAdmin()).andReturn(false);
     params.setTeacherUser(teacherUser);
     params.setPasswd0(LEGAL_PASSWORD1);
     params.setPasswd1(LEGAL_PASSWORD2);
-    params.setPasswd2(LEGAL_PASSWORD2);  // set up is correct (both passwords match)
+    params.setPasswd2(LEGAL_PASSWORD2);
     errors = new BeanPropertyBindingResult(params, "");
-    EasyMock.replay(teacherUser);
     EasyMock.expect(userService.isPasswordCorrect(teacherUser, LEGAL_PASSWORD1)).andReturn(true);
     EasyMock.replay(userService);
   }
@@ -90,31 +88,19 @@ public class ChangePasswordParametersValidatorTest extends TestCase {
   @After
   public void tearDown() {
     EasyMock.verify(userService);
-    EasyMock.verify(teacherUser);
     validator = null;
     params = null;
     errors = null;
   }
 
   @Test
-  public void validate_allCorrectFieldsTeacherIsNotAdmin_OK() {
+  public void validate_allCorrectFieldsTeacher_OK() {
     validator.validate(params, errors);
     assertTrue(!errors.hasErrors());
   }
 
   @Test
-  public void validate_allCorrectFieldsTeacherIsAdmin_OK() {
-    EasyMock.reset(teacherUser);
-    EasyMock.expect(teacherUser.isAdmin()).andReturn(true);
-    EasyMock.replay(teacherUser);
-    EasyMock.reset(userService);
-    EasyMock.replay(userService);
-    validator.validate(params, errors);
-    assertTrue(!errors.hasErrors());
-  }
-
-  @Test
-  public void validate_emptyPassword0_error() throws ObjectNotFoundException {
+  public void validate_emptyPassword0_error() {
     params.setPasswd0(null);
     EasyMock.reset(userService);
     EasyMock.replay(userService);
@@ -125,7 +111,7 @@ public class ChangePasswordParametersValidatorTest extends TestCase {
   }
 
   @Test
-  public void validate_incorrectPassword0_error() throws ObjectNotFoundException {
+  public void validate_incorrectPassword0_error() {
     EasyMock.reset(userService);
     EasyMock.expect(userService.isPasswordCorrect(teacherUser, LEGAL_PASSWORD1)).andReturn(false);
     EasyMock.replay(userService);

--- a/src/test/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidatorTest.java
+++ b/src/test/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidatorTest.java
@@ -52,13 +52,17 @@ public class ChangePasswordParametersValidatorTest extends TestCase {
 
   private Errors errors;
 
+  private static final Long TEACHER_USER_ID = 1L;
+
   private final String LEGAL_PASSWORD1 = "Owl08963!@#$%";
+
+  private final String PASSWORD_TEACHER1 = LEGAL_PASSWORD1;
 
   private final String LEGAL_PASSWORD2 = "owl08963^&*";
 
-  private final String ILLEGAL_PASSWORD1 = "morethantwentyletters";
+  private final String PASSWORD_TOO_LONG = "morethantwentyletters";
 
-  private final String ILLEGAL_PASSWORD2 = "Ceki Gülcü";
+  private final String ILLEGAL_PASSWORD = "Ceki Gülcü";
 
   private final String EMPTY_PASSWORD = "";
 
@@ -66,52 +70,91 @@ public class ChangePasswordParametersValidatorTest extends TestCase {
   private UserImpl teacherUser;
 
   @Mock
-  private UserServiceImpl userServiceImpl;
+  private UserServiceImpl userService;
 
   @Before
   public void setUp() throws ObjectNotFoundException {
     params = new ChangePasswordParameters();
     Long teacherId = new Long(1);
-    EasyMock.expect(teacherUser.getId()).andReturn(teacherId);
-    EasyMock.expect(userServiceImpl.retrieveById(teacherId)).andReturn(teacherUser);
-    EasyMock.expect(teacherUser.isAdmin()).andReturn(true);
+    EasyMock.expect(teacherUser.isAdmin()).andReturn(false);
     params.setTeacherUser(teacherUser);
     params.setPasswd0(LEGAL_PASSWORD1);
-    params.setPasswd1(LEGAL_PASSWORD1);
-    params.setPasswd2(LEGAL_PASSWORD1);  // set up is correct (both passwords match)
+    params.setPasswd1(LEGAL_PASSWORD2);
+    params.setPasswd2(LEGAL_PASSWORD2);  // set up is correct (both passwords match)
     errors = new BeanPropertyBindingResult(params, "");
-    EasyMock.replay(userServiceImpl);
     EasyMock.replay(teacherUser);
+    EasyMock.expect(userService.isPasswordCorrect(teacherUser, LEGAL_PASSWORD1)).andReturn(true);
+    EasyMock.replay(userService);
+  }
+
+  @After
+  public void tearDown() {
+    EasyMock.verify(userService);
+    EasyMock.verify(teacherUser);
+    validator = null;
+    params = null;
+    errors = null;
   }
 
   @Test
-  public void noProblem() {
+  public void validate_allCorrectFieldsTeacherIsNotAdmin_OK() {
     validator.validate(params, errors);
     assertTrue(!errors.hasErrors());
   }
 
   @Test
-  public void emptyPassword1() {
+  public void validate_allCorrectFieldsTeacherIsAdmin_OK() {
+    EasyMock.reset(teacherUser);
+    EasyMock.expect(teacherUser.isAdmin()).andReturn(true);
+    EasyMock.replay(teacherUser);
+    EasyMock.reset(userService);
+    EasyMock.replay(userService);
+    validator.validate(params, errors);
+    assertTrue(!errors.hasErrors());
+  }
+
+  @Test
+  public void validate_emptyPassword0_error() throws ObjectNotFoundException {
+    params.setPasswd0(null);
+    EasyMock.reset(userService);
+    EasyMock.replay(userService);
+    validator.validate(params, errors);
+    assertTrue(errors.hasErrors());
+    assertEquals(1, errors.getErrorCount());
+    assertNotNull(errors.getFieldError("passwd0"));
+  }
+
+  @Test
+  public void validate_incorrectPassword0_error() throws ObjectNotFoundException {
+    EasyMock.reset(userService);
+    EasyMock.expect(userService.isPasswordCorrect(teacherUser, LEGAL_PASSWORD1)).andReturn(false);
+    EasyMock.replay(userService);
+    validator.validate(params, errors);
+    assertTrue(errors.hasErrors());
+    assertEquals(1, errors.getErrorCount());
+    assertNotNull(errors.getFieldError("passwd0"));
+  }
+
+  @Test
+  public void validate_emptyPassword1_error() {
     params.setPasswd1(EMPTY_PASSWORD);
     validator.validate(params, errors);
-
     assertTrue(errors.hasErrors());
     assertEquals(1, errors.getErrorCount());
     assertNotNull(errors.getFieldError("passwd1"));
   }
 
   @Test
-  public void emptyPassword2() {
+  public void validate_emptyPassword2_error() {
     params.setPasswd2(EMPTY_PASSWORD);
     validator.validate(params, errors);
-
     assertTrue(errors.hasErrors());
     assertEquals(1, errors.getErrorCount());
     assertNotNull(errors.getFieldError("passwd2"));
   }
 
   @Test
-  public void emptyPasswords() {
+  public void validate_emptyPassword1Password2_error() {
     params.setPasswd1(EMPTY_PASSWORD);
     params.setPasswd2(EMPTY_PASSWORD);
     validator.validate(params, errors);
@@ -121,42 +164,30 @@ public class ChangePasswordParametersValidatorTest extends TestCase {
   }
 
   @Test
-  public void illegalPassword1() {
-    params.setPasswd1(ILLEGAL_PASSWORD1);
+  public void validate_passwordTooLong_error() {
+    params.setPasswd1(PASSWORD_TOO_LONG);
     validator.validate(params, errors);
-    EasyMock.verify(teacherUser);
     assertTrue(errors.hasErrors());
     assertEquals(2, errors.getErrorCount());
     assertNotNull(errors.getFieldError("passwd1"));
   }
 
   @Test
-  public void illegalPassword2() {
-    params.setPasswd1(ILLEGAL_PASSWORD2);
+  public void validate_illegalPassword_error() {
+    params.setPasswd1(ILLEGAL_PASSWORD);
     validator.validate(params, errors);
-    EasyMock.verify(teacherUser);
     assertTrue(errors.hasErrors());
     assertEquals(1, errors.getErrorCount());
     assertNotNull(errors.getFieldError("passwd1"));
   }
 
   @Test
-  public void misMatchedPasswords() {
+  public void validate_mismatchedPasswords_error() {
     params.setPasswd1(LEGAL_PASSWORD1);
     params.setPasswd2(LEGAL_PASSWORD2);
     validator.validate(params, errors);
-
     assertTrue(errors.hasErrors());
     assertEquals(1, errors.getErrorCount());
     assertNotNull(errors.getFieldError("passwd1"));
-  }
-
-  @After
-  public void tearDown() {
-    EasyMock.verify(userServiceImpl);
-    EasyMock.verify(teacherUser);
-    validator = null;
-    params = null;
-    errors = null;
   }
 }


### PR DESCRIPTION
...to calling isPasswordCorrect method in userService. Fixes #1072. This change caused a new issue where when student tried to change their password, it threw a hibernate NonUniqueObjectException, and I fixed this by removing the userService.retrieveById call in the validator.

What to test:
1. Run mvn test and make sure that all tests pass
2. Changing password this way should work:
a. student changes their own password via account menu
b. teacher changes their own password via account menu
c. teacher changes one student's password via classroom management tool
d. teacher batch changes all students in period via classroom management tool

For 2, check that validating for wrong password works, as well as typing in correct values for all fields.