### PR TITLE
Fixed bug: cannot log in with google id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,7 +472,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <org.springframework.version>4.3.20.RELEASE</org.springframework.version>
     <org.hibernate.version>5.2.10.Final</org.hibernate.version>
-    <spring-security-oauth2.version>2.2.1.RELEASE</spring-security-oauth2.version>
+    <spring-security-oauth2.version>2.2.4.RELEASE</spring-security-oauth2.version>
     <spring-security-jwt.version>1.0.9.RELEASE</spring-security-jwt.version>
     <jwks-rsa.version>0.3.0</jwks-rsa.version>
     <powermock.version>1.7.1</powermock.version>

--- a/src/main/java/org/wise/portal/presentation/web/filters/GoogleOpenIdConnectFilter.java
+++ b/src/main/java/org/wise/portal/presentation/web/filters/GoogleOpenIdConnectFilter.java
@@ -86,11 +86,16 @@ public class GoogleOpenIdConnectFilter extends AbstractAuthenticationProcessingF
       if (user != null) {
         return new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
       } else {
+        invalidateAccesToken();
         throw new BadCredentialsException("google user not found");
       }
     } catch (final Exception e) {
       throw new BadCredentialsException("Could not obtain user details from token", e);
     }
+  }
+
+  private void invalidateAccesToken() {
+    googleOpenIdRestTemplate.getOAuth2ClientContext().setAccessToken((OAuth2AccessToken)null);
   }
 
   public void verifyClaims(Map claims) {

--- a/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
+++ b/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package org.wise.portal.spring.impl;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
@@ -17,5 +18,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
       .antMatchers("/").permitAll();
 
     http.headers().frameOptions().sameOrigin();
+  }
+
+  @Override
+  public void configure(WebSecurity web) throws Exception {
+    web.ignoring().antMatchers("/google-login");
   }
 }

--- a/src/main/resources/wise_sample.properties
+++ b/src/main/resources/wise_sample.properties
@@ -194,8 +194,9 @@ trustedAuthorAllowedProjectAssetContentTypes=text/html,application/javascript,ap
 google.enableOpenIdConnect=false
 google.clientId=
 google.clientSecret=
+
 google.accessTokenUri=https://www.googleapis.com/oauth2/v3/token
-google.userAuthorizationUri=https://accounts.google.com/o/oauth2/auth
+google.userAuthorizationUri=https://accounts.google.com/o/oauth2/auth?prompt=select_account
 google.redirectUri=https://YOUR_WISE_INSTANCE/google-login
 google.issuer=accounts.google.com
 google.jwkUrl=https://www.googleapis.com/oauth2/v2/certs


### PR DESCRIPTION
This PR fixes the issue where user could not log in with google account. This also advances the spring-security-oauth2 dependency to address security issue CVE-2018-15758

First update wise.properties to add ?prompt=select_account to userAuthorizationUri:
```
google.userAuthorizationUri=https://accounts.google.com/o/oauth2/auth?prompt=select_account
```

Test that...
1. you can register a new user (student or teacher) using google id
2. you can log in with google id that you have used to register with WISE
3. you cannot log in with google id that you have not used to register with WISE, and then you can do step 1 again immediately afterwards without closing browser
4. you can log in with a regular account that does not use google id

Closes #1800.