### PR TITLE
Populate language field

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
@@ -308,7 +308,8 @@ public class StudentAPIController {
 
   @ResponseBody
   @RequestMapping(value = "/register", method = RequestMethod.POST)
-  protected String createStudentAccount(@RequestBody Map<String, String> studentFields)
+  protected String createStudentAccount(
+      @RequestBody Map<String, String> studentFields, HttpServletRequest request)
       throws DuplicateUsernameException {
     StudentUserDetails studentUserDetails = new StudentUserDetails();
     studentUserDetails.setFirstname(studentFields.get("firstName"));
@@ -324,6 +325,8 @@ public class StudentAPIController {
     } else {
       studentUserDetails.setPassword(studentFields.get("password"));
     }
+    Locale locale = request.getLocale();
+    studentUserDetails.setLanguage(locale.getLanguage());
     User createdUser = this.userService.createUser(studentUserDetails);
     return createdUser.getUserDetails().getUsername();
   }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
@@ -127,7 +127,7 @@ public class TeacherAPIController {
   @ResponseBody
   @RequestMapping(value = "/register", method = RequestMethod.POST)
   protected String createTeacherAccount(
-    @RequestBody Map<String, String> teacherFields
+    @RequestBody Map<String, String> teacherFields, HttpServletRequest request
   ) throws DuplicateUsernameException {
     TeacherUserDetails teacherUserDetails = new TeacherUserDetails();
     teacherUserDetails.setFirstname(teacherFields.get("firstName"));
@@ -147,6 +147,8 @@ public class TeacherAPIController {
     teacherUserDetails.setSchoollevel(Schoollevel.valueOf(teacherFields.get("schoolLevel")));
     teacherUserDetails.setSchoolname(teacherFields.get("schoolName"));
     teacherUserDetails.setHowDidYouHearAboutUs(teacherFields.get("howDidYouHearAboutUs"));
+    Locale locale = request.getLocale();
+    teacherUserDetails.setLanguage(locale.getLanguage());
     User createdUser = this.userService.createUser(teacherUserDetails);
     return createdUser.getUserDetails().getUsername();
   }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
@@ -87,7 +87,11 @@ public class UserAPIController {
         userJSON.put("schoolName", teacherUserDetails.getSchoolname());
         userJSON.put("schoolLevel", teacherUserDetails.getSchoollevel());
       }
-      userJSON.put("language", userDetails.getLanguage());
+      String language = userDetails.getLanguage();
+      if (language == null) {
+        language = "en";
+      }
+      userJSON.put("language", language);
 
       return userJSON.toString();
     } else {


### PR DESCRIPTION
Make sure the language field is populated in the profile edit form for teachers and students even if their language is set to NULL in their user_details.
http://localhost:8080/wise/site/teacher/profile/edit
http://localhost:8080/wise/site/student/profile/edit

Most user accounts have their language value set to NULL in the database by default. Now when a new user registers, we set the language by looking at the request locale. Make sure new teacher and student accounts now have their user_details language set.