### PR TITLE
Added back WISESessionListener. 

### DIFF
--- a/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
+++ b/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
@@ -1,10 +1,15 @@
 package org.wise.portal.spring.impl;
 
+import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.wise.portal.presentation.web.listeners.WISESessionListener;
+
+import javax.servlet.http.HttpSessionListener;
 
 @Configuration
 @EnableWebSecurity
@@ -23,5 +28,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
   @Override
   public void configure(WebSecurity web) throws Exception {
     web.ignoring().antMatchers("/google-login");
+  }
+
+  @Bean
+  public ServletListenerRegistrationBean<HttpSessionListener> sessionListener() {
+    return new ServletListenerRegistrationBean<HttpSessionListener>(new WISESessionListener());
   }
 }


### PR DESCRIPTION
This fixes issue where currently logged in user information was not correctly updating.

To test:
1. Log in as teacher A, then log out as teacher A.
2. Log in as admin and go to currently logged in users page. You should only see the admin user. Before this fix, it still showed teacher A as being logged in.

Fixes #1812