### PR TITLE
Removed the "Use Again" option from teacher run listing

### DIFF
--- a/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.html
+++ b/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.html
@@ -21,10 +21,6 @@
       <mat-icon>share</mat-icon>
       <span>Share</span>
     </a>
-    <a mat-menu-item (click)="showCreateRunDialog()">
-      <mat-icon>refresh</mat-icon>
-      <span>Use Again</span>
-    </a>
     <mat-divider></mat-divider>
     <a mat-menu-item *ngIf="isScheduled()">
       <mat-icon color="warn">cancel</mat-icon>

--- a/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.ts
+++ b/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { Run } from "../../domain/run";
 import { TeacherService } from "../teacher.service";
-import { CreateRunDialogComponent } from "../create-run-dialog/create-run-dialog.component";
 import { ShareRunDialogComponent } from "../share-run-dialog/share-run-dialog.component";
 
 @Component({
@@ -28,16 +27,6 @@ export class RunMenuComponent implements OnInit {
   shareRun() {
     this.dialog.open(ShareRunDialogComponent, {
       data: { run: this.run }
-    });
-  }
-
-  showCreateRunDialog() {
-    const dialogRef = this.dialog.open(CreateRunDialogComponent, {
-      data: this.run
-    });
-
-    dialogRef.afterClosed().subscribe(result => {
-      scrollTo(0, 0);
     });
   }
 


### PR DESCRIPTION
To test, load /teacher on the new Site and open the the menu for a run listing item. Make sure the "Use Again" option isn't there.