### PR TITLE
Added wiseBaseURL to config. Closes #1140.

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
@@ -274,7 +274,9 @@ public class StudentAPIController {
   @RequestMapping(value = "/config", method = RequestMethod.GET)
   protected String getConfig(ModelMap modelMap) throws JSONException {
     JSONObject configJSON = new JSONObject();
-    configJSON.put("logOutURL", wiseProperties.get("wiseBaseURL") + "/logout");
+    String wiseBaseURL = (String) wiseProperties.get("wiseBaseURL");
+    configJSON.put("wiseBaseURL", wiseBaseURL);
+    configJSON.put("logOutURL", wiseBaseURL + "/logout");
     return configJSON.toString();
   }
 


### PR DESCRIPTION
We decided to use wiseBaseURL instead of context path because it will contain the full path on production servers.