### PR TITLE
Remove CA implementation model select from library

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/admin/ManagePortalController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/admin/ManagePortalController.java
@@ -109,15 +109,7 @@ public class ManagePortalController {
    */
   public void addOfficialTagToProjectLibraryGroup(String projectLibraryGroup)
       throws JSONException {
-    JSONArray arrangements = new JSONArray(projectLibraryGroup);
-    for (int i = 0; i < arrangements.length(); i++) {
-      JSONObject arrangement = arrangements.getJSONObject(i);
-      addOfficialTagToArrangement(arrangement);
-    }
-  }
-
-  private void addOfficialTagToArrangement(JSONObject arrangement) throws JSONException {
-    JSONArray groups = arrangement.getJSONArray("children");
+    JSONArray groups = new JSONArray(projectLibraryGroup);
     for (int i = 0; i < groups.length(); i++) {
       JSONObject group = groups.getJSONObject(i);
       addOfficialTagToGroup(group);

--- a/src/main/webapp/site/src/app/modules/library/home-page-project-library/home-page-project-library.component.html
+++ b/src/main/webapp/site/src/app/modules/library/home-page-project-library/home-page-project-library.component.html
@@ -2,12 +2,12 @@
   <div fxLayout="column" fxLayout.gt-sm="row">
     <div class="content-block dark-theme library__header primary-bg"
          fxFlex.gt-sm="33">
-      <p class="info-block center">
-        Explore suggested WISE curricula for the given grade levels or search for specific units that address your needs.
-      </p>
       <app-library-filters></app-library-filters>
     </div>
     <div class="library__content library-home__content content-block" fxFlex.gt-sm="67">
+      <p class="info-block center">
+        Explore suggested WISE curricula for the given grade levels or search for specific units that address your needs.
+      </p>
       <app-official-library></app-official-library>
     </div>
   </div>

--- a/src/main/webapp/site/src/app/modules/library/library/library.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/library/library.component.ts
@@ -34,17 +34,16 @@ export abstract class LibraryComponent implements OnInit {
   /**
    * Add given project or all child projects from a given group to the list of projects
    * @param item
-   * @param {string} implementationModel
+   * @param {LibraryProject[]} projects
    */
-  populateProjects(item: any, implementationModel: string, projects: LibraryProject[]): void {
+  populateProjects(item: any, projects: LibraryProject[]): void {
     if (item.type === 'project') {
       item.visible = true;
-      item.implementationModel = implementationModel;
       projects.push(item);
     } else if (item.type === 'group') {
       let children = item.children;
       for (let child of children) {
-        this.populateProjects(child, implementationModel, projects);
+        this.populateProjects(child, projects);
       }
     }
   }
@@ -130,18 +129,8 @@ export abstract class LibraryComponent implements OnInit {
       }
       project.visible = searchMatch || filterMatch;
     }
-    this.setImplementationModelOptions();
     let numProjectsVisible = this.countVisibleProjects(this.projects);
     this.emitNumberOfProjectsVisible(numProjectsVisible);
-  }
-
-  setImplementationModelOptions() {
-    this.implementationModelOptions = [];
-    for (let i = 0; i < this.libraryService.implementationModelOptions.length; i++) {
-      const option = {...this.libraryService.implementationModelOptions[i]};
-      option.name = option.name + ` (${this.countVisibleProjects(this.projects, option.id)})`;
-      this.implementationModelOptions.push(option);
-    }
   }
 
   emitNumberOfProjectsVisible(numProjectsVisible) {
@@ -262,16 +251,7 @@ export abstract class LibraryComponent implements OnInit {
     return false;
   }
 
-  countVisibleProjects(set: LibraryProject[], implementationModel: string = ''): number {
-    if (implementationModel) {
-      return set.filter((project) => 'project' && project.visible &&
-        project.implementationModel === implementationModel).length;
-    } else {
-      return set.filter((project) => 'project' && project.visible).length;
-    }
-  }
-
-  implementationModelUpdated(value: string): void {
-    this.implementationModelValue = value;
+  countVisibleProjects(set: LibraryProject[]): number {
+    return set.filter((project) => 'project' && project.visible).length;
   }
 }

--- a/src/main/webapp/site/src/app/modules/library/official-library/official-library.component.html
+++ b/src/main/webapp/site/src/app/modules/library/official-library/official-library.component.html
@@ -1,55 +1,32 @@
-<div fxLayout="row" fxLayoutAlign="start start">
-  <div fxLayout="row" fxLayoutAlign="start start">
-    <app-select-menu [options]="implementationModelOptions"
-                     [placeholderText]="'CA NGSS Implementation Model'"
-                     [value]="implementationModelValue"
-                     (update)="implementationModelUpdated($event)"
-                     [valueProp]="'id'"
-                     [viewValueProp]="'name'">
-    </app-select-menu>
-    <button mat-button
-            mat-icon-button
-            color="primary"
-            class="input-control--appearance-fill"
-            aria-label="Implementation model select explanation"
-            matTooltip="California has defined two NGSS course arrangements for grades 6-8. Select one to see WISE projects organized by grade level for that implementation model."
-            matTooltipPosition="after">
-      <mat-icon> info </mat-icon>
-    </button>
-  </div>
-</div>
-<ng-container id="libraryGroups" *ngFor="let group of libraryGroups">
-  <mat-accordion class="library__groups"
-                 multi="true"
-                 *ngIf="implementationModelValue === group.id">
-    <ng-container *ngFor="let child of group.children; let i = index">
-      <mat-expansion-panel *ngIf="child.type === 'group'"
-                           class="library-group"
-                           (opened)="expandedGroups[child.id] = true"
-                           (closed)="expandedGroups[child.id] = false"
-                           [expanded]="expandedGroups[child.id] && countVisibleProjects(child.children, implementationModelValue) > 0"
-                           [disabled]="countVisibleProjects(child.children, implementationModelValue) < 1">
-        <mat-expansion-panel-header class="mat-expansion-panel-header--lg">
-          <div fxLayout="column" class="library-group__title">
-            <div>{{ child.name }}</div>
-            <div class="mat-caption">
-              {{ countVisibleProjects(child.children, implementationModelValue) }} unit(s)
-            </div>
+<mat-accordion class="library__groups"
+               multi="true">
+  <ng-container *ngFor="let group of libraryGroups; let i = index">
+    <mat-expansion-panel *ngIf="group.type === 'group'"
+                         class="library-group"
+                         (opened)="expandedGroups[group.id] = true"
+                         (closed)="expandedGroups[group.id] = false"
+                         [expanded]="expandedGroups[group.id] && countVisibleProjects(group.children) > 0"
+                         [disabled]="countVisibleProjects(group.children) < 1">
+      <mat-expansion-panel-header class="mat-expansion-panel-header--lg">
+        <div fxLayout="column" class="library-group__title">
+          <div>{{ group.name }}</div>
+          <div class="mat-caption">
+            {{ countVisibleProjects(group.children) }} unit(s)
           </div>
-          <app-library-group-thumbs [group]="child"
-                                    [ngClass]="{ 'hide': expandedGroups[child.id] }">
-          </app-library-group-thumbs>
-        </mat-expansion-panel-header>
-        <div fxLayout="row wrap">
-          <ng-container *ngFor="let project of child.children">
-            <div *ngIf="project.visible"
-                 fxFlex="50"
-                 fxFlex.gt-xs="33">
-              <app-library-project [project]="project" ></app-library-project>
-            </div>
-          </ng-container>
         </div>
-      </mat-expansion-panel>
-    </ng-container>
-  </mat-accordion>
-</ng-container>
+        <app-library-group-thumbs [group]="group"
+                                  [ngClass]="{ 'hide': expandedGroups[group.id] }">
+        </app-library-group-thumbs>
+      </mat-expansion-panel-header>
+      <div fxLayout="row wrap">
+        <ng-container *ngFor="let project of group.children">
+          <div *ngIf="project.visible"
+               fxFlex="50"
+               fxFlex.gt-xs="33">
+            <app-library-project [project]="project" ></app-library-project>
+          </div>
+        </ng-container>
+      </div>
+    </mat-expansion-panel>
+  </ng-container>
+</mat-accordion>

--- a/src/main/webapp/site/src/app/modules/library/official-library/official-library.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/official-library/official-library.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { LibraryGroup } from "../libraryGroup";
 import { LibraryProject } from "../libraryProject";
-import { Standard } from "../standard";
 import { LibraryService } from "../../../services/library.service";
 import { LibraryComponent } from "../library/library.component";
 
@@ -14,17 +13,6 @@ export class OfficialLibraryComponent extends LibraryComponent {
 
   projects: LibraryProject[] = [];
   libraryGroups: LibraryGroup[] = [];
-  expandedGroups: object = {};
-  implementationModelValue: string = '';
-  implementationModelOptions: LibraryGroup[] = [];
-  searchValue: string = '';
-  dciArrangementOptions: Standard[] = [];
-  dciArrangementValue = [];
-  disciplineOptions: Standard[] = [];
-  disciplineValue = [];
-  peOptions: Standard[] = [];
-  peValue = [];
-  showFilters: boolean = false;
 
   constructor(libraryService: LibraryService) {
     super(libraryService);
@@ -34,8 +22,6 @@ export class OfficialLibraryComponent extends LibraryComponent {
     libraryService.officialLibraryProjectsSource$.subscribe((libraryProjects) => {
       this.projects = libraryProjects;
       this.emitNumberOfProjectsVisible(this.projects.length);
-      this.setImplementationModelOptions();
-      this.implementationModelValue = libraryService.implementationModelValue;
     });
     libraryService.projectFilterOptionsSource$.subscribe((projectFilterOptions) => {
       this.filterUpdated(projectFilterOptions);

--- a/src/main/webapp/site/src/app/services/library.service.ts
+++ b/src/main/webapp/site/src/app/services/library.service.ts
@@ -39,23 +39,14 @@ export class LibraryService {
   private tabIndexSource = new Subject<number>();
   public tabIndexSource$ = this.tabIndexSource.asObservable();
 
-  implementationModelValue: string = '';
-  implementationModelOptions: LibraryGroup[] = [];
-
   constructor(private http: HttpClient) { }
 
   getOfficialLibraryProjects() {
     this.http.get<LibraryGroup[]>(this.libraryGroupsUrl).subscribe((libraryGroups) => {
       this.libraryGroups = libraryGroups;
-      this.implementationModelOptions = [];
       const projects: LibraryProject[] = [];
       for (let group of this.libraryGroups) {
-        if (!this.implementationModelValue) {
-          this.implementationModelValue = group.id;
-        }
-        this.implementationModelOptions.push(group);
-
-        this.populateProjects(group, group.id, projects);
+        this.populateProjects(group, projects);
       }
       this.officialLibraryProjectsSource.next(projects);
       this.libraryGroupsSource.next(libraryGroups);
@@ -98,17 +89,16 @@ export class LibraryService {
   /**
    * Add given project or all child projects from a given group to the list of projects
    * @param item
-   * @param {string} implementationModel
+   * @param {LibraryProject[]} projects
    */
-  populateProjects(item: any, implementationModel: string, projects: LibraryProject[]): void {
+  populateProjects(item: any, projects: LibraryProject[]): void {
     if (item.type === 'project') {
       item.visible = true;
-      item.implementationModel = implementationModel;
       projects.push(item);
     } else if (item.type === 'group') {
       let children = item.children;
       for (let child of children) {
-        this.populateProjects(child, implementationModel, projects);
+        this.populateProjects(child, projects);
       }
     }
   }

--- a/src/main/webapp/site/src/style/abstracts/_mixins.scss
+++ b/src/main/webapp/site/src/style/abstracts/_mixins.scss
@@ -164,6 +164,10 @@
     }
   }
 
+  .mat-expansion-panel-header {
+    font-weight: 500;
+  }
+
   .mat-form-field {
     font-size: 14px;
   }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/admin/ManagePortalControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/admin/ManagePortalControllerTest.java
@@ -36,7 +36,6 @@ public class ManagePortalControllerTest extends TestCase {
     EasyMock.expect(projectService.addTagToProject("official", new Long(24447))).andReturn(1);
     EasyMock.expect(projectService.addTagToProject("official", new Long(24449))).andReturn(1);
     EasyMock.expect(projectService.addTagToProject("official", new Long(24358))).andReturn(1);
-    EasyMock.expect(projectService.addTagToProject("official", new Long(24445))).andReturn(1);
     EasyMock.replay(projectService);
     controller.addOfficialTagToProjectLibraryGroup(projectLibraryGroupJSONString);
     EasyMock.verify(projectService);

--- a/src/test/resources/projectLibraryGroupSample.json
+++ b/src/test/resources/projectLibraryGroupSample.json
@@ -1,15 +1,13 @@
-[{
-  "type": "group",
-  "id": "californiaIntegrated",
-  "name": "California Integrated",
-  "children": [{
+[
+  {
     "type": "group",
     "name": "6th Grade",
-    "children": [{
-      "type": "project",
-      "notes": "Test",
-      "id": 24447
-    },
+    "children": [
+      {
+        "type": "project",
+        "notes": "Test",
+        "id": 24447
+      },
       {
         "type": "project",
         "notes": "Nested branch",
@@ -17,29 +15,15 @@
       }
     ]
   },
-    {
-      "type": "group",
-      "name": "7th Grade",
-      "children": [{
+  {
+    "type": "group",
+    "name": "7th Grade",
+    "children": [
+      {
         "type": "project",
         "notes": "How Can We Recycle Old Tires? 2018",
         "id": 24358
-      }]
-    }
-  ]
-},
-  {
-    "type": "group",
-    "id": "disciplineSpecific",
-    "name": "Discipline Specific",
-    "children": [{
-      "type": "group",
-      "name": "8th Grade",
-      "children": [{
-        "type": "project",
-        "notes": "How Can We Recycle Old Tires? Kingdom of Saudi Arabia",
-        "id": 24445
-      }]
-    }]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This removes the select dropdown for NGSS implementation models from the official library displays. We now just show one level of unit groupings.

To test:
- Update your database value for the projectLibraryGroups json to match the updated format: https://github.com/WISE-Community/WISE/wiki/Defining-project-library-groups-for-display-on-the-new-Site-homepage.
- Load the site homepage and make sure the unit library groups populate correctly.
- Load `/teacher` and select the Browse WISE Units tab. Make sure the library groups show correctly.