### PR TITLE
Match: Fixed a problem with not being able to choose an image for a target bucket

### DIFF
--- a/src/main/webapp/wise5/components/match/authoring.html
+++ b/src/main/webapp/wise5/components/match/authoring.html
@@ -330,7 +330,7 @@
                    placeholder='{{ "TYPE_TEXT_OR_CHOOSE_AN_IMAGE" | translate }}'/>
           </md-input-container>
           <md-button class='moveComponentButton md-raised md-primary'
-                     ng-click='matchController.chooseBucketAsset(choice)'>
+                     ng-click='matchController.chooseBucketAsset(bucket)'>
             <md-icon>insert_photo</md-icon>
             <md-tooltip md-direction='top'
                         class='projectButtonTooltip'>


### PR DESCRIPTION
How to test
1. Open a Match component in the Authoring Tool
2. Add a target bucket
3. Click on the "Choose an Image" button for that target bucket
4. Choose an image
5. The <img> html should be inserted into the "Target Bucket Name"
#1325