### PR TITLE
Made site tests run faster with karma-parallel plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10272,6 +10272,16 @@
         }
       }
     },
+    "karma-parallel": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/karma-parallel/-/karma-parallel-0.3.1.tgz",
+      "integrity": "sha512-64jxNYamYi/9Y67h4+FfViSYhwDgod3rLuq+ZdZ0c3XeZFp/3q3v3HVkd8b5Czp3hCB+LLF8DIv4zlR4xFqbRw==",
+      "dev": true,
+      "requires": {
+        "istanbul": "^0.4.5",
+        "lodash": "^4.17.11"
+      }
+    },
     "karma-source-map-support": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/karma-source-map-support/-/karma-source-map-support-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-json-fixtures-preprocessor": "0.0.6",
     "karma-jspm": "^2.2.3",
+    "karma-parallel": "^0.3.1",
     "karma-spec-reporter": "0.0.31",
     "node-sass": "^4.11.0",
     "plato": "^1.7.0",

--- a/src/main/webapp/site/karma.conf.js
+++ b/src/main/webapp/site/karma.conf.js
@@ -4,9 +4,10 @@
 module.exports = function (config) {
   config.set({
     basePath: '',
-    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    frameworks: ['parallel', 'jasmine', '@angular-devkit/build-angular'],
     plugins: [
       require('karma-jasmine'),
+      require('karma-parallel'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),


### PR DESCRIPTION
This change parallelizes the tests so they complete faster.

To verify, check the following:
1. run ```npm install``` to download new plugin
2. run ```npm run test-site``` and make sure that site tests pass
3. run ```npm run watch-all-site``` and make sure that site tests are run when you make changes to a site file.
