### PR TITLE
Removed studentPreview heading from label component in run mode

### DIFF
--- a/src/main/webapp/wise5/components/label/index.html
+++ b/src/main/webapp/wise5/components/label/index.html
@@ -7,192 +7,186 @@
 </style>
 <div ng-controller='LabelController as labelController' flex>
   <br/>
-  <div ng-style='{"border": "5px solid black", "padding": "20px"}'>
-    <div>
-      <h5>{{ 'studentPreview' | translate }}</h5>
+  <div ng-switch='labelController.mode'>
+    <div ng-switch-when='grading|gradingRevision'
+        ng-switch-when-separator='|'
+        layout='row'
+        layout-wrap>
+      <div flex='100'
+          flex-gt-sm='66'
+          layout='column'
+          class='component--grading__response'>
+        <div class='component--grading__response__content'>
+          <div id='canvasParent_{{labelController.canvasId}}'
+              ng-if='labelController.$scope.componentState'>
+            <canvas id='{{labelController.canvasId}}'
+                width='800'
+                height='600'
+                style='border:1px solid black;'>
+            </canvas>
+          </div>
+        </div>
+        <span flex></span>
+        <component-revisions-info node-id='labelController.nodeId'
+            component-id='labelController.componentId'
+            to-workgroup-id='workgroupId'
+            component-state='componentState'
+            active='labelController.mode === "grading"'>
+        </component-revisions-info>
+      </div>
+      <div flex='100'
+          flex-gt-sm='33'
+          class='component--grading__annotations'>
+        <component-grading node-id='labelController.nodeId'
+            component-id='labelController.componentId'
+            max-score='labelController.componentContent.maxScore'
+            from-workgroup-id='teacherWorkgroupId'
+            to-workgroup-id='workgroupId'
+            component-state-id='componentState.id'
+            show-all-annotations='labelController.mode !== "grading"'
+            is-disabled='labelController.mode !== "grading"'>
+        </component-grading>
+      </div>
     </div>
