### PR TITLE
Fixed issue where responses weren't being encoded correctly. 

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,8 +2,9 @@ debug=false
 logging.level.org.springframework=ERROR
 logging.level.com=ERROR
 
-#spring.mvc.view.prefix=classpath:/portal/
-#spring.mvc.view.suffix=.jsp
+spring.http.encoding.charset=UTF-8
+spring.http.encoding.enabled=true
+spring.http.encoding.force=true
 
 server.error.include-exception=true # Include the "exception" attribute.
 #spring.resources.static-locations=classpath:/portal/

--- a/src/main/resources/configurations/applicationContexts.xml
+++ b/src/main/resources/configurations/applicationContexts.xml
@@ -54,7 +54,6 @@
     <sec:filter-chain-map request-matcher="ant">
       <sec:filter-chain pattern="/**" filters="
           openSessionInViewFilter,
-          charsetFilter,
           httpSessionContextIntegrationFilter,
           logoutFilter,
           oAuth2ClientContextFilter,
@@ -130,13 +129,6 @@
     <property name="switchUserUrl" value="/login/impersonate" />
     <property name="exitUserUrl" value="/logout/impersonate" />
     <property name="targetUrl" value="/index.html" />
-  </bean>
-
-  <!-- =================== Encoding ==================== -->
-
-  <bean id="charsetFilter" class="org.springframework.web.filter.CharacterEncodingFilter">
-    <property name="encoding" value="UTF-8" />
-    <property name="forceEncoding" value="true" />
   </bean>
 
   <!-- =================== SECURITY SYSTEM DEFINITIONS ================== -->


### PR DESCRIPTION
How to test:
1. Log in as student.
2. Go to open response step and type response in non-english language.
3. Refresh browser. Your work should appear correctly (before it was showing gibberish)
4. Log in as teacher. Verify that students' response appears correctly.
5. Give non-english feedback. Verify that it appears correctly in student's view.

Closes #1781