### PR TITLE
Updated versionBump script

### DIFF
--- a/versionBump.sh
+++ b/versionBump.sh
@@ -25,4 +25,16 @@ sed -i.bak "1,/\"version\": \".*\"/{s/\"version\": \".*\"/\"version\": \"${NEW_V
 # Note: this assumes that WISE version is the first <version>...</version> tag in pom.xml
 sed -i.bak "1,/<version>.*<\/version>/{s/<version>.*<\/version>/<version>${NEW_VERSION_NUMBER}<\/version>/;}" pom.xml && rm pom.xml.bak
 
+# Note: this assumes that WISE version is in the ?v=versionNumber in jsp
+sed -i.bak "1,/config\.js\?v\=.*\""/{s/config\.js\?v\=.*\"/config\.js\?v\=${NEW_VERSION_NUMBER}\""/;}" src/main/webapp/portal/author.jsp
+
+# Note: this assumes that WISE version is in the ?v=versionNumber in jsp
+sed -i.bak "1,/config\.js\?v\=.*\""/{s/config\.js\?v\=.*\"/config\.js\?v\=${NEW_VERSION_NUMBER}\""/;}" src/main/webapp/portal/classroomMonitor.jsp
+
+# Note: this assumes that WISE version is in the ?v=versionNumber in jsp
+sed -i.bak "1,/config\.js\?v\=.*\""/{s/config\.js\?v\=.*\"/config\.js\?v\=${NEW_VERSION_NUMBER}\""/;}" src/main/webapp/portal/student.jsp
+
+# Note: this assumes that WISE version is in the ?v=versionNumber in config.js
+sed -i.bak "1,/\'\?v\=.*\'"/{s/\'\?v\=.*\'/\'\?v\=${NEW_VERSION_NUMBER}\'"/;}" src/main/webapp/wise5/config.js
+
 echo "Bumped version number to ${NEW_VERSION_NUMBER}.\nYou might want to commit changes now:\ngit commit -a -m \"Bumped version number to ${NEW_VERSION_NUMBER}\""


### PR DESCRIPTION
versionBump.sh was updated to also modify the WISE version numbers in 
  * src/main/webapp/portal/author.jsp
  * src/main/webapp/portal/classroomMonitor.jsp
  * src/main/webapp/portal/student.jsp
  * src/main/webapp/wise5/config.js

How to test:
1. run ./versionBump.sh 5.8.0
2. check that the above files as well as these files are updated to 5.8.0:
   1. package.json
   2. pom.xml
   3. src/main/resources/version.txt