### PR TITLE
Added projectMetadata when retrieving json for a run project

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
@@ -119,6 +119,7 @@ public class TeacherAPIController {
     projectJSON.put("projectThumb", getProjectThumbIconPath(project));
     projectJSON.put("owner", getOwnerJSON(project.getOwner()));
     projectJSON.put("sharedOwners", getProjectSharedOwnersJSON(project));
+    projectJSON.put("metadata", project.getMetadata().toJSONObject());
     return projectJSON;
   }
 


### PR DESCRIPTION
To test:
- Log in as a teacher and select "Unit Info" from menu for any runs in the Class Schedule.
- Make sure project details dialog appears.

Closes #1490.