### PR TITLE
Better separate regular login and Google login buttons

### DIFF
--- a/src/main/webapp/site/src/app/login/login-home/login-home.component.html
+++ b/src/main/webapp/site/src/app/login/login-home/login-home.component.html
@@ -30,7 +30,7 @@
       </p>
       <p>
         <button fxFlex
-                mat-raised-button
+                mat-flat-button
                 color="primary"
                 type="submit"
                 [disabled]="processing">
@@ -39,17 +39,17 @@
         </button>
       </p>
     </form>
-    <span *ngIf="isGoogleAuthenticationEnabled">
-      <p class="center mat-subheading-1">- or -</p>
+    <div *ngIf="isGoogleAuthenticationEnabled">
+      <p class="center mat-title">- or -</p>
       <p class="center">
         <button class="button--social-login button--google"
                 color="accent"
-                mat-raised-button
+                mat-flat-button
                 (click)="socialSignIn('google')">
           <img src="assets/img/icons/g-logo.png" alt="Google logo" />Sign in with Google
         </button>
       </p>
-    </span>
+    </div>
   </mat-card-content>
   <mat-divider></mat-divider>
   <mat-card-actions>

--- a/src/main/webapp/site/src/app/register/register-google-user-already-exists/register-google-user-already-exists.component.html
+++ b/src/main/webapp/site/src/app/register/register-google-user-already-exists/register-google-user-already-exists.component.html
@@ -7,7 +7,7 @@
     <mat-card-actions>
       <button class="button--social-login button--google"
               color="accent"
-              mat-raised-button
+              mat-flat-button
               (click)="socialSignIn('google')">
         <img src="assets/img/icons/g-logo.png" alt="Google logo" />Sign in with Google
       </button>

--- a/src/main/webapp/site/src/app/register/register-student-complete/register-student-complete.component.html
+++ b/src/main/webapp/site/src/app/register/register-student-complete/register-student-complete.component.html
@@ -8,7 +8,7 @@
       Please write this down. You will need it when signing in to WISE in the future.
     </p>
     <mat-card-actions>
-      <a mat-raised-button color="primary" routerLink="/login">
+      <a mat-flat-button color="primary" routerLink="/login">
         Sign In to Get Started
       </a>
     </mat-card-actions>

--- a/src/main/webapp/site/src/app/register/register-student-form/register-student-form.component.html
+++ b/src/main/webapp/site/src/app/register/register-student-form/register-student-form.component.html
@@ -111,7 +111,7 @@
       <p>
         By clicking "Create Account", you agree to our <a href="privacy" target="_blank">Privacy Policy & Terms of Use</a>
       </p>
-      <button mat-raised-button color="primary" type="submit">
+      <button mat-flat-button color="primary" type="submit">
         Create Account
       </button>
     </form>

--- a/src/main/webapp/site/src/app/register/register-student/register-student.component.html
+++ b/src/main/webapp/site/src/app/register/register-student/register-student.component.html
@@ -23,18 +23,18 @@
     </p>
     <p>
       <button fxFlex
-              mat-raised-button
+              mat-flat-button
               color="primary"
               (click)="signUp()">
         Sign Up
       </button>
     </p>
     <span *ngIf="isGoogleAuthenticationEnabled">
-      <p class="center mat-subheading-1">- or -</p>
+      <p class="center mat-title">- or -</p>
       <p class="center">
         <button class="button--social-login button--google"
                 color="accent"
-                mat-raised-button
+                mat-flat-button
                 (click)="socialSignIn('google')">
           <img src="assets/img/icons/g-logo.png" alt="Google logo" />Sign up with Google
         </button>

--- a/src/main/webapp/site/src/app/register/register-teacher-complete/register-teacher-complete.component.html
+++ b/src/main/webapp/site/src/app/register/register-teacher-complete/register-teacher-complete.component.html
@@ -8,7 +8,7 @@
       You should also receive an email with your account details.
     </p>
     <mat-card-actions>
-      <a mat-raised-button color="primary" routerLink="/login">
+      <a mat-flat-button color="primary" routerLink="/login">
         Sign In to Get Started
       </a>
     </mat-card-actions>

--- a/src/main/webapp/site/src/app/register/register-teacher-form/register-teacher-form.component.html
+++ b/src/main/webapp/site/src/app/register/register-teacher-form/register-teacher-form.component.html
@@ -1,154 +1,154 @@
 <mat-card class="standalone__content mat-elevation-z4">
