### PR TITLE
Generate messages during watch-all-site command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@
 
 const gulp = require('gulp');
 const babel = require('gulp-babel');
+const exec = require('child_process').exec;
 const sourcemaps = require('gulp-sourcemaps');
 const autoprefixer = require('autoprefixer');
 const cssnano = require('cssnano');
@@ -27,6 +28,9 @@ const sass = require('gulp-sass');
 const sassOptions = { style: 'compact' };
 const paths = ['./src/main/webapp/wise5/style/**/*.scss',
   './src/main/webapp/wise5/themes/*/style/**/*.scss'];
+const sitePaths = ['./src/main/webapp/site/src/**/*.ts',
+  './src/main/webapp/site/src/**/*.html'
+];
 const autoprefixerOptions = { browsers: ['> 5%', 'last 2 versions',
     'Firefox ESR', 'not ie <= 10'] };
 
@@ -71,6 +75,26 @@ gulp.task('watch-sass', gulp.series('set-watch', function(done) {
       console.log('File ' + path + ' was changed');
     });
 }));
+
+gulp.task('site-i18n', (cb) => {
+  return gulp
+    .watch(sitePaths)
+    .on('change', function(path, stat) {
+      console.log('File ' + path + ' was changed...generating messages.');
+      exec('ng xi18n', (err, stdout, stderr) => {
+        console.log('Generating messages part 1/2 [ng xi18n] complete.');
+        console.log(stdout);
+        console.log(stderr);
+        exec('npm run ngx-extractor', (err, stdout, stderr) => {
+          console.log('Generating messages part 2/2 [npm run ngx-extractor] complete.');
+          console.log(stdout);
+          console.log(stderr);
+          cb(err);
+        });
+        cb(err);
+      });
+    });
+});
 
 gulp.task('transpile', gulp.series(() => {
   return gulp.watch(['./src/main/webapp/wise5/**/*.es6'])

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "browser-sync": "./node_modules/browser-sync/bin/browser-sync.js start --config bs-config.js",
     "postinstall": "node ./node_modules/jspm/jspm.js install -y",
     "watch-all-wise5": "node node_modules/concurrently/src/main.js \"node ./node_modules/gulp/bin/gulp.js\" \"npm run test-watch\"",
-    "watch-all-site": "node node_modules/concurrently/src/main.js \"ng build --watch --extract-css=true\" \"ng test --karma-config src/main/webapp/site/karma.conf.js --browsers Chrome\"",
+    "watch-all-site": "node node_modules/concurrently/src/main.js \"ng build --watch --extract-css=true\" \"ng test --karma-config src/main/webapp/site/karma.conf.js --browsers Chrome\" \"node ./node_modules/gulp/bin/gulp.js site-i18n\"",
     "watch-all-site-headless": "node node_modules/concurrently/src/main.js \"ng build --watch --extract-css=true\" \"ng test --karma-config src/main/webapp/site/karma.conf.js --browsers ChromeHeadless\"",
     "watch-sass": "npm rebuild node-sass && node ./node_modules/gulp/bin/gulp.js",
     "update-i18n": "node ./node_modules/gulp/bin/gulp.js update-i18n",


### PR DESCRIPTION
This ensures that messages.xlf is rebuilt when there are changes to html and ts files in the site directory.

What to test:
1. Start WISE and run npm run watch-all-site
2. Make a change to a html file that is an i18n string. See that the change is reflected in the browser, and messages.xlf is updated.
3. Make a change to a ts file that is an i18n string. See that the change is reflected in the browser, and messages.xlf is updated.

Closes #1788