### PR TITLE
Made copyright year in footer dynamic based on current date

### DIFF
--- a/src/main/webapp/site/src/app/modules/footer/footer.component.html
+++ b/src/main/webapp/site/src/app/modules/footer/footer.component.html
@@ -72,7 +72,7 @@
         <div class="footer__section"
              fxLayoutAlign="center center"
              fxLayoutAlign.gt-sm="end center">
-          <span class="center" i18n>©1996-2018, <a href="https://www.berkeley.edu" target="_blank">UC Berkeley</a> | Web-based Inquiry Science Environment</span>
+          <span class="center" i18n>©1996-{{time | amDateFormat:'YYYY'}}, <a href="https://www.berkeley.edu" target="_blank">UC Berkeley</a> | Web-based Inquiry Science Environment</span>
         </div>
       </div>
     </div>

--- a/src/main/webapp/site/src/app/modules/footer/footer.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/footer/footer.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FooterComponent } from './footer.component';
 import { RouterTestingModule } from "@angular/router/testing";
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { MomentModule } from "ngx-moment";
 
 describe('FooterComponent', () => {
   let component: FooterComponent;
@@ -10,7 +11,7 @@ describe('FooterComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ FooterComponent ],
-      imports: [ RouterTestingModule ],
+      imports: [ RouterTestingModule, MomentModule ],
       schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();

--- a/src/main/webapp/site/src/app/modules/footer/footer.component.ts
+++ b/src/main/webapp/site/src/app/modules/footer/footer.component.ts
@@ -7,9 +7,11 @@ import { Component, OnInit } from '@angular/core';
 })
 export class FooterComponent implements OnInit {
 
+  time: Date;
+
   constructor() { }
 
   ngOnInit() {
+    this.time = new Date();
   }
-
 }

--- a/src/main/webapp/site/src/app/modules/footer/footer.module.ts
+++ b/src/main/webapp/site/src/app/modules/footer/footer.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatButtonModule, MatIconModule, MatToolbarModule } from '@angular/material';
-
+import { MomentModule } from 'ngx-moment';
 import { FooterComponent } from './footer.component';
 import { AppRoutingModule } from "../../app-routing.module";
 
@@ -15,7 +15,8 @@ const materialModules = [
     CommonModule,
     FlexLayoutModule,
     AppRoutingModule,
-    materialModules
+    materialModules,
+    MomentModule
   ],
   declarations: [FooterComponent],
   exports: [FooterComponent]

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -172,8 +172,8 @@
           <context context-type="sourcefile">app/modules/footer/footer.component.html</context>
           <context context-type="linenumber">70</context>
         </context-group>
-      </trans-unit><trans-unit id="6d21387dacc5dac5c5d1dbee7cc49de1fc78c229" datatype="html">
-        <source>©1996-2018, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>UC Berkeley<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> | Web-based Inquiry Science Environment</source>
+      </trans-unit><trans-unit id="ffac91e3ed3d3f9238f218aaa135735f55daec60" datatype="html">
+        <source>©1996-<x id="INTERPOLATION" equiv-text="{{time | amDateFormat:&apos;YYYY&apos;}}"/>, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>UC Berkeley<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> | Web-based Inquiry Science Environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/footer/footer.component.html</context>
           <context context-type="linenumber">75</context>


### PR DESCRIPTION
To test:
- Check to make sure the copyright date in the site footer shows 1996-2019.

Resolves #1909. 