-    <div ng-switch='labelController.mode'>
-      <div ng-switch-when='grading|gradingRevision'
-          ng-switch-when-separator='|'
+    <div ng-switch-default>
+      <div class='component__prompt'>
+        <div class='component__prompt__content'>
+          <compile data='labelController.getPrompt()'></compile>
+        </div>
+        <possible-score max-score='labelController.componentContent.maxScore'
+            ng-if='labelController.mode === "student" && !labelController.latestAnnotations.score'>
+        </possible-score>
+      </div>
+      <div class='input-wrapper' style='display: flex; align-items: center; width: 800px;'>
+        <md-button class='studentButton md-raised md-primary'
+            ng-click='labelController.newLabelButtonClicked()'
+            ng-disabled='labelController.isDisabled'
+            ng-if='labelController.showNewLabelButton() && !labelController.createLabelMode'>
+          <md-icon>add</md-icon>
+          <md-tooltip md-direction='top'
+              class='projectButtonTooltip'>
+            {{ 'label.addNewLabel' | translate }}
+          </md-tooltip>
+        </md-button>
+        <span ng-if='labelController.createLabelMode'>
+          {{ 'label.clickOnTheImageToCreateALabelOr' | translate }}
+        </span>
+        <md-button class='studentButton md-raised md-primary'
+            ng-click='labelController.cancelButtonClicked()'
+            ng-disabled='labelController.isDisabled'
+            ng-if='labelController.showCancelButton()'>
+          <md-icon>clear</md-icon>
+          <md-tooltip md-direction='top'
+              class='projectButtonTooltip'>
+            {{ 'CANCEL' | translate }}
+          <md-tooltip>
+        </md-button>
+        <span ng-if='labelController.createLabelMode'>
+          {{ 'label.toCancel' | translate }}
+        </span>
+        <span ng-if='labelController.editLabelMode'>
+          {{ 'label.labelText' | translate }}:&nbsp
+        </span>
+        <input id='editLabelTextInput'
+            type='text'
+            ng-model='labelController.selectedLabel.textString'
+            ng-if='labelController.editLabelMode'
+            ng-change='labelController.selectedLabelTextChanged(labelController.selectedLabel, labelController.selectedLabel.text, labelController.selectedLabel.textString)'
+            size='50'/>
+        <md-button class='studentButton md-raised md-primary'
+            ng-click='labelController.deleteLabelButtonClicked()'
+            ng-if='!labelController.isDisabled && labelController.selectedLabel != null && labelController.selectedLabel.canDelete'>
+          <md-icon>delete</md-icon>
+          <md-tooltip md-direction='top'
+              class='projectButtonTooltip'>
+            {{ 'DELETE' | translate }}
+          </md-tooltip>
+        </md-button>
+        <span style='flex-grow: 1;'></span>
+        <md-button class='md-accent'
+            ng-click='labelController.resetButtonClicked()'
+            ng-if='labelController.isResetButtonVisible'>
+            <md-icon>restore</md-icon>
+            {{ 'RESET' | translate }}
+        </md-button>
+        <md-button class='studentButton md-accent md-primary'
+            ng-click='labelController.snipImage($event)'
+            ng-if='labelController.isAddToNotebookEnabled()'>
+          <md-icon> note_add </md-icon>
+          <md-tooltip md-direction='top'
+              class='projectButtonTooltip'>
+            {{ 'ADD_TO_NOTEBOOK' | translate:{label:labelController.notebookConfig.label} }}
+          </md-tooltip>
+        </md-button>
+        <br/>
+        <div ng-if='labelController.componentContent.enableStudentUploadBackground'>
+          {{ 'label.uploadBackgroundImage' | translate }}:
+          <input type='file'
+              ng-if='labelController.componentContent.enableStudentUploadBackground'
+              onchange='angular.element(this).scope().fileUploadChanged(this)'
+              style='display:inline'/>
+        </div>
+      </div>
+      <div id='canvasParent_{{labelController.canvasId}}' style='margin-top: 10px;'>
+        <canvas id='{{labelController.canvasId}}'
+            width='800'
+            height='600'
+            style='border:1px solid black;'>
+        </canvas>
+      </div>
+      <div class='component__actions'
+          ng-if='labelController.attachments.length && labelController.isStudentAttachmentEnabled'
           layout='row'
