### PR TITLE
Restrict admin path to admins and researchers. 

### DIFF
--- a/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
+++ b/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
@@ -20,7 +20,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     http
       .csrf().disable()
       .authorizeRequests()
-      .antMatchers("/admin/**").hasAnyRole("ROLE_ADMINISTRATOR,ROLE_RESEARCHER")
+      .antMatchers("/admin/**").hasAnyRole("ADMINISTRATOR,RESEARCHER")
       .antMatchers("/").permitAll();
 
     http.headers().frameOptions().sameOrigin();

--- a/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
+++ b/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
@@ -20,6 +20,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     http
       .csrf().disable()
       .authorizeRequests()
+      .antMatchers("/admin/**").hasAnyRole("ROLE_ADMINISTRATOR,ROLE_RESEARCHER")
       .antMatchers("/").permitAll();
 
     http.headers().frameOptions().sameOrigin();


### PR DESCRIPTION
Make sure that you cannot visit any pages in /admin unless you are logged in with a user with admin or researcher roles.

Fixes #1835 