### PR TITLE
Download sample csv for creating batch student accounts.

### DIFF
--- a/src/main/webapp/portal/admin/account/batchcreateuseraccounts.jsp
+++ b/src/main/webapp/portal/admin/account/batchcreateuseraccounts.jsp
@@ -48,7 +48,7 @@
 		</c:if>
 
 		<br>
-		<div>Please choose a CSV file with student account information. <a href="${contextPath}/portal/pages/resources/WISE_BatchCreateUserAccounts_Sample.csv"><spring:message code="admin.account.batchcreateuseraccounts.sampleFile" /></a></div>
+		<div>Please choose a CSV file with student account information. <a href="${contextPath}/pages/resources/WISE_BatchCreateUserAccounts_Sample.csv"><spring:message code="admin.account.batchcreateuseraccounts.sampleFile" /></a></div>
 		<br/>
 		<form:form method="post" action="batchcreateuseraccounts.html"
 				   commandName="csvFile" id="csvFileForm" enctype="multipart/form-data" autocomplete='off' onsubmit="return validateForm();">


### PR DESCRIPTION
This also removed CRLF from file as a byproduct of the change and file save. The only change I made is removing /portal from the link to download.

Before:
```
<a href="${contextPath}/portal/pages/resources/WISE_BatchCreateUserAccounts_Sample.csv">
```

After:
```
<a href="${contextPath}/pages/resources/WISE_BatchCreateUserAccounts_Sample.csv">
```

How to test:
1. Log in as admin.
2. Click on "Batch Create User Accounts"
3. Click on "Download Sample CSV File"

This should download the sample CSV file. Before it was throwing an error page not found.

Closes #1494.