### PR TITLE
Fixed a problem where the launch run button would not show up if the student computer clock was set incorrectly 

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
@@ -30,6 +30,7 @@ import org.wise.portal.service.user.UserService;
 
 import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
+import java.sql.Timestamp;
 import java.util.*;
 
 /**
@@ -70,6 +71,7 @@ public class TeacherAPIController {
     String contextPath = request.getContextPath();
     configJSON.put("contextPath", contextPath);
     configJSON.put("googleClientId", wiseProperties.get("google.clientId"));
+    configJSON.put("currentTime", new Timestamp(System.currentTimeMillis()));
     configJSON.put("logOutURL", contextPath + "/logout");
     return configJSON.toString();
   }

--- a/src/main/webapp/site/src/app/domain/run.spec.ts
+++ b/src/main/webapp/site/src/app/domain/run.spec.ts
@@ -1,0 +1,71 @@
+import { async } from '@angular/core/testing';
+import {Run} from "./run";
+
+describe('Run', () => {
+  beforeEach(async(() => {
+
+  }));
+
+  beforeEach(() => {
+
+  });
+
+  it('should create', () => {
+    expect(true).toBeTruthy();
+  });
+
+  it('should calculate active with no end time', () => {
+    const run = new Run({
+      startTime: '2019-03-21 8:00:00.0'
+    });
+    const before = new Date('2019-03-20 8:00:00.0');
+    expect(run.isActive(before)).toBeFalsy();
+    const after = new Date('2019-03-22 8:00:00.0');
+    expect(run.isActive(after)).toBeTruthy();
+  });
+
+  it('should calculate active with end time', () => {
+    const run = new Run({
+      startTime: '2019-03-21 8:00:00.0',
+      endTime: '2019-03-23 8:00:00.0'
+    });
+    const before = new Date('2019-03-20 8:00:00.0');
+    expect(run.isActive(before)).toBeFalsy();
+    const during = new Date('2019-03-22 8:00:00.0');
+    expect(run.isActive(during)).toBeTruthy();
+    const after = new Date('2019-03-24 8:00:00.0');
+    expect(run.isActive(after)).toBeFalsy();
+  });
+
+  it('should calculate completed with no end time', () => {
+    const run = new Run({
+      startTime: '2019-03-21 8:00:00.0'
+    });
+    const now = new Date('2019-03-22 8:00:00.0');
+    expect(run.isCompleted(now)).toBeFalsy();
+  });
+
+  it('should calculate completed with end time', () => {
+    const run = new Run({
+      startTime: '2019-03-21 8:00:00.0',
+      endTime: '2019-03-23 8:00:00.0'
+    });
+    const before = new Date('2019-03-20 8:00:00.0');
+    expect(run.isCompleted(before)).toBeFalsy();
+    const during = new Date('2019-03-22 8:00:00.0');
+    expect(run.isCompleted(during)).toBeFalsy();
+    const after = new Date('2019-03-24 8:00:00.0');
+    expect(run.isCompleted(after)).toBeTruthy();
+  });
+
+  it('should calculate scheduled', () => {
+    const run = new Run({
+      startTime: '2019-03-21 8:00:00.0'
+    });
+    const before = new Date('2019-03-20 8:00:00.0');
+    expect(run.isScheduled(before)).toBeTruthy();
+    const after = new Date('2019-03-22 8:00:00.0');
+    expect(run.isScheduled(after)).toBeFalsy();
+  });
+
+});

--- a/src/main/webapp/site/src/app/domain/run.ts
+++ b/src/main/webapp/site/src/app/domain/run.ts
@@ -59,7 +59,7 @@ export class Run {
   }
 
   isSharedOwnerWithPermission(userId, permissionId) {
-    for (let sharedOwner of this.sharedOwners) {
+    for (const sharedOwner of this.sharedOwners) {
       if (sharedOwner.id == userId) {
         return this.userHasPermission(sharedOwner, permissionId);
       }
@@ -71,25 +71,24 @@ export class Run {
     return user.permissions.includes(permission);
   }
 
-  isActive() {
-    const now = new Date().getTime();
-    const endTime = new Date(this.endTime).getTime();
-    if (endTime && endTime <= now) {
-      return false;
+  isScheduled(now) {
+    const startTime = new Date(this.startTime).getTime();
+    return now < startTime;
+  }
+
+  isActive(now) {
+    return !this.isScheduled(now) && !this.isCompleted(now);
+  }
+
+  isCompleted(now) {
+    if (this.hasEndTime()) {
+      const endTime = new Date(this.endTime).getTime();
+      return endTime <= now;
     }
-    const startTime = new Date(this.startTime).getTime();
-    return startTime <= now;
+    return false;
   }
 
-  isCompleted() {
-    const now = new Date().getTime();
-    const endTime = new Date(this.endTime).getTime();
-    return endTime <= now;
-  }
-
-  isScheduled() {
-    const now = new Date().getTime();
-    const startTime = new Date(this.startTime).getTime();
-    return startTime > now;
+  hasEndTime() {
+    return this.endTime != null;
   }
 }

--- a/src/main/webapp/site/src/app/login/login-home/login-home.component.spec.ts
+++ b/src/main/webapp/site/src/app/login/login-home/login-home.component.spec.ts
@@ -25,6 +25,9 @@ export class MockConfigService {
       observer.complete();
     });
   }
+  getRecaptchaPublicKey(): string {
+    return '';
+  }
 }
 
 describe('LoginHomeComponent', () => {

--- a/src/main/webapp/site/src/app/modules/library/official-library/official-library.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/library/official-library/official-library.component.spec.ts
@@ -8,7 +8,12 @@ import { LibraryGroup } from "../libraryGroup";
 export class MockLibraryService {
   libraryGroupsSource$ = fakeAsyncResponse({});
   officialLibraryProjectsSource$ = fakeAsyncResponse([]);
-  projectFilterOptionsSource$ = fakeAsyncResponse([]);
+  projectFilterOptionsSource$ = fakeAsyncResponse({
+    searchValue: "",
+    disciplineValue: [],
+    dciArrangementValue: [],
+    peValue: []
+  });
   implementationModelOptions: LibraryGroup[] = [];
   getOfficialLibraryProjects() {
 

--- a/src/main/webapp/site/src/app/modules/library/personal-library/personal-library.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/library/personal-library/personal-library.component.spec.ts
@@ -9,7 +9,12 @@ export class MockLibraryService {
   implementationModelOptions = [];
   personalLibraryProjectsSource$ = fakeAsyncResponse([]);
   sharedLibraryProjectsSource$ = fakeAsyncResponse([]);
-  projectFilterOptionsSource$ = fakeAsyncResponse({});
+  projectFilterOptionsSource$ = fakeAsyncResponse({
+    searchValue: "",
+    disciplineValue: [],
+    dciArrangementValue: [],
+    peValue: []
+  });
   newProjectSource$ = fakeAsyncResponse({});
   getPersonalLibraryProjects() {
 

--- a/src/main/webapp/site/src/app/services/config.service.ts
+++ b/src/main/webapp/site/src/app/services/config.service.ts
@@ -49,6 +49,6 @@ export class ConfigService {
   }
 
   getCurrentServerTime() {
-    return new Date(Date.now()).getTime() - this.timeDiff;
+    return Date.now() - this.timeDiff;
   }
 }

--- a/src/main/webapp/site/src/app/student/student-run-list-item/student-run-list-item.component.html
+++ b/src/main/webapp/site/src/app/student/student-run-list-item/student-run-list-item.component.html
@@ -24,7 +24,7 @@
          matTooltipPosition="above"></div>
     <div fxFlex="1 1 100%" fxLayout="row" fxLayoutWrap>
         <div fxLayout="column">
-          <mat-card-title [class.secondary-text]="run.isCompleted()"
+          <mat-card-title [class.secondary-text]="isRunCompleted(run)"
                           class="mat-body-2">
             {{ run.name }}
           </mat-card-title>
@@ -35,7 +35,7 @@
       </div>
     </mat-card-content>
     <mat-card-content fxHide fxShow.xs>
-      <div class="info-block" [class.secondary-text]="run.isCompleted()">
+      <div class="info-block" [class.secondary-text]="isRunCompleted(run)">
         <ng-container *ngTemplateOutlet="runInfo"></ng-container>
       </div>
     </mat-card-content>
@@ -45,7 +45,7 @@
          fxLayoutAlign.gt-xs="start center"
          fxLayoutGap="8px">
       <span fxFlex="1 1 auto" fxShow fxHide.xs></span>
-      <a mat-button *ngIf="run.isActive()"
+      <a mat-button *ngIf="isRunActive(run)"
          href="{{ problemLink }}"
          class="secondary-text"
          fxFlex="0 0 auto"
@@ -53,7 +53,7 @@
         <ng-container i18n>Report Problem</ng-container>
       </a>
       <button mat-flat-button
-             *ngIf="run.isActive()"
+             *ngIf="isRunActive(run)"
              (click)="launchRun()"
              color="primary"
              fxFlex="0 0 auto"
@@ -61,7 +61,7 @@
         <mat-icon>play_circle_filled</mat-icon>&nbsp;<ng-container i18n>Launch</ng-container>
       </button>
       <button mat-flat-button
-             *ngIf="run.isCompleted()"
+             *ngIf="isRunCompleted(run)"
              (click)="reviewRun()"
              color="secondary-text"
              fxFlex="0 0 auto"

--- a/src/main/webapp/site/src/app/student/student-run-list-item/student-run-list-item.component.spec.ts
+++ b/src/main/webapp/site/src/app/student/student-run-list-item/student-run-list-item.component.spec.ts
@@ -26,7 +26,7 @@ export class MockConfigService {
     return '/wise';
   }
   getCurrentServerTime(): number {
-    return Date.now();
+    return new Date('2018-10-17 00:00:00.0').getTime();
   }
 }
 
@@ -75,12 +75,12 @@ describe('StudentRunListItemComponent', () => {
   });
 
   it('should say a run is active', () => {
-    expect(component.run.isActive()).toBeTruthy();
+    expect(component.isRunActive(component.run)).toBeTruthy();
   });
 
   it('should say a run is not active yet', () => {
     component.run.startTime = '2100-10-17 00:00:00.0';
     component.ngOnInit();
-    expect(component.run.isScheduled()).toBeTruthy();
+    expect(component.isRunActive(component.run)).toBeFalsy();
   });
 });

--- a/src/main/webapp/site/src/app/student/student-run-list-item/student-run-list-item.component.ts
+++ b/src/main/webapp/site/src/app/student/student-run-list-item/student-run-list-item.component.ts
@@ -60,4 +60,12 @@ export class StudentRunListItemComponent implements OnInit {
   skipTeamSign() {
     window.location.href = `${this.configService.getContextPath()}/student/startproject.html?runId=${this.run.id}`;
   }
+
+  isRunActive(run) {
+    return run.isActive(this.configService.getCurrentServerTime());
+  }
+
+  isRunCompleted(run) {
+    return run.isCompleted(this.configService.getCurrentServerTime());
+  }
 }

--- a/src/main/webapp/site/src/app/student/student-run-list/student-run-list.component.html
+++ b/src/main/webapp/site/src/app/student/student-run-list/student-run-list.component.html
@@ -28,7 +28,7 @@
     </div>
     <app-timeline>
       <ng-container *ngFor="let run of filteredRuns.sort(sortByStartTimeDesc); let i=index">
-        <app-timeline-item [active]="run.isActive()" *ngIf="i < 10 || showAll" id="run{{run.id}}">
+        <app-timeline-item [active]="isRunActive(run)" *ngIf="i < 10 || showAll" id="run{{run.id}}">
           <app-timeline-item-label>
             <ng-container *ngIf="run.endTime">
               <ng-container *ngIf="runSpansYears(run)">

--- a/src/main/webapp/site/src/app/student/student-run-list/student-run-list.component.spec.ts
+++ b/src/main/webapp/site/src/app/student/student-run-list/student-run-list.component.spec.ts
@@ -6,6 +6,7 @@ import { StudentService } from '../student.service';
 import { StudentRunListComponent } from "./student-run-list.component";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { Run } from '../../domain/run';
+import {ConfigService} from "../../services/config.service";
 
 export function fakeAsyncResponse<T>(data: T) {
   return defer(() => Promise.resolve(data));
@@ -49,6 +50,12 @@ export class MockStudentService {
   }
 }
 
+export class MockConfigService {
+  getCurrentServerTime(): number {
+    return new Date('2018-08-24 00:00:00.0').getTime();
+  }
+}
+
 describe('StudentRunListComponent', () => {
   let component: StudentRunListComponent;
   let fixture: ComponentFixture<StudentRunListComponent>;
@@ -58,7 +65,8 @@ describe('StudentRunListComponent', () => {
       declarations: [ StudentRunListComponent ],
       imports: [ MomentModule ],
       providers: [
-        { provide: StudentService, useClass: MockStudentService }
+        { provide: StudentService, useClass: MockStudentService },
+        { provide: ConfigService, useClass: MockConfigService }
       ],
       schemas: [ NO_ERRORS_SCHEMA ]
     })

--- a/src/main/webapp/site/src/app/student/student-run-list/student-run-list.component.ts
+++ b/src/main/webapp/site/src/app/student/student-run-list/student-run-list.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { DateFormatPipe } from 'ngx-moment';
 import { StudentRun } from '../student-run';
 import { StudentService } from '../student.service';
+import {ConfigService} from "../../services/config.service";
 
 @Component({
   selector: 'app-student-run-list',
@@ -16,7 +17,8 @@ export class StudentRunListComponent implements OnInit {
   loaded: boolean = false;
   showAll: boolean = false;
 
-  constructor(private studentService: StudentService) {
+  constructor(private studentService: StudentService,
+              private configService: ConfigService) {
     studentService.newRunSource$.subscribe(run => {
       run.isHighlighted = true;
       this.runs.unshift(new StudentRun(run));
@@ -95,8 +97,9 @@ export class StudentRunListComponent implements OnInit {
 
   activeTotal(): number {
     let total = 0;
+    const now = this.configService.getCurrentServerTime();
     for (let run of this.filteredRuns) {
-      if (run.isActive()) {
+      if (run.isActive(now)) {
         total++;
       }
     }
@@ -105,8 +108,9 @@ export class StudentRunListComponent implements OnInit {
 
   completedTotal(): number {
     let total = 0;
+    const now = this.configService.getCurrentServerTime();
     for (let run of this.filteredRuns) {
-      if (run.isCompleted()) {
+      if (run.isCompleted(now)) {
         total++;
       }
     }
@@ -115,8 +119,9 @@ export class StudentRunListComponent implements OnInit {
 
   scheduledTotal(): number {
     let total = 0;
+    const now = this.configService.getCurrentServerTime();
     for (let run of this.filteredRuns) {
-      if (run.isScheduled()) {
+      if (run.isScheduled(now)) {
         total++;
       }
     }
@@ -150,5 +155,9 @@ export class StudentRunListComponent implements OnInit {
 
   reset(): void {
     this.searchUpdated('');
+  }
+
+  isRunActive(run) {
+    return run.isActive(this.configService.getCurrentServerTime());
   }
 }

--- a/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.html
+++ b/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.html
@@ -29,11 +29,5 @@
       <mat-icon>report_problem</mat-icon>
       <span i18n>Report Problem</span>
     </a>
-    <!-- TODO: put back once restart, and cancel run are implemented
-    <mat-divider></mat-divider>
-    <a mat-menu-item *ngIf="isScheduled()">
-      <mat-icon color="warn">cancel</mat-icon>
-      <span i18n>Cancel Unit</span>
-    </a-->
   </div>
 </mat-menu>

--- a/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.ts
+++ b/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.ts
@@ -51,18 +51,6 @@ export class RunMenuComponent implements OnInit {
     });
   }
 
-  isScheduled() {
-    if (this.run.endTime) {
-      return false;
-    }
-    let startTime = new Date(this.run.startTime).getTime();
-    let now = new Date().getTime();
-    if (startTime < now) {
-      return false;
-    }
-    return true;
-  }
-
   canEdit() {
     return this.run.project.canEdit(this.userService.getUserId());
   }

--- a/src/main/webapp/site/src/app/teacher/teacher-home/teacher-home.component.spec.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher-home/teacher-home.component.spec.ts
@@ -87,6 +87,10 @@ export class MockConfigService {
   getContextPath(): string {
     return "/wise";
   }
+
+  getCurrentServerTime(): number {
+    return new Date('2018-10-17 00:00:00.0').getTime();
+  }
 }
 
 describe('TeacherHomeComponent', () => {

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
@@ -30,7 +30,7 @@
     <div mat-card-avatar [style.background-image]="run.project.thumbStyle"></div>
     <div fxFlex="1 1 100%" fxLayout="row" fxLayoutWrap>
       <div fxLayout="column">
-        <mat-card-title [class.secondary-text]="run.isCompleted()" class="mat-body-2">
+        <mat-card-title [class.secondary-text]="isRunCompleted(run)" class="mat-body-2">
           {{ run.project.name }}
         </mat-card-title>
         <mat-card-subtitle fxHide fxShow.gt-xs>
@@ -42,7 +42,7 @@
     </div>
   </mat-card-content>
   <mat-card-content fxHide fxShow.xs>
-    <div class="info-block" [class.secondary-text]="run.isCompleted()">
+    <div class="info-block" [class.secondary-text]="isRunCompleted(run)">
       <ng-container *ngTemplateOutlet="runInfo"></ng-container>
     </div>
   </mat-card-content>
@@ -55,7 +55,7 @@
       <span *ngIf="run.lastRun"
             class="mat-caption secondary-text center"
             i18n>Last student login: {{ run.lastRun | amCalendar }}</span>
-      <a *ngIf="run.isActive()"
+      <a *ngIf="isRunActive(run)"
          mat-flat-button
          href="{{ gradeAndManageLink }}"
          color="primary"
@@ -63,7 +63,7 @@
          fxFlex.xs="100">
         <mat-icon>build</mat-icon>&nbsp;<ng-container i18n>Teacher Tools</ng-container>
       </a>
-      <a *ngIf="run.isCompleted()"
+      <a *ngIf="isRunCompleted(run)"
          mat-flat-button
          href="{{ gradeAndManageLink }}"
          color="secondary-text"

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.spec.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.spec.ts
@@ -17,6 +17,9 @@ export class MockConfigService {
   getContextPath(): string {
     return '/wise';
   }
+  getCurrentServerTime(): number {
+    return new Date('2018-08-24 00:00:00.0').getTime();
+  }
 }
 
 describe('TeacherRunListItemComponent', () => {

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
@@ -61,4 +61,12 @@ export class TeacherRunListItemComponent implements OnInit {
     }
     return string;
   }
+
+  isRunActive(run) {
+    return run.isActive(this.configService.getCurrentServerTime());
+  }
+
+  isRunCompleted(run) {
+    return run.isCompleted(this.configService.getCurrentServerTime());
+  }
 }

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list/teacher-run-list.component.html
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list/teacher-run-list.component.html
@@ -39,7 +39,7 @@
 
   <app-timeline>
     <ng-container *ngFor="let run of filteredRuns.sort(sortByStartTimeDesc); let i=index">
-      <app-timeline-item [active]="run.isActive()" *ngIf="i < 10 || showAll" id="run{{run.id}}">
+      <app-timeline-item [active]="isRunActive(run)" *ngIf="i < 10 || showAll" id="run{{run.id}}">
         <app-timeline-item-label>
           <ng-container *ngIf="run.endTime">
             <ng-container *ngIf="runSpansYears(run)">

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list/teacher-run-list.component.spec.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list/teacher-run-list.component.spec.ts
@@ -7,6 +7,7 @@ import { TeacherService } from "../teacher.service";
 import { Project } from "../../domain/project";
 import { TeacherRun } from "../teacher-run";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
+import {ConfigService} from "../../services/config.service";
 
 @Component({selector: 'app-teacher-run-list-item', template: ''})
 class TeacherRunListItemStubComponent {
@@ -65,7 +66,12 @@ export class MockTeacherService {
       periods: ["1", "2"]
     }
   );
+}
 
+export class MockConfigService {
+  getCurrentServerTime(): number {
+    return new Date('2018-08-24 00:00:00.0').getTime();
+  }
 }
 
 describe('TeacherRunListComponent', () => {
@@ -76,7 +82,10 @@ describe('TeacherRunListComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ TeacherRunListComponent ],
       imports: [ MomentModule ],
-      providers: [ { provide: TeacherService, useClass: MockTeacherService }],
+      providers: [
+        { provide: TeacherService, useClass: MockTeacherService },
+        { provide: ConfigService, useClass: MockConfigService }
+      ],
       schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { DateFormatPipe } from 'ngx-moment';
 import { TeacherService } from '../teacher.service';
 import { TeacherRun } from '../teacher-run';
+import {ConfigService} from "../../services/config.service";
 
 @Component({
   selector: 'app-teacher-run-list',
@@ -22,7 +23,8 @@ export class TeacherRunListComponent implements OnInit {
   isSharedRunsRetrieved: boolean = false;
   showAll: boolean = false;
 
-  constructor(private teacherService: TeacherService) {
+  constructor(private teacherService: TeacherService,
+              private configService: ConfigService) {
     teacherService.newRunSource$.subscribe(run => {
       let teacherRun: TeacherRun = new TeacherRun(run);
       teacherRun.isHighlighted = true;
@@ -169,8 +171,9 @@ export class TeacherRunListComponent implements OnInit {
 
   activeTotal(): number {
     let total = 0;
+    const now = this.configService.getCurrentServerTime();
     for (let run of this.filteredRuns) {
-      if (run.isActive()) {
+      if (run.isActive(now)) {
         total++;
       }
     }
@@ -179,8 +182,9 @@ export class TeacherRunListComponent implements OnInit {
 
   completedTotal(): number {
     let total = 0;
+    const now = this.configService.getCurrentServerTime();
     for (let run of this.filteredRuns) {
-      if (run.isCompleted()) {
+      if (run.isCompleted(now)) {
         total++;
       }
     }
@@ -189,8 +193,9 @@ export class TeacherRunListComponent implements OnInit {
 
   scheduledTotal(): number {
     let total = 0;
+    const now = this.configService.getCurrentServerTime();
     for (let run of this.filteredRuns) {
-      if (run.isScheduled()) {
+      if (run.isScheduled(now)) {
         total++;
       }
     }
@@ -254,5 +259,9 @@ export class TeacherRunListComponent implements OnInit {
     this.searchValue = '';
     this.filterValue = '';
     this.performSearchAndFilter();
+  }
+
+  isRunActive(run) {
+    return run.isActive(this.configService.getCurrentServerTime());
   }
 }


### PR DESCRIPTION
1. Set your computer system clock to the past like changing the year to 2018.
2. Sign in as a student.
3. All the runs that start after 2018 for the student should not show a "Launch" button because their start time is thought to be in the future.
3. Set a breakpoint in config.service.ts in the browser on line 35.
```
this.timeDiff = new Date(Date.now()).getTime() - new Date(config.currentTime).getTime();
```
4. Refresh the page.
5. When the breakpoint is reached set config.currentTime to the current correct time by doing something like
```
config.currentTime = "2019-03-25 15:28:50.258"
```
This will simulate the server time being set to the correct current time.
6. Click play to continue past the breakpoint.
7. The student launch buttons should show up correctly.

Closes #1856