### PR TITLE
Bug Fix new WISE4 runs could not be launched

### DIFF
--- a/src/main/java/org/wise/portal/service/project/impl/ProjectServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/project/impl/ProjectServiceImpl.java
@@ -614,7 +614,9 @@ public class ProjectServiceImpl implements ProjectService {
     String projectFolderPath = FileManager.getProjectFolderPath(parentProject);
     String curriculumBaseDir = wiseProperties.getProperty("curriculum_base_dir");
     String newProjectDirname = FileManager.copyProject(curriculumBaseDir, projectFolderPath);
-    String newProjectPath = "/" + newProjectDirname + "/project.json";
+    String projectModulePath = parentProject.getModulePath();
+    String projectJSONFilename = projectModulePath.substring(projectModulePath.lastIndexOf("/") + 1);
+    String newProjectPath = "/" + newProjectDirname + "/" + projectJSONFilename;
     String newProjectName = parentProject.getName();
     Long parentProjectId = (Long) parentProject.getId();
     ProjectParameters pParams = new ProjectParameters();
@@ -622,7 +624,7 @@ public class ProjectServiceImpl implements ProjectService {
     pParams.setOwner(user);
     pParams.setProjectname(newProjectName);
     pParams.setProjectType(ProjectType.LD);
-    pParams.setWiseVersion(5);
+    pParams.setWiseVersion(parentProject.getWiseVersion());
     pParams.setParentProjectId(parentProjectId);
     ProjectMetadata parentProjectMetadata = parentProject.getMetadata();
     if (parentProjectMetadata != null) {


### PR DESCRIPTION
This fixes the issue where new wise4 runs created in the site could not be launched by students. 

To test:
1. Create a new WISE4 run in the new site
2. As student, add the new run and launch it.

You should be able to see the new run as a student.

Closes #1604