### PR TITLE
Added controller to handle direct access to routes in angular portal

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/admin/SiteController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/admin/SiteController.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2007-2018 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.wise.portal.presentation.web.controllers.admin;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+/**
+ * Controller for single-page site app built with Angular
+ * @author Hiroki Terashima
+ * @author Geoffrey Kwan
+ */
+@Controller
+@RequestMapping("/site")
+public class SiteController {
+
+  @RequestMapping(value = {"", "/student", "/student/**", "/news", "/about", "/features"},
+      method = RequestMethod.GET)
+  protected String showSite() {
+    return "forward:/site/index.html";
+  }
+}


### PR DESCRIPTION
Fixes #1110.

You should be able to access these routes directly now:

- "/site"
- "/site/about"
- "/site/news"
- "/site/features"
- "/site/student"
- "/site/student/profile/edit"

Note: The routes need to be listed in the controller RequestMapping annotation for now. We tried various regex ("/site/**", "/site/*", etc) to no avail: it was throwing a StackOverflowException. This could be a conflict with the /site url and the folder being named "site".  We should keep this in mind in the future.