### PR TITLE
Issue 1957 Enable sourcemaps on the production build of the Site

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,7 +30,7 @@
             "production": {
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "statsJson": true,
               "extractCss": true,
               "namedChunks": false,
@@ -50,7 +50,7 @@
             "production-es": {
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "statsJson": true,
               "extractCss": true,
               "namedChunks": false,

--- a/wise.sh
+++ b/wise.sh
@@ -28,7 +28,7 @@ fi
 
 if [ $1 = "package" ]; then
   npm install
-  ng build --configuration=production --stats-json
+  node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build --configuration=production --stats-json
   ./mvnw clean -Dmaven.test.skip=true package
   exit 0
 fi


### PR DESCRIPTION
When sourcemaps are enabled and you run
```ng build --prod```
you will see this error and the build will fail
```FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory```

In order to avoid this problem you need to run this command which increases the build memory
```node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build --prod```

This problem is documented here
https://github.com/angular/angular-cli/issues/13734

Closes #1957 