### PR TITLE
Added a copy project confirmation dialog with a copying indicator. #1455

### DIFF
--- a/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html
+++ b/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html
@@ -1,0 +1,29 @@
+<p class="copy-confirmation-message">
+  Copying a project creates a duplicate of the project. You will own the duplicate and can customize it.
+</p>
+<p class="copy-confirmation-message">
+  Are you sure you want to copy this project?
+</p>
+<p class="copy-confirmation-message">
+  Name: {{data.project.name}}<br/>
+  Unit ID: {{data.project.id}}
+</p>
+<div class="buttons-div">
+  <button mat-button
+          mat-raised-button
+          color="primary"
+          class="button"
+          (click)="copy()"
+          [disabled]="isCopying">
+    <span *ngIf="!isCopying">Copy</span>
+    <span *ngIf="isCopying">Copying...</span>
+  </button>
+  <div class="buttons-spacer"></div>
+  <button mat-button
+          mat-raised-button
+          color="primary"
+          (click)="cancel()"
+          class="button">
+    Cancel
+  </button>
+</div>

--- a/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html
+++ b/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html
@@ -1,5 +1,5 @@
 <p class="copy-confirmation-message">
-  Copying a project creates a duplicate of the project. You will own the duplicate and can customize it.
+  This will create a new copy of this project that will show up in the “My Units” section of the project library. You will be the owner of this project and can edit it.
 </p>
 <p class="copy-confirmation-message">
   Are you sure you want to copy this project?

--- a/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.scss
+++ b/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.scss
@@ -1,0 +1,18 @@
+
+.copy-confirmation-message {
+  font-size: 16px;
+  margin-bottom: 20px;
+}
+
+.buttons-div {
+  display: flex;
+  justify-content: center;
+}
+
+.buttons-spacer {
+  width: 30px;
+}
+
+.button {
+  width: 100px;
+}

