### PR TITLE
Fixed NGSS broken links

### DIFF
--- a/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.html
+++ b/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.html
@@ -33,9 +33,9 @@
     <p *ngIf="ngss.dciArrangements.length">
       <strong>Performance Expectations: </strong>
       <ng-container *ngFor="let dcia of ngss.dciArrangements; let isLast=last">
-        <a href="{{ data.ngssWebUrl }}{{ dcia.id }}" target="_blank">{{ dcia.id }} {{ dcia.name }}</a>
+        <a href="{{ ngssWebUrl }}{{ dcia.id }}" target="_blank">{{ dcia.id }} {{ dcia.name }}</a>
         <ng-container *ngIf="dcia.children.length">
-          (<ng-container *ngFor="let pe of dcia.children; let isLastChild=last"><a class="library-project-details__pe" href="{{ data.ngssWebUrl }}{{ pe.id }}"
+          (<ng-container *ngFor="let pe of dcia.children; let isLastChild=last"><a class="library-project-details__pe" href="{{ ngssWebUrl }}{{ pe.id }}"
                                                                                    target="_blank" matTooltip="{{ pe.name }}"
                                                                                    [matTooltipPosition]="'above'">{{ pe.id }}</a>{{ isLastChild ? '' : ', ' }}</ng-container>)
         </ng-container>{{ isLast ? '' : ' / ' }}

--- a/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.spec.ts
@@ -1,9 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, Input } from '@angular/core';
 import { Observable } from "rxjs";
-import { MatDialog } from "@angular/material/dialog";
-import { MatDialogRef } from '@angular/material/dialog';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from "@angular/material/dialog";
 import { LibraryProjectDetailsComponent } from './library-project-details.component';
 import { UserService } from "../../../services/user.service";
 import { Project } from "../../../domain/project";


### PR DESCRIPTION
Fixed a bug the was breaking links to NGSS standards in the library project details dialog.

To test:
- Load site, scroll to library, click on a library group, and click on a project.
- Click on the Performance Expectation links and make sure they open correctly in a new tab.