-    <mat-card-content>
-        <form role="form"
-            fxLayout="column"
-            (submit)="createAccount()"
-            [formGroup]="createTeacherAccountFormGroup">
-            <h2 class="standalone__title accent">Create Teacher Account</h2>
-            <p>
-            <mat-form-field appearance="fill" fxFlex>
-                <mat-label>First Name</mat-label>
-                <input matInput
-                id="firstName"
-                name="firstName"
-                formControlName="firstName"
-                autofocus
-                required />
-                <mat-error *ngIf="createTeacherAccountFormGroup.controls['firstName'].hasError('required')">First Name Required</mat-error>
-            </mat-form-field>
-            </p>
-            <p>
-            <mat-form-field appearance="fill" fxFlex>
-                <mat-label>Last Name</mat-label>
-                <input matInput
-                id="lastName"
-                name="lastName"
-                formControlName="lastName"
-                required />
-                <mat-error *ngIf="createTeacherAccountFormGroup.controls['lastName'].hasError('required')">Last Name Required</mat-error>
-            </mat-form-field>
-            </p>
-            <p>
-            <mat-form-field class="mat-form-field--extra-sub"
-                appearance="fill"
-                fxFlex>
-                <mat-label>Email</mat-label>
-                <input matInput
-                id="email"
-                name="email"
-                formControlName="email"
-                required />
-                <mat-hint>We’ll never share your email address or personal information with anyone without your consent.</mat-hint>
-                <mat-error *ngIf="createTeacherAccountFormGroup.controls['email'].hasError('required')">Email Required</mat-error>
-                <mat-error *ngIf="createTeacherAccountFormGroup.controls['email'].hasError('email')">Please enter a valid email address</mat-error>
-            </mat-form-field>
-            </p>
-            <p>
-            <mat-form-field appearance="fill" fxFlex>
-                <mat-label>City</mat-label>
-                <input matInput
-                id="city"
-                name="city"
-                formControlName="city"
-                required />
-                <mat-error *ngIf="createTeacherAccountFormGroup.controls['city'].hasError('required')">City Required</mat-error>
-            </mat-form-field>
-            </p>
-            <p>
-            <mat-form-field appearance="fill" fxFlex>
-                <mat-label>State</mat-label>
-                <input matInput
-                id="state"
-                name="state"
-                formControlName="state"
-                required />
-                <mat-error *ngIf="createTeacherAccountFormGroup.controls['state'].hasError('required')">State Required</mat-error>
-            </mat-form-field>
-            </p>
-            <p>
-            <mat-form-field appearance="fill" fxFlex>
-                <mat-label>Country</mat-label>
-                <input matInput
-                id="country"
-                name="country"
-                formControlName="country"
-                required />
-                <mat-error *ngIf="createTeacherAccountFormGroup.controls['country'].hasError('required')">Country Required</mat-error>
-            </mat-form-field>
-            </p>
-            <p>
-            <mat-form-field appearance="fill" fxFlex>
-                <mat-label>School Name</mat-label>
-                <input matInput
-                id="schoolName"
-                name="schoolName"
-                formControlName="schoolName"
-                required />
-                <mat-error *ngIf="createTeacherAccountFormGroup.controls['schoolName'].hasError('required')">School Name Required</mat-error>
-            </mat-form-field>
-            </p>
-            <p>
-            <mat-form-field appearance="fill" fxFlex>
-                <mat-label>School Level</mat-label>
-                <mat-select placeholder="School Level"
-                    [(value)]="teacherUser.schoolLevel"
-                    formControlName="schoolLevel"
-                    required>
-                    <mat-option *ngFor="let schoolLevel of schoolLevels" [value]="schoolLevel.code">
-                        {{schoolLevel.label}}
-                    </mat-option>
-                </mat-select>
-                <mat-error *ngIf="createTeacherAccountFormGroup.controls['schoolLevel'].hasError('required')">School Level Required</mat-error>
-            </mat-form-field>
-            </p>
-            <p>
-            <mat-form-field appearance="fill" fxFlex>
-                <mat-label>How did you hear about us?</mat-label>
-                <input matInput
-                id="howDidYouHearAboutUs"
-                name="howDidYouHearAboutUs"
-                formControlName="howDidYouHearAboutUs" />
-            </mat-form-field>
-            </p>
-            <div *ngIf="teacherUser.googleUserId == null" formGroupName="passwords">
-                <p>
-                <mat-form-field appearance="fill" fxFlex>
-                    <mat-label>Password</mat-label>
-                    <input matInput
-                    id="password"
-                    type="password"
-                    name="password"
-                    formControlName="password"
-                    required />
-                    <mat-error *ngIf="passwordsFormGroup.controls['password'].hasError('required')">Password Required</mat-error>
-                </mat-form-field>
-                </p>
-                <p>
-                <mat-form-field appearance="fill" fxFlex>
-                    <mat-label>Confirm Password</mat-label>
-                    <input matInput
-                    id="confirmPassword"
-                    type="password"
-                    name="confirmPassword"
-                    formControlName="confirmPassword"
-                    required />
-                    <mat-error *ngIf="passwordsFormGroup.controls['confirmPassword'].hasError('required')">Confirm Password Required</mat-error>
-                    <mat-error *ngIf="passwordsFormGroup.hasError('passwordDoesNotMatch')">Password does not match</mat-error>
-                </mat-form-field>
-                </p>
-            </div>
-            <div class="mat-form-field--extra-sub">
-                <p>
-                <mat-checkbox class="mat-checkbox--inline" formControlName="agree">I agree to the <a href="privacy" target="_blank">WISE Privacy Policy & Terms of Use</a> *</mat-checkbox>
-                    <mat-error *ngIf="isSubmitted && createTeacherAccountFormGroup.hasError('agreeNotChecked')">You must agree to the Privacy Policy & Terms of Use</mat-error>
-                    </p>
-                    </div>
-                    <p>
-                    <button fxFlex mat-raised-button color="primary" type="submit">
-                    Create Account
-                    </button>
-                    </p>
-                    </form>
-                    </mat-card-content>
-                    </mat-card>
+  <mat-card-content>
+    <form role="form"
+          fxLayout="column"
+          (submit)="createAccount()"
+          [formGroup]="createTeacherAccountFormGroup">
+      <h2 class="standalone__title accent">Create Teacher Account</h2>
+      <p>
+        <mat-form-field appearance="fill" fxFlex>
+          <mat-label>First Name</mat-label>
+          <input matInput
+                 id="firstName"
+                 name="firstName"
+                 formControlName="firstName"
+                 autofocus
+                 required />
+          <mat-error *ngIf="createTeacherAccountFormGroup.controls['firstName'].hasError('required')">First Name Required</mat-error>
+        </mat-form-field>
+      </p>
+      <p>
+        <mat-form-field appearance="fill" fxFlex>
+          <mat-label>Last Name</mat-label>
+          <input matInput
+                 id="lastName"
+                 name="lastName"
+                 formControlName="lastName"
+                 required />
+          <mat-error *ngIf="createTeacherAccountFormGroup.controls['lastName'].hasError('required')">Last Name Required</mat-error>
+        </mat-form-field>
+      </p>
+      <p>
+        <mat-form-field class="mat-form-field--extra-sub"
+                        appearance="fill"
+                        fxFlex>
+          <mat-label>Email</mat-label>
+          <input matInput
+                 id="email"
+                 name="email"
+                 formControlName="email"
+                 required />
+          <mat-hint>We’ll never share your email address or personal information with anyone without your consent.</mat-hint>
+          <mat-error *ngIf="createTeacherAccountFormGroup.controls['email'].hasError('required')">Email Required</mat-error>
+          <mat-error *ngIf="createTeacherAccountFormGroup.controls['email'].hasError('email')">Please enter a valid email address</mat-error>
+        </mat-form-field>
+      </p>
+      <p>
+        <mat-form-field appearance="fill" fxFlex>
+          <mat-label>City</mat-label>
+          <input matInput
+                 id="city"
+                 name="city"
+                 formControlName="city"
+                 required />
+          <mat-error *ngIf="createTeacherAccountFormGroup.controls['city'].hasError('required')">City Required</mat-error>
+        </mat-form-field>
+      </p>
+      <p>
+        <mat-form-field appearance="fill" fxFlex>
+          <mat-label>State</mat-label>
+          <input matInput
+                 id="state"
+                 name="state"
+                 formControlName="state"
+                 required />
+          <mat-error *ngIf="createTeacherAccountFormGroup.controls['state'].hasError('required')">State Required</mat-error>
+        </mat-form-field>
+      </p>
+      <p>
+        <mat-form-field appearance="fill" fxFlex>
+          <mat-label>Country</mat-label>
+          <input matInput
+                 id="country"
+                 name="country"
+                 formControlName="country"
+                 required />
+          <mat-error *ngIf="createTeacherAccountFormGroup.controls['country'].hasError('required')">Country Required</mat-error>
+        </mat-form-field>
+      </p>
+      <p>
+        <mat-form-field appearance="fill" fxFlex>
+          <mat-label>School Name</mat-label>
+          <input matInput
+                 id="schoolName"
+                 name="schoolName"
+                 formControlName="schoolName"
+                 required />
+          <mat-error *ngIf="createTeacherAccountFormGroup.controls['schoolName'].hasError('required')">School Name Required</mat-error>
+        </mat-form-field>
+      </p>
+      <p>
+        <mat-form-field appearance="fill" fxFlex>
+          <mat-label>School Level</mat-label>
+          <mat-select placeholder="School Level"
+                      [(value)]="teacherUser.schoolLevel"
+                      formControlName="schoolLevel"
+                      required>
+            <mat-option *ngFor="let schoolLevel of schoolLevels" [value]="schoolLevel.code">
+              {{schoolLevel.label}}
+            </mat-option>
+          </mat-select>
+          <mat-error *ngIf="createTeacherAccountFormGroup.controls['schoolLevel'].hasError('required')">School Level Required</mat-error>
+        </mat-form-field>
+      </p>
+      <p>
+        <mat-form-field appearance="fill" fxFlex>
+          <mat-label>How did you hear about us?</mat-label>
+          <input matInput
+                 id="howDidYouHearAboutUs"
+                 name="howDidYouHearAboutUs"
+                 formControlName="howDidYouHearAboutUs" />
+        </mat-form-field>
+      </p>
+      <div *ngIf="teacherUser.googleUserId == null" formGroupName="passwords">
+        <p>
+          <mat-form-field appearance="fill" fxFlex>
+            <mat-label>Password</mat-label>
+            <input matInput
+                   id="password"
+                   type="password"
+                   name="password"
+                   formControlName="password"
+                   required />
+            <mat-error *ngIf="passwordsFormGroup.controls['password'].hasError('required')">Password Required</mat-error>
+          </mat-form-field>
+        </p>
+        <p>
+          <mat-form-field appearance="fill" fxFlex>
+            <mat-label>Confirm Password</mat-label>
+            <input matInput
+                   id="confirmPassword"
+                   type="password"
+                   name="confirmPassword"
+                   formControlName="confirmPassword"
+                   required />
+            <mat-error *ngIf="passwordsFormGroup.controls['confirmPassword'].hasError('required')">Confirm Password Required</mat-error>
+            <mat-error *ngIf="passwordsFormGroup.hasError('passwordDoesNotMatch')">Password does not match</mat-error>
+          </mat-form-field>
+        </p>
+      </div>
+      <div class="mat-form-field--extra-sub">
+        <p>
+          <mat-checkbox class="mat-checkbox--inline" formControlName="agree">I agree to the <a href="privacy" target="_blank">WISE Privacy Policy & Terms of Use</a> *</mat-checkbox>
+          <mat-error *ngIf="isSubmitted && createTeacherAccountFormGroup.hasError('agreeNotChecked')">You must agree to the Privacy Policy & Terms of Use</mat-error>
+        </p>
+      </div>
+      <p>
+        <button fxFlex mat-flat-button color="primary" type="submit">
+          Create Account
+        </button>
+      </p>
+    </form>
+  </mat-card-content>
+</mat-card>
                     

