### PR TITLE
fixed npe when changing teacher & student password on legacy site

### DIFF
--- a/src/main/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidator.java
+++ b/src/main/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidator.java
@@ -57,7 +57,7 @@ public class ChangePasswordParametersValidator implements Validator {
   public void validate(Object paramsIn, Errors errors) {
     ChangePasswordParameters params = (ChangePasswordParameters) paramsIn;
 
-    if (!params.getTeacherUser().getUserDetails().isGoogleUser()) {
+    if (!params.getUser().getUserDetails().isGoogleUser()) {
       validatePasswd0(errors,params);
       if (errors.getErrorCount() != 0) {
         return;

--- a/src/main/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidator.java
+++ b/src/main/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidator.java
@@ -57,7 +57,8 @@ public class ChangePasswordParametersValidator implements Validator {
   public void validate(Object paramsIn, Errors errors) {
     ChangePasswordParameters params = (ChangePasswordParameters) paramsIn;
 
-    if (!params.getUser().getUserDetails().isGoogleUser()) {
+    if (params.getUser() != null && !params.getUser().getUserDetails().isGoogleUser() ||
+        params.getTeacherUser() != null && !params.getTeacherUser().getUserDetails().isGoogleUser()) {
       validatePasswd0(errors,params);
       if (errors.getErrorCount() != 0) {
         return;

--- a/src/main/webapp/portal/student/index.jsp
+++ b/src/main/webapp/portal/student/index.jsp
@@ -178,9 +178,11 @@
                 <li>
                   <a id="addprojectLink" class="wisebutton altbutton"><spring:message code="student.addproject.title" /></a>
                 </li>
-                <li>
-                  <a id="changePasswordLink" class="wisebutton altbutton-small"><spring:message code="changePassword" /></a>
-                </li>
+                <c:if test="${!user.userDetails.isGoogleUser()}">
+                  <li>
+                    <a id="changePasswordLink" class="wisebutton altbutton-small"><spring:message code="changePassword" /></a>
+                  </li>
+                </c:if>
                 <li>
                   <a class="wisebutton altbutton-small" href="${contextPath}/logout" id="studentsignout"><spring:message code="signOut" /></a>
                 </li>

--- a/src/main/webapp/portal/teacher/account.jsp
+++ b/src/main/webapp/portal/teacher/account.jsp
@@ -166,41 +166,43 @@
             </form:form>
           </div>
           <hr/>
-          <div class="panelHeader"><spring:message code="teacher.management.updatemyaccount.changePassword" /></div>
-          <form:form method="post" action="${contextPath}/legacy/teacher/account/password"
-              modelAttribute="changePasswordParameters" id="changepassword"
-              autocomplete='off'>
-            <table style="margin:0 auto;">
-              <tr>
-                <td><label><spring:message code="changePassword_current" /></label></td>
-                <td><form:password path="passwd0" /></td>
-              </tr>
-              <tr>
-                <td><label><spring:message code="changePassword_new" /></label></td>
-                <td><form:password path="passwd1" /></td>
-              </tr>
-              <tr>
-                <td><label for="changestudentpassword"><spring:message code="changePassword_confirm" /></label></td>
-                <td><form:password path="passwd2" /></td>
-              </tr>
-            </table>
+          <c:if test="${!teacherAccountForm.userDetails.isGoogleUser()}">
+            <div class="panelHeader"><spring:message code="teacher.management.updatemyaccount.changePassword" /></div>
+            <form:form method="post" action="${contextPath}/legacy/teacher/account/password"
+                       modelAttribute="changePasswordParameters" id="changepassword"
+                       autocomplete='off'>
+              <table style="margin:0 auto;">
+                <tr>
+                  <td><label><spring:message code="changePassword_current" /></label></td>
+                  <td><form:password path="passwd0" /></td>
+                </tr>
+                <tr>
+                  <td><label><spring:message code="changePassword_new" /></label></td>
+                  <td><form:password path="passwd1" /></td>
+                </tr>
+                <tr>
+                  <td><label for="changestudentpassword"><spring:message code="changePassword_confirm" /></label></td>
+                  <td><form:password path="passwd2" /></td>
+                </tr>
+              </table>
 
-            <div class="errorMsgNoBg">
-              <spring:bind path="changePasswordParameters.*">
-                <c:forEach var="error" items="${status.errorMessages}">
-                  <p>
-                    <c:out value="${error}" />
-                  </p>
-                </c:forEach>
-              </spring:bind>
-            </div>
+              <div class="errorMsgNoBg">
+                <spring:bind path="changePasswordParameters.*">
+                  <c:forEach var="error" items="${status.errorMessages}">
+                    <p>
+                      <c:out value="${error}" />
+                    </p>
+                  </c:forEach>
+                </spring:bind>
+              </div>
 
-            <div style="text-align:center">
-              <input type="submit" value="<spring:message code="saveChanges"/>"/>
-              <span style="font-style:italic; font-weight: bold; color: gray"><c:out value="${passwordSavedMessage}"></c:out></span>
-            </div>
+              <div style="text-align:center">
+                <input type="submit" value="<spring:message code="saveChanges"/>"/>
+                <span style="font-style:italic; font-weight: bold; color: gray"><c:out value="${passwordSavedMessage}"></c:out></span>
+              </div>
 
-          </form:form>
+            </form:form>
+          </c:if>
           <sec:authorize access="!hasAnyRole('ROLE_TRANSLATOR,ROLE_ADMINISTRATOR')">
             <div id="translateWISEMessage" class="panelFooter" style="text-align:left; padding:10px; color:#745A33">
               <span>Interested in helping us translate WISE in another language? Please <a href="${contextPath}/contact/contactwise.html">contact us</a>.</span>

--- a/src/test/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidatorTest.java
+++ b/src/test/java/org/wise/portal/presentation/validators/ChangePasswordParametersValidatorTest.java
@@ -105,7 +105,6 @@ public class ChangePasswordParametersValidatorTest extends TestCase {
 
   @After
   public void tearDown() {
-    EasyMock.verify(userService);
     validator = null;
     params = null;
     errors = null;


### PR DESCRIPTION
1. log into the legacy site as a teacher then as a student.
- verify that you can change password for both teacher and student non-google users
- verify that you do not see the option for changing user password for google users

closes #1979 