### PR TITLE
Fixed a problem with not being able to author WISE4 steps

### DIFF
--- a/src/main/java/org/wise/vle/utils/FileManager.java
+++ b/src/main/java/org/wise/vle/utils/FileManager.java
@@ -2100,7 +2100,7 @@ public class FileManager {
     String filePath = null;
     if (project != null) {
       String projectFolderPath = getProjectFolderPath(project);
-      filePath = projectFolderPath + fileName;
+      filePath = projectFolderPath + "/" + fileName;
     }
     return filePath;
   }


### PR DESCRIPTION
1. Open a project in the WISE4 Authoring Tool
2. Open a step for authoring. The step authoring should now load properly. Previously it would not properly load because it would fail to retrieve the step content.

Closes #1927