--- a/src/main/webapp/site/src/app/register/register-teacher/register-teacher.component.html
+++ b/src/main/webapp/site/src/app/register/register-teacher/register-teacher.component.html
@@ -12,18 +12,18 @@
     </p>
     <p>
       <button fxFlex
-              mat-raised-button
+              mat-flat-button
               color="primary"
               (click)="signUp()">
         Sign Up
       </button>
     </p>
     <span *ngIf="isGoogleAuthenticationEnabled">
-      <p class="center mat-subheading-1">- or -</p>
+      <p class="center mat-title">- or -</p>
       <p class="center">
         <button class="button--social-login button--google"
                 color="accent"
-                mat-raised-button
+                mat-flat-button
                 (click)="socialSignIn('google')">
           <img src="assets/img/icons/g-logo.png" alt="Google logo" />Sign up with Google
         </button>

--- a/src/main/webapp/site/src/style/layout/_standalone.scss
+++ b/src/main/webapp/site/src/style/layout/_standalone.scss
@@ -38,7 +38,9 @@
   margin: 0 auto 16px;
 
   @media (min-width: breakpoint('sm.min')) {
-    padding: 24px !important;
+    &.mat-card {
+      padding: 24px !important;
+    }
   }
 }
 


### PR DESCRIPTION
Increased the font size and bolded the text separating the regular login and Google login buttons on the sign in form as well as on the register forms. Hopefully this provides enough separation to reduce confusion.

Resolves #1540.

(Also changed login and register buttons to be mat-flat-buttons so they match the rest of the site).