### PR TITLE
Updated the wise_sample.properties file to not allow application files to be uploaded in the authoring tool

### DIFF
--- a/src/main/resources/wise_sample.properties
+++ b/src/main/resources/wise_sample.properties
@@ -186,7 +186,7 @@ student_max_total_assets_size=10485760
 student_max_work_size=512000
 
 # allowed assets for projects. Reference: http://en.wikipedia.org/wiki/Internet_media_type
-normalAuthorAllowedProjectAssetContentTypes=text/plain,text/csv,text/xml,image/gif,image/jpeg,image/png,image/svg+xml,image/gif,audio/mp3,audio/mp4,audio/mpeg,audio/wav,audio/vnd.wave,audio/ogg,audio/webm,audio/x-aac,video/mpeg,video/mp4,video/ogg,video/quicktime,video/x-flv,video/avi,video/webm,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadhseet,application/vnd.oasis.opendocument.presentation,application/vnd.oasis.opendocument.graphics,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/java-archive,application/octet-stream,application/x-shockwave-flash,application/json
+normalAuthorAllowedProjectAssetContentTypes=text/plain,text/csv,text/xml,image/gif,image/jpeg,image/png,image/svg+xml,image/gif,audio/mp3,audio/mp4,audio/mpeg,audio/wav,audio/vnd.wave,audio/ogg,audio/webm,audio/x-aac,video/mpeg,video/mp4,video/ogg,video/quicktime,video/x-flv,video/avi,video/webm
 trustedAuthorAllowedProjectAssetContentTypes=text/html,application/javascript,application/x-javascript,text/javascript,text/css,application/zip,application/x-zip,application/x-zip-compressed,application/gzip
 
 ########## Optional Plugins ##########


### PR DESCRIPTION
1. Update your wise.properties file with the normalAuthorAllowedProjectAssetContentTypes value from the wise_sample.properties file.
2. Make sure you can't upload .jsp files and other application files.

Closes #1954