### PR TITLE
Fixed server caching problem by appending version numbers to the end of .js files

### DIFF
--- a/src/main/webapp/portal/author.jsp
+++ b/src/main/webapp/portal/author.jsp
@@ -12,7 +12,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <%@ include file="favicon.jsp"%>
         <script src="${contextPath}/wise5/jspm_packages/system.js"></script>
-        <script src="${contextPath}/wise5/config.js"></script>
+        <script src="${contextPath}/wise5/config.js?v=5.7.5"></script>
         <script>
             System.import('${contextPath}/wise5/authoringTool/bootstrap');
         </script>

--- a/src/main/webapp/portal/classroomMonitor.jsp
+++ b/src/main/webapp/portal/classroomMonitor.jsp
@@ -12,7 +12,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <%@ include file="favicon.jsp"%>
         <script src="${contextPath}/wise5/jspm_packages/system.js"></script>
-        <script src="${contextPath}/wise5/config.js"></script>
+        <script src="${contextPath}/wise5/config.js?v=5.7.5"></script>
         <script>
             System.import('${contextPath}/wise5/classroomMonitor/bootstrap');
         </script>

--- a/src/main/webapp/portal/student.jsp
+++ b/src/main/webapp/portal/student.jsp
@@ -13,7 +13,7 @@
 		<%@ include file="favicon.jsp"%>
 		<link rel="apple-touch-icon" href="apple-touch-icon.png">
 	    <script src="${contextPath}/wise5/jspm_packages/system.js"></script>
-    	<script src="${contextPath}/wise5/config.js"></script>
+    	<script src="${contextPath}/wise5/config.js?v=5.7.5"></script>
 		<script>
         	System.import('${contextPath}/wise5/vle/bootstrap');
 	    </script>

--- a/src/main/webapp/wise5/config.js
+++ b/src/main/webapp/wise5/config.js
@@ -559,3 +559,16 @@ System.config({
     }
   }
 });
+
+//Cache Busting
+var systemLocate = System.locate;
+System.locate = function (load) {
+  var System = this; // its good to ensure exact instance-binding
+  return Promise.resolve(systemLocate.call(this, load)).then(function (address) {
+    if (address.endsWith('.html.js')) {
+      address = address.slice(0, -3);
+    }
+    return address + System.cacheBust;
+  });
+}
+System.cacheBust = '?v=5.7.5';


### PR DESCRIPTION
Check that changing the version number in the config.js file and author.jsp, classroomMonitor.jsp, and student.jsp files will force the browser to retrieve the file from the server instead of from cache.

Here's how to test
1. Load the VLE.
2. Update a .js file on your server like drawService.js with a comment.
3. Reload the VLE. This may or may not retrieve your changes.
4. Update the config.js, author.jsp, classroomMonitor.jsp, and student.jsp files by changing the ?v=5.7.5 to something like 5.7.6 in all these files.
5. Update the same .js file you previously changed by adding to your previous comment.
6. Reload the VLE. This should retrieve the latest version of the file you changed so that you see your latest comment.