### PR TITLE
Upgraded spring-boot parent dependency from 2.1.5 to 2.1.6. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.5.RELEASE</version>
+    <version>2.1.6.RELEASE</version>
   </parent>
 
   <dependencies>
@@ -302,12 +302,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-redis</artifactId>
-      <version>2.1.4.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.session</groupId>
       <artifactId>spring-session-data-redis</artifactId>
-      <version>2.1.4.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Also removed specific 2.1.4 version dependencies. 

To test:
1. run mvn test and make sure that all tests pass.
2. make sure that WISE still works as before.

Closes #1951