### PR TITLE
Implemented mobile menu for site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -792,6 +792,12 @@
         }
       }
     },
+    "@types/grecaptcha": {
+      "version": "2.0.35",
+      "resolved": "https://registry.npmjs.org/@types/grecaptcha/-/grecaptcha-2.0.35.tgz",
+      "integrity": "sha512-s0WTB7do/+9IHBAMzZs3UNM8JygJxW5UTycdXof1hQ/+2jp2HAJ0JbMzFr+BcXWZ1TMUm6jCPVF+ImZtpMt1Jw==",
+      "optional": true
+    },
     "@types/jasmine": {
       "version": "2.5.54",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.54.tgz",
@@ -10762,6 +10768,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "ng-recaptcha": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ng-recaptcha/-/ng-recaptcha-4.0.0.tgz",
+      "integrity": "sha512-eT62d14cK4IRhrp9g/T8nsZdnDCBodBPDf90mhLVZMxHmx5uXIt0R+zdc0VpZgrgqpHyrpl6KQY4cLkik2l+6g==",
+      "requires": {
+        "@types/grecaptcha": "^2.0.33"
+      }
     },
     "ngx-moment": {
       "version": "3.1.0",

--- a/src/main/webapp/site/src/app/app.component.html
+++ b/src/main/webapp/site/src/app/app.component.html
@@ -1,3 +1,10 @@
-<app-header class="dark-theme" *ngIf="showHeaderAndFooter()"></app-header>
-<router-outlet></router-outlet>
-<app-footer *ngIf="showHeaderAndFooter()"></app-footer>
+<mat-sidenav-container class="root-content">
+  <mat-sidenav #mainMenu [(opened)]="showMobileMenu" position="end">
+    Mobile menu content
+  </mat-sidenav>
+  <mat-sidenav-content>
+    <app-header class="dark-theme" *ngIf="showHeaderAndFooter()"></app-header>
+    <router-outlet></router-outlet>
+    <app-footer *ngIf="showHeaderAndFooter()"></app-footer>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/src/main/webapp/site/src/app/app.component.html
+++ b/src/main/webapp/site/src/app/app.component.html
@@ -1,6 +1,9 @@
-<mat-sidenav-container class="root-content">
-  <mat-sidenav #mainMenu [(opened)]="showMobileMenu" position="end">
-    Mobile menu content
+<mat-sidenav-container fullscreen>
+  <mat-sidenav #mobileMenu
+               class="primary-bg"
+               [(opened)]="showMobileMenu"
+               position="end">
+    <app-mobile-menu></app-mobile-menu>
   </mat-sidenav>
   <mat-sidenav-content>
     <app-header class="dark-theme" *ngIf="showHeaderAndFooter()"></app-header>

--- a/src/main/webapp/site/src/app/app.component.spec.ts
+++ b/src/main/webapp/site/src/app/app.component.spec.ts
@@ -3,14 +3,43 @@ import { AppComponent } from './app.component';
 import { Component } from "@angular/core";
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
+import { MediaChange, ObservableMedia } from '@angular/flex-layout';
+import { Observable } from 'rxjs';
+import { UtilService } from "./services/util.service";
 
 @Component({selector: 'router-outlet', template: ''})
 class RouterOutletStubComponent { }
 
+export class MockUtilService {
+  getMobileMenuState(): Observable<boolean> {
+    return Observable.create(observer => {
+      const state: boolean = false;
+      observer.next(state);
+      observer.complete();
+    });
+  }
+}
+
+export class MockObservableMedia {
+  isActive(query: string): boolean {
+    return false;
+  }
+
+  subscribe(): Observable<MediaChange> {
+    return Observable.create(observer => {
+      observer.next(new MediaChange());
+      observer.complete();
+    });
+  }
+}
+
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      providers: [],
+      providers: [
+        { provide: UtilService, useClass: MockUtilService },
+        { provide: ObservableMedia, useClass: MockObservableMedia }
+      ],
       declarations: [ AppComponent ],
       imports: [ RouterTestingModule ],
       schemas: [ NO_ERRORS_SCHEMA ]

--- a/src/main/webapp/site/src/app/app.component.ts
+++ b/src/main/webapp/site/src/app/app.component.ts
@@ -2,6 +2,9 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MatIconRegistry } from '@angular/material';
+import { Subscription } from 'rxjs';
+import { MediaChange, ObservableMedia } from '@angular/flex-layout';
+import { UtilService } from "./services/util.service";
 
 @Component({
   selector: 'app-root',
@@ -10,9 +13,14 @@ import { MatIconRegistry } from '@angular/material';
 })
 export class AppComponent {
   title = 'app';
+  showMobileMenu: boolean = false;
+  mediaWatcher: Subscription;
 
-  constructor(private router: Router, iconRegistry: MatIconRegistry,
-      sanitizer: DomSanitizer) {
+  constructor(private router: Router,
+              iconRegistry: MatIconRegistry,
+              sanitizer: DomSanitizer,
+              utilService: UtilService,
+              media: ObservableMedia) {
     iconRegistry.addSvgIcon(
       'ki-elicit',
       sanitizer.bypassSecurityTrustResourceUrl('assets/img/icons/ki-elicit.svg')
@@ -37,6 +45,15 @@ export class AppComponent {
       'twitter',
       sanitizer.bypassSecurityTrustResourceUrl('assets/img/icons/twitter.svg')
     );
+    utilService.getMobileMenuState()
+      .subscribe(state => {
+        this.showMobileMenu = state;
+      });
+    this.mediaWatcher = media.subscribe((change: MediaChange) => {
+      if (media.isActive('gt-sm')) {
+        utilService.showMobileMenu(false);
+      }
+    });
   }
 
   showHeaderAndFooter(): boolean {

--- a/src/main/webapp/site/src/app/app.component.ts
+++ b/src/main/webapp/site/src/app/app.component.ts
@@ -54,6 +54,9 @@ export class AppComponent {
         utilService.showMobileMenu(false);
       }
     });
+    router.events.subscribe((event) => {
+      utilService.showMobileMenu(false);
+    });
   }
 
   showHeaderAndFooter(): boolean {

--- a/src/main/webapp/site/src/app/app.module.ts
+++ b/src/main/webapp/site/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { HttpErrorInterceptor } from "./http-error.interceptor";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { MAT_SNACK_BAR_DEFAULT_OPTIONS } from '@angular/material';
+import { MAT_SNACK_BAR_DEFAULT_OPTIONS, MatSidenavModule } from '@angular/material';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -69,7 +69,8 @@ export function getAuthServiceConfigs(configService: ConfigService) {
     StudentModule,
     TeacherModule,
     SocialLoginModule,
-    NewsModule
+    NewsModule,
+    MatSidenavModule
   ],
   providers: [
     ConfigService,

--- a/src/main/webapp/site/src/app/app.module.ts
+++ b/src/main/webapp/site/src/app/app.module.ts
@@ -27,6 +27,7 @@ import {
   AuthServiceConfig,
   GoogleLoginProvider,
 } from "angularx-social-login";
+import { MobileMenuModule } from "./modules/mobile-menu/mobile-menu.module";
 
 export function initialize(configService: ConfigService, userService: UserService): () => Promise<any> {
   return (): Promise<any> => {
@@ -65,6 +66,7 @@ export function getAuthServiceConfigs(configService: ConfigService) {
     HeaderModule,
     HomeModule,
     LoginModule,
+    MobileMenuModule,
     RegisterModule,
     StudentModule,
     TeacherModule,

--- a/src/main/webapp/site/src/app/modules/header/header.component.html
+++ b/src/main/webapp/site/src/app/modules/header/header.component.html
@@ -7,7 +7,7 @@
       <span fxFlex="1 1 auto"></span>
       <app-header-links fxHide fxShow.gt-sm [user]="user" [location]="location"></app-header-links>
       <app-header-account-menu *ngIf="role" [user]="user"></app-header-account-menu>
-      <button mat-icon-button fxHide.gt-sm>
+      <button *ngIf="!location" mat-icon-button fxHide.gt-sm (click)="showMobileMenu()">
         <mat-icon aria-label="Main menu">menu</mat-icon>
       </button>
     </div>

--- a/src/main/webapp/site/src/app/modules/header/header.component.html
+++ b/src/main/webapp/site/src/app/modules/header/header.component.html
@@ -1,5 +1,5 @@
-<header>
-  <mat-toolbar class="header section--slant">
+<header class="header">
+  <mat-toolbar class="header__content section--slant">
     <div class="content" fxLayout="row" fxLayoutAlign="start center">
       <a routerLink="/" class="header__logo">
         <img src="assets/img/wise-web-header-img.png" alt="WISE header logo" />

--- a/src/main/webapp/site/src/app/modules/header/header.component.scss
+++ b/src/main/webapp/site/src/app/modules/header/header.component.scss
@@ -6,10 +6,14 @@
 .header {
   position: fixed;
   top: 0;
-  min-height: 80px;
+  width: 100%;
   z-index: 2;
-  font-size: 14px;
   padding: 0;
+}
+
+.header__content {
+  min-height: 80px;
+  font-size: 14px;
 }
 
 .header__logo {

--- a/src/main/webapp/site/src/app/modules/header/header.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/header/header.component.spec.ts
@@ -9,6 +9,7 @@ import { ConfigService } from '../../services/config.service';
 import { UserService } from "../../services/user.service";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { Config } from "../../domain/config";
+import { UtilService } from "../../services/util.service";
 
 export class MockUserService {
   getUser(): Observable<User> {
@@ -18,6 +19,10 @@ export class MockUserService {
       observer.complete();
     });
   }
+}
+
+export class MockUtilService {
+  showMainMenu() {}
 }
 
 export class MockConfigService {
@@ -50,7 +55,8 @@ describe('HeaderComponent', () => {
       declarations: [ HeaderComponent ],
       providers: [
         { provide: UserService, useClass: MockUserService },
-        { provide: ConfigService, useClass: MockConfigService }
+        { provide: ConfigService, useClass: MockConfigService },
+        { provide: UtilService, useClass: MockUtilService },
       ],
       schemas: [ NO_ERRORS_SCHEMA ]
     })

--- a/src/main/webapp/site/src/app/modules/header/header.component.ts
+++ b/src/main/webapp/site/src/app/modules/header/header.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { User } from '../../domain/user';
 import { UserService } from "../../services/user.service";
+import { UtilService } from "../../services/util.service";
 
 @Component({
   selector: 'app-header',
@@ -16,7 +17,9 @@ export class HeaderComponent implements OnInit {
   role: string = '';
   url: string = '';
 
-  constructor(private router: Router, private userService: UserService) {
+  constructor(private router: Router,
+              private userService: UserService,
+              private utilService: UtilService) {
     this.router = router;
     this.router.events.subscribe((event) => {
       this.setLocation();
@@ -47,5 +50,9 @@ export class HeaderComponent implements OnInit {
     } else {
       this.location = '';
     }
+  }
+
+  showMobileMenu() {
+    this.utilService.showMobileMenu();
   }
 }

--- a/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.html
+++ b/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.html
@@ -1,0 +1,18 @@
+<nav class="mobile-menu dark-theme">
+  <div class="mobile-menu__close" fxLayoutAlign="end center">
+    <button mat-icon-button (click)="close()" aria-label="Close menu">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+  <div fxLayout="column" fxLayoutGap="8px">
+    <a mat-button routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">WISE Home</a>
+    <a mat-button routerLink="/features" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Features</a>
+    <a mat-button routerLink="/about" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">About Us</a>
+    <a mat-button routerLink="/news" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">News</a>
+    <div *ngIf="!signedIn" fxLayout="column" fxLayoutGap="8px">
+      <mat-divider></mat-divider>
+      <a mat-button routerLink="/login">Sign In</a>
+      <a mat-button routerLink="/join">Create Account</a>
+    </div>
+  </div>
+</nav>

--- a/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.html
+++ b/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.html
@@ -9,7 +9,10 @@
     <a mat-button routerLink="/features" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Features</a>
     <a mat-button routerLink="/about" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">About Us</a>
     <a mat-button routerLink="/news" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">News</a>
-    <div *ngIf="!signedIn" fxLayout="column" fxLayoutGap="8px">
+    <div id="mobileMenuAccountLinks"
+         *ngIf="!signedIn"
+         fxLayout="column"
+         fxLayoutGap="8px">
       <mat-divider></mat-divider>
       <a mat-button routerLink="/login">Sign In</a>
       <a mat-button routerLink="/join">Create Account</a>

--- a/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.scss
+++ b/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.scss
@@ -1,0 +1,21 @@
+@import '~@angular/material/theming';
+
+// Create a config with the default typography levels.
+$config: mat-typography-config();
+
+.mobile-menu {
+  width: 300px;
+  padding: 16px;
+}
+
+.mobile-menu__close {
+  height: 48px;
+  margin-bottom: 16px;
+  margin-right: 16px;
+}
+
+a {
+  text-transform: none;
+  text-align: start;
+  font-size: mat-font-size($config, subheading-2);
+}

--- a/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.spec.ts
@@ -1,0 +1,28 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from "@angular/router/testing";
+import { MatIconModule } from "@angular/material";
+
+import { MobileMenuComponent } from './mobile-menu.component';
+
+describe('MobileMenuComponent', () => {
+  let component: MobileMenuComponent;
+  let fixture: ComponentFixture<MobileMenuComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ RouterTestingModule, MatIconModule ],
+      declarations: [ MobileMenuComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MobileMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.spec.ts
@@ -1,6 +1,5 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from "@angular/router/testing";
-import { MatIconModule } from "@angular/material";
 import { Observable } from 'rxjs';
 import { NO_ERRORS_SCHEMA, Provider } from '@angular/core';
 import { By } from '@angular/platform-browser';
@@ -38,7 +37,7 @@ describe('MobileMenuComponent', () => {
 
   function createComponent(providers: Provider[] = []) {
     TestBed.configureTestingModule({
-      imports: [ RouterTestingModule, MatIconModule ],
+      imports: [ RouterTestingModule ],
       declarations: [ MobileMenuComponent ],
       providers: [
         { provide: UserService, useValue: new MockUserServiceLogIn() }

--- a/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.spec.ts
@@ -1,28 +1,81 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from "@angular/router/testing";
 import { MatIconModule } from "@angular/material";
+import { Observable } from 'rxjs';
+import { NO_ERRORS_SCHEMA, Provider } from '@angular/core';
+import { By } from '@angular/platform-browser';
 
 import { MobileMenuComponent } from './mobile-menu.component';
+import { User } from "../../domain/user";
+import { UserService } from "../../services/user.service";
+
+export class MockUserServiceLogIn {
+  getUser(): Observable<User[]> {
+    const user: User = new User();
+    user.role = 'teacher';
+    return Observable.create(observer => {
+        observer.next(user);
+        observer.complete();
+      }
+    );
+  }
+}
+
+export class MockUserServiceLogOut {
+  getUser(): Observable<User[]> {
+    const user: User = null;
+    return Observable.create(observer => {
+        observer.next(user);
+        observer.complete();
+      }
+    );
+  }
+}
 
 describe('MobileMenuComponent', () => {
   let component: MobileMenuComponent;
   let fixture: ComponentFixture<MobileMenuComponent>;
 
-  beforeEach(async(() => {
+  function createComponent(providers: Provider[] = []) {
     TestBed.configureTestingModule({
       imports: [ RouterTestingModule, MatIconModule ],
-      declarations: [ MobileMenuComponent ]
+      declarations: [ MobileMenuComponent ],
+      providers: [
+        { provide: UserService, useValue: new MockUserServiceLogIn() }
+      ],
+      schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(MobileMenuComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  describe('', () => {
+    beforeEach(() => {
+      createComponent();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should hide account links when user logs in', () => {
+      const accountLinks = fixture.debugElement.query(By.css('#mobileMenuAccountLinks'));
+      expect(accountLinks).toBeFalsy();
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('', () => {
+    beforeEach(() => {
+      TestBed.overrideProvider(UserService, { useValue: new MockUserServiceLogOut() });
+      createComponent();
+    });
+
+    it('should show account links when user logs out', () => {
+      const accountLinks = fixture.debugElement.query(By.css('#mobileMenuAccountLinks'));
+      expect(accountLinks).toBeTruthy();
+    });
   });
 });

--- a/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.ts
+++ b/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { UserService } from "../../services/user.service";
+import { User } from "../../domain/user";
+import { UtilService } from "../../services/util.service";
+
+@Component({
+  selector: 'app-mobile-menu',
+  templateUrl: './mobile-menu.component.html',
+  styleUrls: ['./mobile-menu.component.scss']
+})
+export class MobileMenuComponent implements OnInit {
+
+  signedIn: boolean = false;
+
+  constructor(private userService: UserService,
+              private utilService: UtilService) {
+    this.userService = userService;
+    this.utilService = utilService;
+  }
+
+  ngOnInit() {
+    this.getUser();
+  }
+
+  close() {
+    this.utilService.showMobileMenu(false);
+  }
+
+  getUser() {
+    this.userService.getUser()
+      .subscribe(user => {
+        if (user && user.role) {
+          this.signedIn = true;
+        } else {
+          this.signedIn = false;
+        }
+      });
+  }
+}

--- a/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.module.ts
+++ b/src/main/webapp/site/src/app/modules/mobile-menu/mobile-menu.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import {
+  MatButtonModule,
+  MatDividerModule,
+  MatIconModule } from '@angular/material';
+
+import { AppRoutingModule } from "../../app-routing.module";
+import { MobileMenuComponent } from './mobile-menu.component';
+
+@NgModule({
+  imports: [
+    AppRoutingModule,
+    CommonModule,
+    FlexLayoutModule,
+    MatButtonModule,
+    MatDividerModule,
+    MatIconModule
+  ],
+  declarations: [MobileMenuComponent],
+  exports: [
+    MobileMenuComponent
+  ]
+})
+export class MobileMenuModule { }

--- a/src/main/webapp/site/src/app/services/util.service.spec.ts
+++ b/src/main/webapp/site/src/app/services/util.service.spec.ts
@@ -21,4 +21,8 @@ describe('UtilService', () => {
     expect(service.getLastName("Spongebob Squarepants")).toEqual("Squarepants");
   }));
 
+  it('should set and get the mobile menu state', inject([UtilService], (service: UtilService) => {
+    service.showMobileMenu();
+    expect(service.getMobileMenuState().getValue()).toEqual(true);
+  }));
 });

--- a/src/main/webapp/site/src/app/services/util.service.ts
+++ b/src/main/webapp/site/src/app/services/util.service.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class UtilService {
+
+  private mobileMenuState$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   constructor() { }
 
@@ -13,5 +16,13 @@ export class UtilService {
 
   getLastName(fullName: string): string {
     return fullName.substring(fullName.indexOf(" ") + 1);
+  }
+
+  showMobileMenu(state: boolean = true): void {
+    this.mobileMenuState$.next(state);
+  }
+
+  getMobileMenuState(): BehaviorSubject<boolean> {
+    return this.mobileMenuState$;
   }
 }

--- a/src/main/webapp/site/src/index.html
+++ b/src/main/webapp/site/src/index.html
@@ -11,6 +11,6 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body class="mat-typography default-theme mat-app-background">
-  <app-root class="app-root"></app-root>
+  <app-root></app-root>
 </body>
 </html>

--- a/src/main/webapp/site/src/style/base/_base.scss
+++ b/src/main/webapp/site/src/style/base/_base.scss
@@ -1,15 +1,11 @@
-html, body {
-  height: 100%;
-}
-
 body {
   margin: 0;
 }
 
-.app-root {
-  display: flex;
-  flex-direction: column;
+.root-content.mat-sidenav-container {
+  position: absolute;
   height: 100%;
+  width: 100%;
 }
 
 a {

--- a/src/main/webapp/site/src/style/base/_base.scss
+++ b/src/main/webapp/site/src/style/base/_base.scss
@@ -2,12 +2,6 @@ body {
   margin: 0;
 }
 
-.root-content.mat-sidenav-container {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-}
-
 a {
   text-decoration: none;
 


### PR DESCRIPTION
Added a mobile menu to the site that appears on smaller screens. Closes #1553.

To test:
- Load the site and resize browser window. On smaller screens, the header menu links should disappear and be replaced by a mobile hamburger menu. The mobile menu should disappear and be replaced by the header links when the screen size is increased.
- Make sure the following links are included in the mobile menu: WISE Home, Features, About Us, News, Sign In, Create Account.
- Log in as a teacher and student. View the mobile menu. The Sign In and Create Account links should not appear when logged in.