### PR TITLE
Styled news

### DIFF
--- a/src/main/webapp/site/src/app/news/news.component.html
+++ b/src/main/webapp/site/src/app/news/news.component.html
@@ -19,8 +19,8 @@
               <app-timeline-item-content>
                 <mat-card>
                   <mat-card-content>
-                    <h2 class="news-title mat-body-2">{{newsItem.title}}</h2>
-                    <div class="mat-body-2" [innerHTML]="sanitizer.bypassSecurityTrustHtml(newsItem.news)"></div>
+                    <h2 class="accent-1">{{newsItem.title}}</h2>
+                    <div class="mat-body-1" [innerHTML]="sanitizer.bypassSecurityTrustHtml(newsItem.news)"></div>
                   </mat-card-content>
                 </mat-card>
               </app-timeline-item-content>

--- a/src/main/webapp/site/src/app/news/news.component.scss
+++ b/src/main/webapp/site/src/app/news/news.component.scss
@@ -1,3 +1,1 @@
-.news-title {
-  text-decoration: underline;
-}
+


### PR DESCRIPTION
Updated basic styling for news items to better match the rest of the site.

To test:
- Load `/news` and make sure the formatting looks okay.

Closes #1559.