### PR TITLE
Implemented automatically adding 'official' tag to projects

### DIFF
--- a/src/test/java/org/wise/portal/presentation/web/controllers/admin/ManagePortalControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/admin/ManagePortalControllerTest.java
@@ -1,0 +1,45 @@
+package org.wise.portal.presentation.web.controllers.admin;
+
+import junit.framework.TestCase;
+import org.apache.commons.io.IOUtils;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.ui.ModelMap;
+import org.wise.portal.service.portal.PortalService;
+import org.wise.portal.service.project.ProjectService;
+
+import java.io.IOException;
+
+@RunWith(EasyMockRunner.class)
+public class ManagePortalControllerTest extends TestCase {
+
+  @TestSubject
+  private ManagePortalController controller = new ManagePortalController();
+
+  @Mock
+  private PortalService portalService;
+
+  @Mock
+  private ProjectService projectService;
+
+  private ModelMap modelMap = new ModelMap();
+
+  @Test
+  public void addOfficialTagToProjectLibraryGroup_OK() throws JSONException, IOException {
+    String projectLibraryGroupJSONString = IOUtils.toString(
+        this.getClass().getResourceAsStream("/projectLibraryGroupSample.json"), "UTF-8");
+    EasyMock.expect(projectService.addTagToProject("official", new Long(24447))).andReturn(1);
+    EasyMock.expect(projectService.addTagToProject("official", new Long(24449))).andReturn(1);
+    EasyMock.expect(projectService.addTagToProject("official", new Long(24358))).andReturn(1);
+    EasyMock.expect(projectService.addTagToProject("official", new Long(24445))).andReturn(1);
+    EasyMock.replay(projectService);
+    controller.addOfficialTagToProjectLibraryGroup(projectLibraryGroupJSONString);
+    EasyMock.verify(projectService);
+  }
+
+}

--- a/src/test/resources/projectLibraryGroupSample.json
+++ b/src/test/resources/projectLibraryGroupSample.json
@@ -1,0 +1,45 @@
+[{
+  "type": "group",
+  "id": "californiaIntegrated",
+  "name": "California Integrated",
+  "children": [{
+    "type": "group",
+    "name": "6th Grade",
+    "children": [{
+      "type": "project",
+      "notes": "Test",
+      "id": 24447
+    },
+      {
+        "type": "project",
+        "notes": "Nested branch",
+        "id": 24449
+      }
+    ]
+  },
+    {
+      "type": "group",
+      "name": "7th Grade",
+      "children": [{
+        "type": "project",
+        "notes": "How Can We Recycle Old Tires? 2018",
+        "id": 24358
+      }]
+    }
+  ]
+},
+  {
+    "type": "group",
+    "id": "disciplineSpecific",
+    "name": "Discipline Specific",
+    "children": [{
+      "type": "group",
+      "name": "8th Grade",
+      "children": [{
+        "type": "project",
+        "notes": "How Can We Recycle Old Tires? Kingdom of Saudi Arabia",
+        "id": 24445
+      }]
+    }]
+  }
+]


### PR DESCRIPTION
How to test:

1. Log in as admin
2. Click on "Configure WISE Settings"
3. Edit the Project Library Groups (second textarea on the page).
4. Make sure that the "official" tag was added to each project that is referenced in the libraryGroups JSON in step 3. (see below for useful sql queries)

```
# list all projects that are tagged "official"
select * from projects_related_to_tags pt, tags t where pt.tag_fk = t.id and t.name = "official";

# delete "official" tag from all projects
delete from projects_related_to_tags where tag_fk = (select id from tags where name = "official");
```

#1497