### PR TITLE
Display instructions to teachers after setting up a run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ hsqldb_test
 src/main/webapp/curriculum/*
 !src/main/webapp/curriculum/demo/
 !src/main/webapp/curriculum/e2e-test1/
+.classpath

--- a/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.ts
@@ -66,7 +66,8 @@ export class LibraryProjectDetailsComponent implements OnInit {
   runProject() {
     this.dialog.open(CreateRunDialogComponent, {
       data: this.data,
-      panelClass: 'mat-dialog--md'
+      panelClass: 'mat-dialog--md',
+      disableClose: true
     });
   }
 }

--- a/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.html
+++ b/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.html
@@ -1,7 +1,7 @@
 <h2 class="mat-dialog-title" i18n>Use with Class</h2>
-<form [formGroup]="form" (ngSubmit)="create()">
+<form *ngIf="!isCreated" [formGroup]="form" (ngSubmit)="create()">
   <mat-dialog-content class="mat-dialog-content--scroll" fxLayout="column">
-    <p class="mat-subheading-1 accent-1">
+    <p class="mat-subheading-2 accent-1">
       {{ project.metadata.title }} <span class="mat-caption">(<ng-container i18n>Unit ID:</ng-container> {{ project.id }})</span>
     </p>
     <h3 i18n>1. Choose Periods</h3>
@@ -52,3 +52,17 @@
     </button>
   </mat-dialog-actions>
 </form>
+<ng-container *ngIf="isCreated">
+  <mat-dialog-content>
+    <div class="info-block">
+      <p class="mat-body-2" i18n>Success! This unit has been added to your Class Schedule.</p>
+      <p class="mat-subheading-2 accent-1">{{ run.name }}</p>
+      <p class="mat-subheading-2 accent" i18n>Access Code: {{ run.runCode }}</p>
+      <p i18n>Important: Every classroom unit has a unique Access Code. Students use this code to register for a unit. Give the code to your students when they first sign up for a WISE account. If they already have WISE accounts, have them log in and then select "Add Unit" from the student home page.</p>
+      <p i18n>You can always find the Access Code for each classroom unit in your Class Schedule.</p>
+    </div>
+  </mat-dialog-content>
+  <mat-dialog-actions fxLayoutAlign="end">
+    <button mat-button (click)="closeAll()" i18n>Done</button>
+  </mat-dialog-actions> 
+</ng-container>

--- a/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.spec.ts
+++ b/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.spec.ts
@@ -15,6 +15,8 @@ export class MockTeacherService {
   createRun() {
     return Observable.create(observer => {
       const run: Run = new Run();
+      run.runCode = 'Dog1234';
+      run.name = 'Photosynthesis';
       observer.next(run);
       observer.complete();
     });
@@ -89,7 +91,7 @@ describe('CreateRunDialogComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should show run info', () => {
+  it('should show project info', () => {
     const compiled = fixture.debugElement.nativeElement;
     expect(compiled.textContent).toContain('Photosynthesis');
   });
@@ -125,11 +127,13 @@ describe('CreateRunDialogComponent', () => {
     expect(submitButton.disabled).toBe(false);
   });
 
-  it('should close the dialog when form is successfully submitted', async() => {
+  it('should show the confirmation message when form is successfully submitted', async() => {
     component.periodsGroup.controls[0].get("checkbox").setValue(true);
     const form = getForm();
     form.triggerEventHandler('submit', null);
     fixture.detectChanges();
-    expect(component.dialog.closeAll).toHaveBeenCalled();
+    const compiled = fixture.debugElement.nativeElement;
+    expect(compiled.textContent).toContain('Dog1234');
+    expect(compiled.textContent).toContain('Photosynthesis');
   });
 });

--- a/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.ts
+++ b/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.ts
@@ -22,6 +22,8 @@ export class CreateRunDialogComponent {
   startDate: any;
   periodOptions: string[] = [];
   isCreating: boolean = false;
+  isCreated: boolean = false;
+  run: Run = null;
 
   constructor(public dialog: MatDialog,
               public dialogRef: MatDialogRef<CreateRunDialogComponent>,
@@ -84,10 +86,12 @@ export class CreateRunDialogComponent {
           })
         )
         .subscribe((newRun: Run) => {
-          const run = new Run(newRun);
-          this.teacherService.addNewRun(run);
-          this.teacherService.setTabIndex(0);
-          this.dialog.closeAll();
+          this.run = new Run(newRun);
+          this.dialogRef.afterClosed().subscribe(result => {
+            this.teacherService.addNewRun(this.run);
+            this.teacherService.setTabIndex(0);
+          });
+          this.isCreated = true;
         });
   }
 
@@ -102,5 +106,9 @@ export class CreateRunDialogComponent {
     } else {
       return customPeriods.toString();
     }
+  }
+
+  closeAll() {
+    this.dialog.closeAll();
   }
 }

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -2653,6 +2653,49 @@
           <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="db6e4c2b4925a66905d9a41e398e18b1e1b3a69d" datatype="html">
+        <source>Success! This unit has been added to your Class Schedule.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="08386d4e77c0a63a78f010c21160833578891b20" datatype="html">
+        <source>Access Code: <x id="INTERPOLATION" equiv-text="{{ run.runCode }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="534ba8ba6d05fed93bd074e67fb6d03d2e466b46" datatype="html">
+        <source>Important: Every classroom unit has a unique Access Code. Students use this code to register for a unit. Give the code to your students when they first sign up for a WISE account. If they already have WISE accounts, have them log in and then select &quot;Add Unit&quot; from the student home page.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f2069492a5ba2249fb5f24e59009120d73623289" datatype="html">
+        <source>You can always find the Access Code for each classroom unit in your Class Schedule.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8dd413cee2228118c536f503709329a4d1a395e2" datatype="html">
+        <source>Done</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="07ab43ffb10e6bed417b203bfdc02cdda6aa1b61" datatype="html">
         <source>Grade level:</source>
         <context-group purpose="location">
@@ -2791,17 +2834,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
           <context context-type="linenumber">65</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8dd413cee2228118c536f503709329a4d1a395e2" datatype="html">
-        <source>Done</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">66</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d1acaeb5fa466988ff526619702c4bf21e0a5e15" datatype="html">


### PR DESCRIPTION
To test:
- Log in as a teacher and select a project from "Browse WISE Units".
- Select "Use with Class" and create a new run.
- After the run is created, verify that the run settings form is replaced with a confirmation message that shows the run name, access code, and instructions for how to register students for the run.
- Select "Done" and verify that the tab switches to "Class Schedule" and the browser window scrolls to the new run list item.

Closes #1591.