### PR TITLE
Added warning icons and labels to wise4 units

### DIFF
--- a/src/main/webapp/site/src/app/contact/contact-form/contact-form.component.ts
+++ b/src/main/webapp/site/src/app/contact/contact-form/contact-form.component.ts
@@ -120,25 +120,25 @@ export class ContactFormComponent implements OnInit {
       this.issueTypes = [
         { key: "TROUBLE_LOGGING_IN", value: this.i18n("Trouble Signing In") },
         { key: "NEED_HELP_USING_WISE", value: this.i18n("Need Help Using WISE") },
-        { key: "PROJECT_PROBLEMS", value: this.i18n("Problems with a Project") },
+        { key: "PROJECT_PROBLEMS", value: this.i18n("Problems with a WISE Unit") },
         { key: "FEEDBACK", value: this.i18n("Feedback to WISE") },
-        { key: "OTHER", value: this.i18n("Other Problem") }
+        { key: "OTHER", value: this.i18n("Other") }
       ];
     } else {
       this.issueTypes = [
         { key: "TROUBLE_LOGGING_IN", value: this.i18n("Trouble Signing In") },
         { key: "NEED_HELP_USING_WISE", value: this.i18n("Need Help Using WISE") },
-        { key: "PROJECT_PROBLEMS", value: this.i18n("Problems with a Project") },
+        { key: "PROJECT_PROBLEMS", value: this.i18n("Problems with a WISE Unit") },
         { key: "STUDENT_MANAGEMENT", value: this.i18n("Student Management") },
         { key: "AUTHORING", value: this.i18n("Need Help with Authoring") },
         { key: "FEEDBACK", value: this.i18n("Feedback to WISE") },
-        { key: "OTHER", value: this.i18n("Other Problem") }
+        { key: "OTHER", value: this.i18n("Other") }
       ];
     }
   }
 
   setIssueTypeIfNecessary() {
-    if (this.isStudent && this.runId != null) {
+    if (this.runId != null) {
       this.setControlFieldValue('issueType', 'PROJECT_PROBLEMS')
     }
   }

--- a/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.html
+++ b/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.html
@@ -23,6 +23,17 @@
                               [project]="data.project"></app-library-project-menu>
   </div>
   <div class="library-project-details__info info-block">
+    <p *ngIf="data.project.wiseVersion === 4"
+       class="warn" 
+       fxLayout="row" 
+       fxLayoutAlign="start center">
+      <mat-icon color="warn">warning</mat-icon>&nbsp;
+      <strong class="more-info"
+              i18n-matTooltip
+              matTooltip="This unit is from an old version of WISE and will eventually be phased out."
+              [matTooltipPosition]="'after'"
+              i18n>Legacy Unit</strong>
+    </p>
     <div class="library-project-details__summary" [innerHTML]="data.project.metadata.summary"></div>
     <p *ngIf="ngss.disciplines.length">
       <strong i18n>Discipline:</strong>

--- a/src/main/webapp/site/src/app/modules/library/library-project/library-project.component.html
+++ b/src/main/webapp/site/src/app/modules/library/library-project/library-project.component.html
@@ -9,7 +9,15 @@
   <div class="library-project__cover" [style.background-image]="project.thumbStyle"></div>
   <app-library-project-disciplines [project]="project"></app-library-project-disciplines>
   <div class="library-project__details">
-    <p class="library-project__title">{{ project.metadata.title }} <span class="mat-caption secondary-text" i18n>(ID: {{ project.id }})</span></p>
+    <p class="library-project__title">
+      {{ project.metadata.title }}&nbsp;
+      <span class="mat-caption secondary-text" i18n>(ID: {{ project.id }})</span>&nbsp;
+      <mat-icon *ngIf="project.wiseVersion === 4"
+                color="warn"
+                i18n-matTooltip
+                matTooltip="Legacy Unit"
+                [matTooltipPosition]="'above'">warning</mat-icon>
+    </p>
     <p *ngIf="project.shared" class="info mat-caption" i18n>Shared by {{ project.owner.displayName }}</p>
   </div>
 </mat-card>

--- a/src/main/webapp/site/src/app/modules/library/library-project/library-project.component.scss
+++ b/src/main/webapp/site/src/app/modules/library/library-project/library-project.component.scss
@@ -62,6 +62,10 @@ $config: mat-typography-config();
       margin-bottom: 0;
     }
   }