-          layout-wrap>
-        <div flex='100'
-            flex-gt-sm='66'
-            layout='column'
-            class='component--grading__response'>
-          <div class='component--grading__response__content'>
-            <div id='canvasParent_{{labelController.canvasId}}'
-                ng-if='labelController.$scope.componentState'>
-              <canvas id='{{labelController.canvasId}}'
-                  width='800'
-                  height='600'
-                  style='border:1px solid black;'>
-              </canvas>
-            </div>
-          </div>
-          <span flex></span>
-          <component-revisions-info node-id='labelController.nodeId'
-              component-id='labelController.componentId'
-              to-workgroup-id='workgroupId'
-              component-state='componentState'
-              active='labelController.mode === "grading"'>
-          </component-revisions-info>
-        </div>
-        <div flex='100'
-            flex-gt-sm='33'
-            class='component--grading__annotations'>
-          <component-grading node-id='labelController.nodeId'
-              component-id='labelController.componentId'
-              max-score='labelController.componentContent.maxScore'
-              from-workgroup-id='teacherWorkgroupId'
-              to-workgroup-id='workgroupId'
-              component-state-id='componentState.id'
-              show-all-annotations='labelController.mode !== "grading"'
-              is-disabled='labelController.mode !== "grading"'>
-          </component-grading>
-        </div>
-      </div>
-      <div ng-switch-default>
-        <div class='component__prompt'>
-          <div class='component__prompt__content'>
-            <compile data='labelController.getPrompt()'></compile>
-          </div>
-          <possible-score max-score='labelController.componentContent.maxScore'
-              ng-if='labelController.mode === "student" && !labelController.latestAnnotations.score'>
-          </possible-score>
-        </div>
-        <div class='input-wrapper' style='display: flex; align-items: center; width: 800px;'>
-          <md-button class='studentButton md-raised md-primary'
-              ng-click='labelController.newLabelButtonClicked()'
-              ng-disabled='labelController.isDisabled'
-              ng-if='labelController.showNewLabelButton() && !labelController.createLabelMode'>
-            <md-icon>add</md-icon>
-            <md-tooltip md-direction='top'
-                class='projectButtonTooltip'>
-              {{ 'label.addNewLabel' | translate }}
-            </md-tooltip>
-          </md-button>
-          <span ng-if='labelController.createLabelMode'>
-            {{ 'label.clickOnTheImageToCreateALabelOr' | translate }}
-          </span>
-          <md-button class='studentButton md-raised md-primary'
-              ng-click='labelController.cancelButtonClicked()'
-              ng-disabled='labelController.isDisabled'
-              ng-if='labelController.showCancelButton()'>
-            <md-icon>clear</md-icon>
-            <md-tooltip md-direction='top'
-                class='projectButtonTooltip'>
-              {{ 'CANCEL' | translate }}
-            <md-tooltip>
-          </md-button>
-          <span ng-if='labelController.createLabelMode'>
-            {{ 'label.toCancel' | translate }}
-          </span>
-          <span ng-if='labelController.editLabelMode'>
-            {{ 'label.labelText' | translate }}:&nbsp
-          </span>
-          <input id='editLabelTextInput'
-              type='text'
-              ng-model='labelController.selectedLabel.textString'
-              ng-if='labelController.editLabelMode'
-              ng-change='labelController.selectedLabelTextChanged(labelController.selectedLabel, labelController.selectedLabel.text, labelController.selectedLabel.textString)'
-              size='50'/>
-          <md-button class='studentButton md-raised md-primary'
-              ng-click='labelController.deleteLabelButtonClicked()'
-              ng-if='!labelController.isDisabled && labelController.selectedLabel != null && labelController.selectedLabel.canDelete'>
-            <md-icon>delete</md-icon>
-            <md-tooltip md-direction='top'
-                class='projectButtonTooltip'>
-              {{ 'DELETE' | translate }}
-            </md-tooltip>
-          </md-button>
-          <span style='flex-grow: 1;'></span>
+          layout-wrap='true'>
+        <div class='component__add-attachment'>
           <md-button class='md-accent'
-              ng-click='labelController.resetButtonClicked()'
-              ng-if='labelController.isResetButtonVisible'>
-              <md-icon>restore</md-icon>
-              {{ 'RESET' | translate }}
+              ng-click='nodeController.showStudentAssets($event, component.id, labelController.isDisabled)'>
+            <md-icon>image</md-icon>
+            <span>{{ 'label.addFile' | translate }}</span>
           </md-button>
-          <md-button class='studentButton md-accent md-primary'
-              ng-click='labelController.snipImage($event)'
-              ng-if='labelController.isAddToNotebookEnabled()'>
-            <md-icon> note_add </md-icon>
-            <md-tooltip md-direction='top'
-                class='projectButtonTooltip'>
-              {{ 'ADD_TO_NOTEBOOK' | translate:{label:labelController.notebookConfig.label} }}
-            </md-tooltip>
+        </div>
+        <div class='component__attachment'
+            ng-repeat='attachment in labelController.attachments'>
+          <img ng-src='{{attachment.iconURL}}'
+              class='component__attachment__content' />
+          <md-button class='component__attachment__delete'
+              ng-click='labelController.removeAttachment(attachment)'
+              title='Remove file'>
+            <md-icon>cancel</md-icon>
           </md-button>
