### PR TITLE
Issue 1971 Change server JSON response status from "failure" to "error" 

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/ControllerUtil.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/ControllerUtil.java
@@ -463,18 +463,33 @@ public class ControllerUtil {
     try {
       response.put("status", "success");
     } catch(JSONException e) {
+    }
+    return response;
+  }
 
+  public static JSONObject createSuccessResponse(String messageCode) {
+    JSONObject response = createSuccessResponse();
+    try {
+      response.put("messageCode", messageCode);
+    } catch(JSONException e) {
+    }
+    return response;
+  }
+
+  public static JSONObject createErrorResponse() {
+    JSONObject response = new JSONObject();
+    try {
+      response.put("status", "error");
+    } catch(JSONException e) {
     }
     return response;
   }
 
   public static JSONObject createErrorResponse(String messageCode) {
-    JSONObject response = new JSONObject();
+    JSONObject response = createErrorResponse();
     try {
-      response.put("status", "error");
       response.put("messageCode", messageCode);
     } catch(JSONException e) {
-
     }
     return response;
   }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/contact/ContactAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/contact/ContactAPIController.java
@@ -82,9 +82,7 @@ public class ContactAPIController {
       JSONObject response = sendEmail(fromEmail, toEmails, cc, subject, body);
       return response.toString();
     } else {
-      JSONObject response = new JSONObject();
-      response.put("status", "failure");
-      return response.toString();
+      return ControllerUtil.createErrorResponse().toString();
     }
   }
 