+
+  .mat-icon {
+    vertical-align: bottom;
+  }
 }
 
 .library-project__title {

--- a/src/main/webapp/site/src/app/modules/library/library/library.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/library/library.component.ts
@@ -49,7 +49,7 @@ export abstract class LibraryComponent implements OnInit {
     this.pageSize = event.pageSize;
     this.setPagination();
     if (scroll) {
-      const listEl = document.querySelector('.library__content');
+      const listEl = document.querySelector('.library');
       listEl.scrollIntoView();
     }
   }

--- a/src/main/webapp/site/src/app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html
+++ b/src/main/webapp/site/src/app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html
@@ -1,9 +1,9 @@
-<h2 class="mat-dialog-title" i18n>Wise4 Project Warning</h2>
-<div mat-dialog-content class="mat-dialog-content--scroll">
+<h2 class="mat-dialog-title" i18n>Legacy Unit Warning</h2>
+<div mat-dialog-content>
   <div class="info-block">
     <p class="mat-subheading-2 accent-1">{{ project.metadata.title }} <span class="mat-caption" i18n>(Unit ID: {{ project.id }})</span></p>
-    <p class="mat-body-2" i18n>Warning: this is a legacy unit in a version of WISE that is many years old.</p>
-    <p i18n>We recommend finding a newer version of this unit in the library, as support for classroom implementations of legacy units will be phased out over the coming year. If you cannot find a newer version, contact us if you're interested in upgrading the unit. Thanks!</p>
+    <p class="warn" i18n>WARNING: this is a legacy unit from a version of WISE that is many years old.</p>
+    <p i18n>We recommend finding a newer version in the library, as support for classroom implementations of legacy units will be phased out over the coming year. If you cannot find a newer version, <a routerLink="/contact" target="_blank">contact us</a> if you're interested in upgrading the unit. Thanks!</p>
   </div>
 </div>
 <div mat-dialog-actions

--- a/src/main/webapp/site/src/app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.ts
+++ b/src/main/webapp/site/src/app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.ts
@@ -25,5 +25,7 @@ export class UseWithClassWarningDialogComponent implements OnInit {
       panelClass: 'mat-dialog--md',
       disableClose: true
     })
+
+    this.dialogRef.close();
   }
 }

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -2594,7 +2594,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">63</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/community-library/community-library-details.html</context>
@@ -2646,7 +2646,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">68</context>
         </context-group>
       </trans-unit><trans-unit id="a40392824621859bfd694580f1bb21debbc50eb0" datatype="html">
         <source>(Unit ID: <x id="INTERPOLATION" equiv-text="{{ project.id }}"/>)</source>
@@ -2806,35 +2806,30 @@
           <context context-type="sourcefile">app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
           <context context-type="linenumber">47</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="a158381be2135623f1b321725f34dadcfd0fcbd4" datatype="html">
-        <source>Wise4 Project Warning</source>
+      </trans-unit><trans-unit id="d9b2ffb3e1ce1ca42a3db04d00ea072777898eb3" datatype="html">
+        <source>Legacy Unit Warning</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html</context>
           <context context-type="linenumber">1</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="ab03ea73e6b9710336b5078264a3e3dcdf1345a8" datatype="html">
-        <source>Warning: this is a legacy unit in a version of WISE that is many years old.</source>
+      </trans-unit><trans-unit id="6f526813fe643e11e1e0c4632ab8d782aa2eb1f0" datatype="html">
+        <source>WARNING: this is a legacy unit from a version of WISE that is many years old.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html</context>
           <context context-type="linenumber">5</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="8a1e81aea4d05d0169f20b796866f917fdb83c41" datatype="html">
-        <source>We recommend finding a newer version of this unit in the library, as support for classroom implementations of legacy units will be phased out over the coming year. If you cannot find a newer version, contact us if you&apos;re interested in upgrading the unit. Thanks!</source>
+      </trans-unit><trans-unit id="7673ea16907fbb64650af880042cb4e045382160" datatype="html">
+        <source>We recommend finding a newer version in the library, as support for classroom implementations of legacy units will be phased out over the coming year. If you cannot find a newer version, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>contact us<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> if you&apos;re interested in upgrading the unit. Thanks!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html</context>
           <context context-type="linenumber">6</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="c90c99f8160be2e6bb39fcba6ae4a0009e652474" datatype="html">
+      </trans-unit><trans-unit id="c90c99f8160be2e6bb39fcba6ae4a0009e652474" datatype="html">
         <source>Proceed Anyway</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html</context>
           <context context-type="linenumber">14</context>
         </context-group>
-      </trans-unit>
       </trans-unit><trans-unit id="07ab43ffb10e6bed417b203bfdc02cdda6aa1b61" datatype="html">
         <source>Grade level:</source>
         <context-group purpose="location">