--- a/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.spec.ts
@@ -1,0 +1,101 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CopyProjectDialogComponent } from './copy-project-dialog.component';
+import { LibraryService } from "../../../services/library.service";
+import { ProjectFilterOptions } from "../../../domain/projectFilterOptions";
+import { LibraryGroup } from "../libraryGroup";
+import { Project } from "../../../domain/project";
+import { fakeAsyncResponse } from "../../../student/student-run-list/student-run-list.component.spec";
+import { Observable } from 'rxjs';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+describe('CopyProjectDialogComponent', () => {
+  let component: CopyProjectDialogComponent;
+  let fixture: ComponentFixture<CopyProjectDialogComponent>;
+
+  const libraryServiceStub = {
+    getLibraryGroups(): Observable<LibraryGroup[]> {
+      const libraryGroup: LibraryGroup[] = [];
+      return Observable.create( observer => {
+        observer.next(libraryGroup);
+        observer.complete();
+      });
+    },
+    filterOptions(projectFilterOptions: ProjectFilterOptions): Observable<ProjectFilterOptions> {
+      return Observable.create(observer => {
+        observer.next(projectFilterOptions);
+        observer.complete();
+      });
+    },
+    getOfficialLibraryProjects() {
+
+    },
+    getCommunityLibraryProjects() {
+
+    },
+    getPersonalLibraryProjects() {
+
+    },
+    getSharedLibraryProjects() {
+
+    },
+    getProjectInfo(): Observable<Project> {
+      return Observable.create(observer => {
+        observer.next(projectObj);
+        observer.complete();
+      });
+    },
+    setTabIndex() {
+
+    },
+    libraryGroupsSource$: fakeAsyncResponse({}),
+    officialLibraryProjectsSource$: fakeAsyncResponse([]),
+    communityLibraryProjectsSource$: fakeAsyncResponse([]),
+    personalLibraryProjectsSource$: fakeAsyncResponse([]),
+    sharedLibraryProjectsSource$: fakeAsyncResponse([]),
+    projectFilterOptionsSource$: fakeAsyncResponse({
+      searchValue: "",
+      disciplineValue: [],
+      dciArrangementValue: [],
+      peValue: []
+    }),
+    tabIndexSource$: fakeAsyncResponse({}),
+    newProjectSource$: fakeAsyncResponse({}),
+    implementationModelOptions: []
+  };
+  const projectObj = {
+    id: 1,
+    name: "Test",
+    owner: {
+      id: 123456,
+      displayName: "Spongebob Squarepants"
+    },
+    sharedOwners: []
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CopyProjectDialogComponent ],
+      providers: [
+        { provide: LibraryService, useValue: libraryServiceStub },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {
+            project: projectObj
+          }
+        }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CopyProjectDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.spec.ts
@@ -48,6 +48,12 @@ describe('CopyProjectDialogComponent', () => {
     setTabIndex() {
 
     },
+    copyProject(): Observable<Project> {
+      return Observable.create(observer => {
+        observer.next(projectObj);
+        observer.complete();
+      });
+    },
     libraryGroupsSource$: fakeAsyncResponse({}),
     officialLibraryProjectsSource$: fakeAsyncResponse([]),
     communityLibraryProjectsSource$: fakeAsyncResponse([]),
@@ -73,13 +79,35 @@ describe('CopyProjectDialogComponent', () => {
     sharedOwners: []
   };
 
+  const getCopyButton = () => {
+    const buttons =  fixture.debugElement.nativeElement.querySelectorAll('button');
+    return buttons[0];
+  }
+
+  const getCancelButton = () => {
+    const buttons =  fixture.debugElement.nativeElement.querySelectorAll('button');
+    return buttons[1];
+  }
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ CopyProjectDialogComponent ],
       providers: [
         { provide: LibraryService, useValue: libraryServiceStub },
         { provide: MatDialog, useValue: {} },
-        { provide: MatDialogRef, useValue: {} },
+        {
+          provide: MatDialogRef, useValue: {
+            afterClosed: () => {
+              return Observable.create(observer => {
+                observer.next({});
+                observer.complete();
+              })
+            },
+            close: () => {
+
+            }
+          }
+        },
         { provide: MAT_DIALOG_DATA, useValue: {
             project: projectObj
           }
@@ -97,5 +125,22 @@ describe('CopyProjectDialogComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should click the submit button and disable it', async() => {
+    const copyButton = getCopyButton();
+    copyButton.click();
+    fixture.detectChanges();
+    expect(component.isCopying).toBe(true);
+    expect(copyButton.disabled).toBe(true);
+    expect(copyButton.querySelector('span').innerHTML).toBe('Copying...');
+  });
+
+  it('should click the cancel button and close the dialog', async() => {
+    const cancelButton = getCancelButton();
+    const dialogRefCloseSpy = spyOn(fixture.debugElement.injector.get(MatDialogRef), 'close');
+    cancelButton.click();
+    fixture.detectChanges();
+    expect(dialogRefCloseSpy).toHaveBeenCalled();
   });
 });

--- a/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.ts
@@ -1,0 +1,45 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { LibraryProjectDetailsComponent } from "../library-project-details/library-project-details.component";
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
+import { LibraryProject } from "../libraryProject";
+import { LibraryService } from "../../../services/library.service";
+
+@Component({
+  selector: 'app-copy-project-dialog',
+  templateUrl: './copy-project-dialog.component.html',
+  styleUrls: ['./copy-project-dialog.component.scss']
+})
+export class CopyProjectDialogComponent implements OnInit {
+
+  isCopying: boolean = false;
+
+  constructor(public dialog: MatDialog,
+              public dialogRef: MatDialogRef<LibraryProjectDetailsComponent>,
+              @Inject(MAT_DIALOG_DATA) public data: any,
+              private libraryService: LibraryService) {
+
+    this.libraryService.newProjectSource$.subscribe(() => {
+      this.dialog.closeAll();
+    });
+  }
+
+  ngOnInit() {
+  }
+
+  copy() {
+    this.isCopying = true;
+    this.dialogRef.afterClosed().subscribe(() => {
+      scrollTo(0, 0);
+    });
+    this.libraryService.copyProject(this.data.project.id).subscribe((newProject: LibraryProject) => {
+      const newLibraryProject: LibraryProject = new LibraryProject(newProject);
+      newLibraryProject.visible = true;
+      this.libraryService.addPersonalLibraryProject(newLibraryProject);
+    });
+  }
+
+  cancel() {
+    this.isCopying = false;
+    this.dialogRef.close();
+  }
+}

--- a/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.spec.ts
@@ -9,7 +9,6 @@ import { LibraryService } from "../../../services/library.service";
 import { UserService } from "../../../services/user.service";
 import { Project } from "../../../domain/project";
 import { NGSSStandards } from "../ngssStandards";
-import { TeacherRun } from "../../../teacher/teacher-run";
 
 @Component({ selector: 'app-library-project-menu', template: '' })
 export class LibraryProjectMenuStubComponent {

--- a/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.ts
@@ -2,9 +2,9 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
 import { LibraryService } from "../../../services/library.service";
 import { UserService } from "../../../services/user.service";
-import { LibraryProject } from "../libraryProject";
 import { CreateRunDialogComponent } from "../../../teacher/create-run-dialog/create-run-dialog.component";
 import { NGSSStandards } from "../ngssStandards";
+import { CopyProjectDialogComponent } from "../copy-project-dialog/copy-project-dialog.component";
 
 @Component({
   selector: 'app-library-project-details',
@@ -73,14 +73,8 @@ export class LibraryProjectDetailsComponent implements OnInit {
   }
 
   copyProject() {
-    this.libraryService.copyProject(this.data.project.id).subscribe((newProject: LibraryProject) => {
-      const newLibraryProject: LibraryProject = new LibraryProject(newProject);
-      newLibraryProject.visible = true;
-      this.libraryService.addPersonalLibraryProject(newLibraryProject);
-      this.dialogRef.afterClosed().subscribe(() => {
-        scrollTo(0, 0);
-      });
-      this.dialog.closeAll();
+    this.dialog.open(CopyProjectDialogComponent, {
+      data: this.data
     });
   }
 

--- a/src/main/webapp/site/src/app/modules/library/library.module.ts
+++ b/src/main/webapp/site/src/app/modules/library/library.module.ts
@@ -34,6 +34,7 @@ import { OfficialLibraryComponent } from './official-library/official-library.co
 import { CommunityLibraryComponent } from './community-library/community-library.component';
 import { PersonalLibraryComponent } from './personal-library/personal-library.component';
 import { ShareProjectDialogComponent } from './share-project-dialog/share-project-dialog.component';
+import { CopyProjectDialogComponent } from './copy-project-dialog/copy-project-dialog.component';
 
 const materialModules = [
   MatAutocompleteModule,
@@ -75,9 +76,11 @@ const materialModules = [
     OfficialLibraryComponent,
     CommunityLibraryComponent,
     PersonalLibraryComponent,
-    ShareProjectDialogComponent
+    ShareProjectDialogComponent,
+    CopyProjectDialogComponent
   ],
   entryComponents: [
+    CopyProjectDialogComponent,
     LibraryProjectDetailsComponent,
     ShareProjectDialogComponent
   ],


### PR DESCRIPTION
Open the library and choose the "Copy" option for a project.
- A confirmation dialog should display a brief explanation of what happens when a project is copied
- If "Cancel" is clicked, the confirmation dialog should close
- If "Copy" is clicked, the "Copy" button should disable and the text should change to "Copying..."
- When the copying has completed, all the dialogs should close and the library should switch to the "My Units" tab and scroll to the top

Closes #1455