### PR TITLE
Limit access to JSON blocks in API call to fetch library projects

### DIFF
--- a/src/main/java/org/wise/portal/domain/user/User.java
+++ b/src/main/java/org/wise/portal/domain/user/User.java
@@ -34,46 +34,17 @@ public interface User extends Persistable {
 
   Long getId();
 
-  /**
-   * Gets the UserDetails object.
-   *
-   * @return the userDetails
-   */
   MutableUserDetails getUserDetails();
 
-  /**
-   * Sets the UserDetails object
-   *
-   * @param userDetails
-   *            the userDetails to set
-   */
   void setUserDetails(MutableUserDetails userDetails);
 
-  /**
-   * Returns true if this use is an admin, false otherwise.
-   *
-   * @return boolean
-   */
   boolean isAdmin();
 
-  /**
-   * Returns true if this use is an student, false otherwise.
-   *
-   * @return boolean
-   */
+  boolean isResearcher();
+
   boolean isStudent();
 
-  /**
-   * Returns true if this use is an teacher, false otherwise.
-   *
-   * @return boolean
-   */
   boolean isTeacher();
 
-  /**
-   * Returns true if this use is a trusted author, false otherwise
-   *
-   * @return boolean
-   */
   boolean isTrustedAuthor();
 }

--- a/src/main/java/org/wise/portal/domain/user/impl/UserImpl.java
+++ b/src/main/java/org/wise/portal/domain/user/impl/UserImpl.java
@@ -81,6 +81,10 @@ public class UserImpl implements User {
     return this.userDetails.hasGrantedAuthority(UserDetailsService.ADMIN_ROLE);
   }
 
+  public boolean isResearcher() {
+    return this.userDetails.hasGrantedAuthority(UserDetailsService.RESEARCHER_ROLE);
+  }
+
   public boolean isTrustedAuthor() {
     return this.userDetails.hasGrantedAuthority(UserDetailsService.TRUSTED_AUTHOR_ROLE);
   }


### PR DESCRIPTION
How to test:

1. Log in as admin and go to configure WISE settings.
2. For project library groups, add
```
accessRoles: [
  "admin",
  "researcher"
],
```
to some of the group blocks (e.g. "6th grade" ,"7th grade").

3. Still logged in as admin, make a request to /api/project/library. You should get all of the project library groups.
4. Open another window (or log out) and make the same request to /api/project/library. You should not get the group blocks that you added in step 2.

Closes #1551