### PR TITLE
Changed the network error message

### DIFF
--- a/src/main/webapp/site/src/app/http-error.interceptor.ts
+++ b/src/main/webapp/site/src/app/http-error.interceptor.ts
@@ -24,7 +24,7 @@ export class HttpErrorInterceptor implements HttpInterceptor {
           console.error(this.i18n('Backend returned code {{status}}, body was: {{error}}', {status: err.status, error: err.error}));
         }
 
-        this.snackBar.open(this.i18n(`An error occurred. Please check your connection and try again.`));
+        this.snackBar.open(this.i18n(`An error occurred. Please refresh this page and try again.`));
 
         // return an observable with an empty result
         return throwError('');


### PR DESCRIPTION
Log onto the WISE Website, login as a teacher,  open another WISE tab and sign out, then on the first tab, edit something random on your profile and hit save to view the new error message. It should say please refresh the page instead of check your connection. 

closes #1962