@@ -123,15 +121,13 @@ public class ContactAPIController {
 
   private JSONObject sendEmail(String fromEmail, String[] toEmails, String[] cc, String subject,
         String body) throws JSONException {
-    JSONObject response = new JSONObject();
     try {
       mailService.postMail(toEmails, subject, body, fromEmail, cc);
-      response.put("status", "success");
+      return ControllerUtil.createSuccessResponse();
     } catch (MessagingException e) {
       e.printStackTrace();
-      response.put("status", "failure");
+      return ControllerUtil.createErrorResponse();
     }
-    return response;
   }
 
   private String getSubject(String issueType, String summary) {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentForgotAccountAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentForgotAccountAPIController.java
@@ -7,8 +7,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.domain.authentication.MutableUserDetails;
@@ -27,7 +28,7 @@ public class StudentForgotAccountAPIController {
   @Autowired
   private Properties i18nProperties;
 
-  @RequestMapping(value = "/username/search", method = RequestMethod.GET)
+  @GetMapping("/username/search")
   protected String getStudentUsernames(@RequestParam("firstName") String firstName,
         @RequestParam("lastName") String lastName,
         @RequestParam("birthMonth") Integer birthMonth,
@@ -58,7 +59,7 @@ public class StudentForgotAccountAPIController {
     return usernamesJSON;
   }
 
-  @RequestMapping(value = "/password/security-question", method = RequestMethod.GET)
+  @GetMapping("/password/security-question")
   protected String getSecurityQuestion(@RequestParam("username") String username) 
       throws JSONException {
     User user = userService.retrieveUserByUsername(username);
@@ -75,7 +76,7 @@ public class StudentForgotAccountAPIController {
     return response.toString();
   }
 
-  @RequestMapping(value = "/password/security-question", method = RequestMethod.POST)
+  @PostMapping("/password/security-question")
   protected String checkSecurityAnswer(@RequestParam("username") String username,
         @RequestParam("answer") String answer) throws JSONException {
     User user = userService.retrieveUserByUsername(username);
@@ -92,7 +93,7 @@ public class StudentForgotAccountAPIController {
     return response.toString();
   }
 
-  @RequestMapping(value = "/password/change", method = RequestMethod.POST)
+  @PostMapping("/password/change")
   protected String checkSecurityAnswer(@RequestParam("username") String username,
         @RequestParam("answer") String answer,
         @RequestParam("password") String password,

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentForgotAccountAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentForgotAccountAPIController.java
@@ -1,18 +1,21 @@
 package org.wise.portal.presentation.web.controllers.student;
 
+import java.util.List;
+import java.util.Properties;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
-import org.wise.portal.domain.AccountQuestion;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.domain.authentication.MutableUserDetails;
 import org.wise.portal.domain.authentication.impl.StudentUserDetails;
 import org.wise.portal.domain.user.User;
+import org.wise.portal.presentation.web.controllers.ControllerUtil;
 import org.wise.portal.service.user.UserService;
-
-import java.util.List;
-import java.util.Properties;
 
 @RestController
 @RequestMapping(value = "/api/student/forgot", produces = "application/json;charset=UTF-8")
@@ -26,9 +29,9 @@ public class StudentForgotAccountAPIController {
 
   @RequestMapping(value = "/username/search", method = RequestMethod.GET)
   protected String getStudentUsernames(@RequestParam("firstName") String firstName,
-                                       @RequestParam("lastName") String lastName,
-                                       @RequestParam("birthMonth") Integer birthMonth,
-                                       @RequestParam("birthDay") Integer birthDay) {
+        @RequestParam("lastName") String lastName,
+        @RequestParam("birthMonth") Integer birthMonth,
+        @RequestParam("birthDay") Integer birthDay) {
     String[] fields = new String[4];
     fields[0] = "firstname";
     fields[1] = "lastname";
@@ -56,73 +59,63 @@ public class StudentForgotAccountAPIController {
   }
 
   @RequestMapping(value = "/password/security-question", method = RequestMethod.GET)
-  protected String getSecurityQuestion(@RequestParam("username") String username) throws JSONException {
+  protected String getSecurityQuestion(@RequestParam("username") String username) 
+      throws JSONException {
     User user = userService.retrieveUserByUsername(username);
-    JSONObject response = new JSONObject();
+    JSONObject response;
     if (user != null && user.isStudent()) {
       String accountQuestionKey = getAccountQuestionKey(user);
       String accountQuestionValue = getAccountQuestionValue(accountQuestionKey);
+      response = ControllerUtil.createSuccessResponse("usernameFound");
       response.put("question", accountQuestionValue);
       response.put("questionKey", accountQuestionKey);
-      response.put("status", "success");
-      response.put("messageCode", "usernameFound");
     } else {
-      response.put("status", "failure");
-      response.put("messageCode", "usernameNotFound");
+      response = ControllerUtil.createErrorResponse("usernameNotFound");
     }
     return response.toString();
   }
 
   @RequestMapping(value = "/password/security-question", method = RequestMethod.POST)
   protected String checkSecurityAnswer(@RequestParam("username") String username,
-                                       @RequestParam("answer") String answer) throws JSONException {
+        @RequestParam("answer") String answer) throws JSONException {
     User user = userService.retrieveUserByUsername(username);
-    JSONObject response = new JSONObject();
+    JSONObject response; 
     if (user != null) {
       if (isAnswerCorrect(user, answer)) {
-        response.put("status", "success");
-        response.put("messageCode", "correctAnswer");
+        response = ControllerUtil.createSuccessResponse("correctAnswer");
       } else {
-        response.put("status", "failure");
-        response.put("messageCode", "incorrectAnswer");
+        response = ControllerUtil.createErrorResponse("incorrectAnswer");
       }
     } else {
-      response.put("status", "failure");
-      response.put("messageCode", "invalidUsername");
+      response = ControllerUtil.createErrorResponse("invalidUsername");
     }
     return response.toString();
   }
 
   @RequestMapping(value = "/password/change", method = RequestMethod.POST)
   protected String checkSecurityAnswer(@RequestParam("username") String username,
-                                       @RequestParam("answer") String answer,
-                                       @RequestParam("password") String password,
-                                       @RequestParam("confirmPassword") String confirmPassword) throws JSONException {
+        @RequestParam("answer") String answer,
+        @RequestParam("password") String password,
+        @RequestParam("confirmPassword") String confirmPassword) throws JSONException {
     User user = userService.retrieveUserByUsername(username);
-    JSONObject response = new JSONObject();
+    JSONObject response;
     if (user != null) {
       if (isAnswerCorrect(user, answer)) {
         if (isPasswordBlank(password, confirmPassword)) {
-          response.put("status", "failure");
-          response.put("messageCode", "passwordIsBlank");
+          response = ControllerUtil.createErrorResponse("passwordIsBlank");
         } else if (!isPasswordsMatch(password, confirmPassword)) {
-          response.put("status", "failure");
-          response.put("messageCode", "passwordsDoNotMatch");
+          response = ControllerUtil.createErrorResponse("passwordsDoNotMatch");
         } else if (isPasswordsMatch(password, confirmPassword)) {
           userService.updateUserPassword(user, password);
-          response.put("status", "success");
-          response.put("messageCode", "passwordChanged");
+          response = ControllerUtil.createSuccessResponse("passwordChanged");
         } else {
-          response.put("status", "failure");
-          response.put("messageCode", "invalidPassword");
+          response = ControllerUtil.createErrorResponse("invalidPassword");
         }
       } else {
-        response.put("status", "failure");
-        response.put("messageCode", "incorrectAnswer");
+        response = ControllerUtil.createErrorResponse("incorrectAnswer");
       }
     } else {
-      response.put("status", "failure");
-      response.put("messageCode", "invalidUsername");
+      response = ControllerUtil.createErrorResponse("invalidUsername");
     }
     return response.toString();
   }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherForgotAccountAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherForgotAccountAPIController.java
@@ -5,8 +5,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.domain.user.User;
@@ -37,7 +38,7 @@ public class TeacherForgotAccountAPIController {
   @Autowired
   protected MessageSource messageSource;
 
-  @RequestMapping(value = "/username", method = RequestMethod.POST)
+  @PostMapping("/username")
   protected String sendForgotUsernameEmail(HttpServletRequest request,
       @RequestParam("email") String email) throws JSONException {
     List<User> users = userService.retrieveUserByEmailAddress(email);
@@ -79,7 +80,7 @@ public class TeacherForgotAccountAPIController {
     }
   }
 
-  @RequestMapping(value = "/password/verification-code", method = RequestMethod.GET)
+  @GetMapping("/password/verification-code")
   protected String sendVerificationCodeEmail(HttpServletRequest request,
         @RequestParam("username") String username) throws JSONException {
     JSONObject response;
@@ -139,7 +140,7 @@ public class TeacherForgotAccountAPIController {
     }
   }
 
-  @RequestMapping(value = "/password/verification-code", method = RequestMethod.POST)
+  @PostMapping("/password/verification-code")
   protected String checkVerificationCode(@RequestParam("username") String username,
         @RequestParam("verificationCode") String verificationCode) throws JSONException {
     JSONObject response = new JSONObject();
@@ -181,7 +182,7 @@ public class TeacherForgotAccountAPIController {
     userService.updateUser(user);
   }
 
-  @RequestMapping(value = "/password/change", method = RequestMethod.POST)
+  @PostMapping("/password/change")
   protected String changePassword(@RequestParam("username") String username,
         @RequestParam("verificationCode") String verificationCode,
         @RequestParam("password") String password,

--- a/src/main/java/org/wise/portal/presentation/web/filters/WISEAuthenticationFailureHandler.java
+++ b/src/main/java/org/wise/portal/presentation/web/filters/WISEAuthenticationFailureHandler.java
@@ -85,9 +85,8 @@ public class WISEAuthenticationFailureHandler extends SimpleUrlAuthenticationFai
     }
 
     if (this.isNewSite(request)) {
-      JSONObject responseJSON = new JSONObject();
       try {
-        responseJSON.put("status", "failure");
+        JSONObject responseJSON = ControllerUtil.createErrorResponse();
         responseJSON.put("isRecaptchaRequired", ControllerUtil.isReCaptchaRequired(request));
         response.getWriter().write(responseJSON.toString());
       } catch (JSONException e) {

--- a/src/main/webapp/site/src/app/contact/contact-form/contact-form.component.ts
+++ b/src/main/webapp/site/src/app/contact/contact-form/contact-form.component.ts
@@ -187,7 +187,7 @@ export class ContactFormComponent implements OnInit {
   handleSendContactMessageResponse(response: any) {
     if (response.status == "success") {
       this.complete = true;
-    } else if (response.status == "failure") {
+    } else if (response.status == "error") {
       this.failure = true;
       if (this.isRecaptchaEnabled) {
         this.resetRecaptcha();

--- a/src/main/webapp/site/src/app/contact/contact-form/contact-form.component.ts
+++ b/src/main/webapp/site/src/app/contact/contact-form/contact-form.component.ts
@@ -185,9 +185,9 @@ export class ContactFormComponent implements OnInit {
   }
 
   handleSendContactMessageResponse(response: any) {
-    if (response.status == "success") {
+    if (response.status === "success") {
       this.complete = true;
-    } else if (response.status == "error") {
+    } else if (response.status === "error") {
       this.failure = true;
       if (this.isRecaptchaEnabled) {
         this.resetRecaptcha();


### PR DESCRIPTION
1. Make sure the error message appears correctly in the login page when a user fails to log in.
2. Make sure the error messages appear correctly when a student uses the forgot username and forgot password pages and enters incorrect values.
3. Make sure the error messages appear correctly when a teacher uses the forgot username and forgot password pages and enter incorrect values.

Closes #1971