@@ -2853,29 +2848,45 @@
           <context context-type="sourcefile">app/modules/library/library-project-details/library-project-details.component.html</context>
           <context context-type="linenumber">14</context>
         </context-group>
+      </trans-unit><trans-unit id="59a08e65c39e2cecb841fc7123a77756f52c8db3" datatype="html">
+        <source>Legacy Unit</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/library-project-details/library-project-details.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/library-project/library-project.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit><trans-unit id="3c2ac8a727b69d981f7f6559cc2fd8d0688ebd76" datatype="html">
+        <source>This unit is from an old version of WISE and will eventually be phased out.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/library-project-details/library-project-details.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
       </trans-unit><trans-unit id="c38ef07814e33a674bada9fe331ffd114cec319d" datatype="html">
         <source>Discipline:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit><trans-unit id="4cdcf77b0a246131946d080de95cf21fbd5516a9" datatype="html">
         <source>Features:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">33</context>
+          <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit><trans-unit id="4a074ee53886e04659f3cec8ec30b94ce5ce717c" datatype="html">
         <source>NGSS Performance Expectations: </source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit><trans-unit id="3e2a583f531f7dd9f089f68a6968e444c372c3e8" datatype="html">
         <source>Preview</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">74</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/run-menu/run-menu.component.html</context>
@@ -2885,13 +2896,13 @@
         <source>(ID: <x id="INTERPOLATION" equiv-text="{{ project.id }}"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project/library-project.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit><trans-unit id="e3ae8640f4d05cb4f78a31cfbf18d5701f41d57e" datatype="html">
         <source>Shared by <x id="INTERPOLATION" equiv-text="{{ project.owner.displayName }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project/library-project.component.html</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit><trans-unit id="4bad40355890bcbe1b4003d9fd0632beeffd6580" datatype="html">
         <source>Show project details</source>
@@ -3007,19 +3018,25 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project-menu/library-project-menu.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit><trans-unit id="77bd1ad738d92e35036a6caa0afba8152299876b" datatype="html">
+        <source>Parent ID: <x id="INTERPOLATION" equiv-text="{{ project.parentId }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/library-project-menu/library-project-menu.component.html</context>
           <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit><trans-unit id="28f86ffd419b869711aa13f5e5ff54be6d70731c" datatype="html">
         <source>Edit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project-menu/library-project-menu.component.html</context>
-          <context context-type="linenumber">10</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit><trans-unit id="0bd8b27f60a1f098a53e06328426d818e3508ff9" datatype="html">
         <source>Share</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project-menu/library-project-menu.component.html</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">17</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/run-menu/run-menu.component.html</context>
@@ -4794,8 +4811,8 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="0c5af86112898145b98bcee05fcaca125528a92e" datatype="html">
-        <source>Problems with a Project</source>
+      <trans-unit id="6a6f97816b45d44504a072d73938c951bbd01810" datatype="html">
+        <source>Problems with a WISE Unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/main/webapp/site/src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">1</context>
@@ -4816,14 +4833,22 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="41a1ff0b6dc21c6e5eaff3ce070117f18211f1a9" datatype="html">
-        <source>Other Problem</source>
+      <trans-unit id="c2a9de3714f5767b174d0424bc8abe2dc37acc41" datatype="html">
+        <source>Other</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/main/webapp/site/src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/main/webapp/site/src/app/contact/contact-form/contact-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/main/webapp/site/src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
@@ -5288,17 +5313,6 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c2a9de3714f5767b174d0424bc8abe2dc37acc41" datatype="html">
-        <source>Other</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/main/webapp/site/src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">1</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
-          <context context-type="linenumber">1</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="807f39b93f38db144148c3e05f4886e99593227c" datatype="html">
         <source>Password changed.</source>
         <context-group purpose="location">
@@ -5318,6 +5332,17 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="96e3d7cc1051fa738cbb4f3ee6038c1751d85df6" datatype="html">
+        <source>A teacher cannot be added as a team member.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/main/webapp/site/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/main/webapp/site/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>

--- a/src/main/webapp/site/src/style/components/_info-block.scss
+++ b/src/main/webapp/site/src/style/components/_info-block.scss
@@ -4,7 +4,7 @@
   font-size: mat-font-size($config, body-1);
 
   p {
-    &:last-of-type {
+    &:last-child {
       margin-bottom: 0;
     }
   }


### PR DESCRIPTION
To test:
- Load site homepage and check to see that wise4 units have a warning icon
- Load `/teacher` and select 'Browse WISE Units'
- Make sure wise4 units have a warning icon
- Click on wise4 units and make sure that the project details dialog displays a 'Legacy Unit' label with a tooltip

Closes #1439.