-          <br/>
-          <div ng-if='labelController.componentContent.enableStudentUploadBackground'>
-            {{ 'label.uploadBackgroundImage' | translate }}:
-            <input type='file'
-                ng-if='labelController.componentContent.enableStudentUploadBackground'
-                onchange='angular.element(this).scope().fileUploadChanged(this)'
-                style='display:inline'/>
-          </div>
-        </div>
-        <div id='canvasParent_{{labelController.canvasId}}' style='margin-top: 10px;'>
-          <canvas id='{{labelController.canvasId}}'
-              width='800'
-              height='600'
-              style='border:1px solid black;'>
-          </canvas>
-        </div>
-          <div class='component__actions'
-              ng-if='labelController.attachments.length && labelController.isStudentAttachmentEnabled'
-              layout='row'
-              layout-wrap='true'>
-            <div class='component__add-attachment'>
-              <md-button class='md-accent'
-                  ng-click='nodeController.showStudentAssets($event, component.id, labelController.isDisabled)'>
-                <md-icon>image</md-icon>
-                <span>{{ 'label.addFile' | translate }}</span>
-              </md-button>
-            </div>
-            <div class='component__attachment'
-                ng-repeat='attachment in labelController.attachments'>
-              <img ng-src='{{attachment.iconURL}}'
-                  class='component__attachment__content' />
-              <md-button class='component__attachment__delete'
-                  ng-click='labelController.removeAttachment(attachment)'
-                  title='Remove file'>
-                <md-icon>cancel</md-icon>
-              </md-button>
-            </div>
-          </div>
-          <div ng-if='labelController.isSaveButtonVisible || labelController.isSubmitButtonVisible'
-              class='component__actions'
-              layout='row'
-              layout-align='start center'>
-            <md-button class='md-raised md-primary'
-                ng-click='labelController.saveButtonClicked()'
-                ng-if='labelController.isSaveButtonVisible'
-                ng-disabled='labelController.isDisabled || !labelController.isDirty'>
-              {{ 'SAVE' | translate }}
-            </md-button>
-            <md-button class='md-raised md-primary'
-                ng-click='labelController.submitButtonClicked()'
-                ng-if='labelController.isSubmitButtonVisible'
-                ng-disabled='labelController.isDisabled || !labelController.isSubmitDirty || labelController.isSubmitButtonDisabled'>
-              {{ 'SUBMIT' | translate }}
-            </md-button>
-            <span ng-if='labelController.saveMessage.text'
-                class='component__actions__info md-caption'>
-              {{labelController.saveMessage.text}}
-              <span class='component__actions__more'>
-                <md-tooltip md-direction='top'>
-                  {{ labelController.saveMessage.time | amDateFormat:'ddd, MMM D YYYY, h:mm a' }}
-                </md-tooltip>
-                <span am-time-ago='labelController.saveMessage.time'></span>
-              </span>
-            </span>
-          </div>
-          <component-annotations ng-if='labelController.mode === "student"'
-              annotations='labelController.latestAnnotations'
-              max-score='labelController.componentContent.maxScore'>
-          </component-annotations>
         </div>
       </div>
+      <div ng-if='labelController.isSaveButtonVisible || labelController.isSubmitButtonVisible'
+          class='component__actions'
+          layout='row'
+          layout-align='start center'>
+        <md-button class='md-raised md-primary'
+            ng-click='labelController.saveButtonClicked()'
+            ng-if='labelController.isSaveButtonVisible'
+            ng-disabled='labelController.isDisabled || !labelController.isDirty'>
+          {{ 'SAVE' | translate }}
+        </md-button>
+        <md-button class='md-raised md-primary'
+            ng-click='labelController.submitButtonClicked()'
+            ng-if='labelController.isSubmitButtonVisible'
+            ng-disabled='labelController.isDisabled || !labelController.isSubmitDirty || labelController.isSubmitButtonDisabled'>
+          {{ 'SUBMIT' | translate }}
+        </md-button>
+        <span ng-if='labelController.saveMessage.text'
+            class='component__actions__info md-caption'>
+          {{labelController.saveMessage.text}}
+          <span class='component__actions__more'>
+            <md-tooltip md-direction='top'>
+              {{ labelController.saveMessage.time | amDateFormat:'ddd, MMM D YYYY, h:mm a' }}
+            </md-tooltip>
+            <span am-time-ago='labelController.saveMessage.time'></span>
+          </span>
+        </span>
+      </div>
+      <component-annotations ng-if='labelController.mode === "student"'
+          annotations='labelController.latestAnnotations'
+          max-score='labelController.componentContent.maxScore'>
+      </component-annotations>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Also cleaned up indentation. Closes #1353

Verify that the "studentPreview" heading no longer appears when view the label component as a student.