### PR TITLE
implemented injection of owner, shared owner, date created to /library

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/project/ProjectAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/project/ProjectAPIController.java
@@ -146,6 +146,9 @@ public class ProjectAPIController {
         projectLibraryGroup.put("metadata", metadata.toJSONObject());
         projectLibraryGroup.put("projectThumb", getProjectThumb(project));
         projectLibraryGroup.put("name", project.getName());
+        projectLibraryGroup.put("owner", ControllerUtil.getOwnerJSON(project.getOwner()));
+        projectLibraryGroup.put("sharedOwners", ControllerUtil.getProjectSharedOwnersJSON(project));
+        projectLibraryGroup.put("dateCreated", project.getDateCreated());
       } catch (ObjectNotFoundException e) {
         e.printStackTrace();
       }


### PR DESCRIPTION
closes #1486 

- verify that owner, shared owners, and date created are correctly injected to /api/project/library response object