### PR TITLE
Remove anchor link for periods in run card

### DIFF
--- a/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.html
+++ b/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.html
@@ -21,10 +21,6 @@
       <mat-icon>share</mat-icon>
       <span>Share</span>
     </a>
-    <a mat-menu-item (click)="showCreateRunDialog()">
-      <mat-icon>refresh</mat-icon>
-      <span>Use Again</span>
-    </a>
     <mat-divider></mat-divider>
     <a mat-menu-item *ngIf="isScheduled()">
       <mat-icon color="warn">cancel</mat-icon>

--- a/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.ts
+++ b/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { Run } from "../../domain/run";
 import { TeacherService } from "../teacher.service";
-import { CreateRunDialogComponent } from "../create-run-dialog/create-run-dialog.component";
 import { ShareRunDialogComponent } from "../share-run-dialog/share-run-dialog.component";
 
 @Component({
@@ -28,16 +27,6 @@ export class RunMenuComponent implements OnInit {
   shareRun() {
     this.dialog.open(ShareRunDialogComponent, {
       data: { run: this.run }
-    });
-  }
-
-  showCreateRunDialog() {
-    const dialogRef = this.dialog.open(CreateRunDialogComponent, {
-      data: this.run
-    });
-
-    dialogRef.afterClosed().subscribe(result => {
-      scrollTo(0, 0);
     });
   }
 

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
@@ -6,14 +6,16 @@
         <mat-card-title [class.secondary-text]="run.endTime">{{ run.project.name }}</mat-card-title>
         <mat-card-subtitle fxHide fxShow.gt-xs>
           <div>
-            <a [matTooltip]="periodsString()" matTooltipPosition="above">
+            <span class="more-info"
+                  [matTooltip]="periodsString()"
+                  matTooltipPosition="above">
               {{run.periods.length}}
               <ng-container [ngPlural]="run.periods.length">
                 <ng-template ngPluralCase="=0">periods</ng-template>
                 <ng-template ngPluralCase="=1">period</ng-template>
                 <ng-template ngPluralCase="other">periods</ng-template>
               </ng-container>
-            </a> |
+            </span> |
             <a href="{{ manageStudentsLink }}">
               {{run.numStudents}}
               <ng-container [ngPlural]="run.numStudents">

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list/teacher-run-list.component.html
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list/teacher-run-list.component.html
@@ -14,7 +14,9 @@
                     [value]="searchValue"
                     (update)="searchChanged($event)"></app-search-bar>
     <span fxFlex="1 1 auto" fxHide fxShow.gt-sm></span>
-    <app-select-menu [options]="filterOptions"
+    <app-select-menu fxFlex="0 0 auto"
+                     fxFlex.sm="0 0 calc(50%-8px)"
+                     [options]="filterOptions"
                      [placeholderText]="'Filter By Period'"
                      [value]="filterValue"
                      (update)="filterChanged($event)"

--- a/src/main/webapp/site/src/style/base/_base.scss
+++ b/src/main/webapp/site/src/style/base/_base.scss
@@ -21,3 +21,7 @@ a {
     }
   }
 }
+
+.more-info {
+  border-bottom: 1px dotted;
+}


### PR DESCRIPTION
To test, load /teacher and make sure the periods display in run listing items doesn't look like a normal <a> link anymore but has a dotted underline. Make sure the tooltip showing the period names appears when hoevring over the periods text.

Closes #1449.