### PR TITLE
Fixed blank pages on ios devices

### DIFF
--- a/src/main/webapp/site/src/app/app.component.html
+++ b/src/main/webapp/site/src/app/app.component.html
@@ -1,18 +1,28 @@
-<mat-sidenav-container fullscreen [class.has-announcement]="hasAnnouncement">
-  <mat-sidenav #mobileMenu
-               class="primary-bg"
-               [(opened)]="showMobileMenu"
-               position="end">
-    <app-mobile-menu></app-mobile-menu>
-  </mat-sidenav>
-  <mat-sidenav-content>
-    <app-announcement *ngIf="showHeaderAndFooter() && hasAnnouncement"
-                      message="Thanks for testing our new site!"
-                      action="Learn More"
-                      (callback)="showAnnouncementDetails()"
-                      (dismiss)="dismissAnnouncement()"></app-announcement>
-    <app-header class="dark-theme" *ngIf="showHeaderAndFooter()"></app-header>
-    <router-outlet></router-outlet>
-    <app-footer *ngIf="showHeaderAndFooter()"></app-footer>
-  </mat-sidenav-content>
-</mat-sidenav-container>
+<ng-template #standalone>
+  <router-outlet></router-outlet>
+</ng-template>
+
+<ng-template #default>
+  <mat-sidenav-container fullscreen [class.has-announcement]="hasAnnouncement" class="app-background">
+    <mat-sidenav #mobileMenu
+                 class="primary-bg"
+                 [(opened)]="showMobileMenu"
+                 position="end">
+      <app-mobile-menu></app-mobile-menu>
+    </mat-sidenav>
+    <mat-sidenav-content fxLayout="column">
+      <app-announcement *ngIf="showHeaderAndFooter() && hasAnnouncement"
+                        message="Thanks for testing our new site!"
+                        action="Learn More"
+                        (callback)="showAnnouncementDetails()"
+                        (dismiss)="dismissAnnouncement()"></app-announcement>
+      <app-header class="dark-theme"></app-header>
+      <div fxFlex>
+        <router-outlet></router-outlet>
+      </div>
+      <app-footer></app-footer>
+    </mat-sidenav-content>
+  </mat-sidenav-container>
+</ng-template>
+
+<ng-container *ngTemplateOutlet="showHeaderAndFooter() ? default: standalone"></ng-container>

--- a/src/main/webapp/site/src/app/app.component.ts
+++ b/src/main/webapp/site/src/app/app.component.ts
@@ -1,5 +1,5 @@
-import { Component, Inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { Router, NavigationEnd, NavigationStart } from '@angular/router';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MatIconRegistry } from '@angular/material';
 import { MatDialog, MatDialogRef } from "@angular/material";
@@ -18,6 +18,7 @@ export class AppComponent {
   showMobileMenu: boolean = false;
   mediaWatcher: Subscription;
   hasAnnouncement: boolean = true;
+  popstate: boolean = false;
 
   constructor(private router: Router,
               iconRegistry: MatIconRegistry,
@@ -60,6 +61,31 @@ export class AppComponent {
     });
     router.events.subscribe((event) => {
       utilService.showMobileMenu(false);
+    });
+  }
+
+  ngOnInit() {
+    /** Temporary hack to ensure scroll to top on router navigation (excluding
+     * back/forward browser button presses)
+     * TODO: remove when https://github.com/angular/material2/issues/4280 is resolved
+     */
+    this.router.events.subscribe((ev: any) => {
+      const sidenavContentElement = document.querySelector(
+        '.mat-sidenav-content',
+      );
+      if (!sidenavContentElement) {
+        return;
+      }
+      if (ev instanceof NavigationStart) {
+        this.popstate = ev.navigationTrigger === 'popstate';
+      } else if (ev instanceof NavigationEnd) {
+        if (!this.popstate) {
+          sidenavContentElement.scroll({
+            left: 0,
+            top: 0
+          });
+        }
+      }
     });
   }
 

--- a/src/main/webapp/site/src/app/app.module.ts
+++ b/src/main/webapp/site/src/app/app.module.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { HttpErrorInterceptor } from "./http-error.interceptor";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { RouterModule } from '@angular/router';
 import { MatDialogModule, MAT_SNACK_BAR_DEFAULT_OPTIONS, MatSidenavModule } from '@angular/material';
 import {
   SocialLoginModule,
@@ -79,7 +80,11 @@ export function getAuthServiceConfigs(configService: ConfigService) {
     NewsModule,
     FeaturesModule,
     MatSidenavModule,
-    MatDialogModule
+    MatDialogModule,
+    RouterModule.forRoot([], {
+      scrollPositionRestoration: 'enabled',
+      anchorScrolling: 'enabled',
+    })
   ],
   entryComponents: [ AnnouncementDialogComponent ],
   providers: [

--- a/src/main/webapp/site/src/app/login/login.component.html
+++ b/src/main/webapp/site/src/app/login/login.component.html
@@ -1,4 +1,4 @@
-<div class="standalone">
+<div class="standalone mat-app-background">
   <div class="standalone__logo">
     <a routerLink="/">
       <img src="assets/img/wise-web-logo-full.png" alt="WISE logo" />

--- a/src/main/webapp/site/src/app/register/register.component.html
+++ b/src/main/webapp/site/src/app/register/register.component.html
@@ -1,4 +1,4 @@
-<div class="standalone">
+<div class="standalone mat-app-background">
   <div class="standalone__logo">
     <a routerLink="/">
       <img src="assets/img/wise-web-logo-full.png" alt="WISE logo" />


### PR DESCRIPTION
Fix for blank pages on ios devices for standalone routes like `/login` and `/join`. (Also made sure pages scroll to top when loading new routes.)

To test:
- Load site using ios emulator or on ios device connected to local WISE instance.
- Navigate to `/login` and `/join` pages and sub-pages and make sure the content appears and layout is correct.
- Try navigating using links as well as directly loading the pages and refreshing the pages.

Closes #1597.