### PR TITLE
Fixed the branch path taken constraint message for students. 

### DIFF
--- a/src/main/webapp/wise5/vle/i18n/i18n_en.json
+++ b/src/main/webapp/wise5/vle/i18n/i18n_en.json
@@ -17,6 +17,7 @@
   "areYouSureYouWantToDeleteThisItem": "Are you sure you want to delete this item?",
   "autoLogoutMessage": "You have been inactive for a long time. Do you want to stay logged in?",
   "automatedFeedbackLabel": "Computer Feedback",
+  "branchPathTakenFromTo": "Take the branch path from <b>{{fromNodeTitle}}</b> to <b>{{toNodeTitle}}</b>",
   "cancel": "Cancel",
   "chooseABranchPath": "Choose a Branch Path",
   "chooseItemToSnipToNotebook": "Choose Item to Snip to Notebook",


### PR DESCRIPTION
You can test this by going to production and downloading project 25961.

Directly load node79 and click the next button. You should see the constraint message that says "branchPathTakenFromTo"
https://wise.berkeley.edu/project/25961#/vle/node79

When you run the fixed code locally it should instead say something like "Take the branch path from **3.5: Bowls in a Fridge** to **3.6 A: Bowls: Improve Sara's Explanation**".

Closes #1681