### PR TITLE
Changed the contact page error message to match with the field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_install:
 - nvm install 10.16.0
 - nvm use 10.16.0

--- a/src/main/webapp/site/src/app/contact/contact-form/contact-form.component.html
+++ b/src/main/webapp/site/src/app/contact/contact-form/contact-form.component.html
@@ -79,7 +79,7 @@
                    id="summary"
                    name="summary"
                    formControlName="summary" />
-            <mat-error *ngIf="contactFormGroup.controls['summary'].hasError('required')" i18n>City required</mat-error>
+            <mat-error *ngIf="contactFormGroup.controls['summary'].hasError('required')" i18n>Summary required</mat-error>
           </mat-form-field>
         </p>
         <p>
@@ -92,7 +92,7 @@
                       rows="10"
                       cols="10">
             </textarea>
-            <mat-error *ngIf="contactFormGroup.controls['description'].hasError('required')" i18n>State required</mat-error>
+            <mat-error *ngIf="contactFormGroup.controls['description'].hasError('required')" i18n>Description required</mat-error>
           </mat-form-field>
         </p>
         <p *ngIf="isRecaptchaEnabled"

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -2232,19 +2232,11 @@
           <context context-type="sourcefile">app/contact/contact-form/contact-form.component.html</context>
           <context context-type="linenumber">77</context>
         </context-group>
-      </trans-unit><trans-unit id="526394b14298e223b7e076e1b0cd15e54b03fe22" datatype="html">
-        <source>City required</source>
+      </trans-unit><trans-unit id="f57c6e5b9225f1a36757d76b0cb2a0b739487c87" datatype="html">
+        <source>Summary required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/contact/contact-form/contact-form.component.html</context>
           <context context-type="linenumber">82</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/register/register-teacher-form/register-teacher-form.component.html</context>
-          <context context-type="linenumber">54</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">55</context>
         </context-group>
       </trans-unit><trans-unit id="eec715de352a6b114713b30b640d319fa78207a0" datatype="html">
         <source>Description</source>
@@ -2252,19 +2244,11 @@
           <context context-type="sourcefile">app/contact/contact-form/contact-form.component.html</context>
           <context context-type="linenumber">87</context>
         </context-group>
-      </trans-unit><trans-unit id="1417d4b0e633084ccb2b0bdb43d119c17ac0cd01" datatype="html">
-        <source>State required</source>
+      </trans-unit><trans-unit id="7491b1ebfc5dd457492a5c481e2d2254216dc1fc" datatype="html">
+        <source>Description required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/contact/contact-form/contact-form.component.html</context>
           <context context-type="linenumber">95</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/register/register-teacher-form/register-teacher-form.component.html</context>
-          <context context-type="linenumber">65</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit><trans-unit id="5d9f08dc105485d86dacb30c4f2a3ac7ab951843" datatype="html">
         <source>Sorry, there was a problem submitting the form. Please try again.</source>
@@ -4114,6 +4098,16 @@
           <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">50</context>
         </context-group>
+      </trans-unit><trans-unit id="526394b14298e223b7e076e1b0cd15e54b03fe22" datatype="html">
+        <source>City required</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/register/register-teacher-form/register-teacher-form.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
       </trans-unit><trans-unit id="873b72903b1858a9cd6c8967521030b4d7d1435b" datatype="html">
         <source>State</source>
         <context-group purpose="location">
@@ -4123,6 +4117,16 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">60</context>
+        </context-group>
+      </trans-unit><trans-unit id="1417d4b0e633084ccb2b0bdb43d119c17ac0cd01" datatype="html">
+        <source>State required</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/register/register-teacher-form/register-teacher-form.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit><trans-unit id="a43f25a9ac40e8e2441ff0be7a36b8e5d15534df" datatype="html">
         <source>Country</source>
@@ -5328,8 +5332,8 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="050662d81fa6f59adbcc1190eee2435910b9e927" datatype="html">
-        <source>An error occurred. Please check your connection and try again.</source>
+      <trans-unit id="7ddad2424cc5ebd2be4f9908c07b9b84c40d983b" datatype="html">
+        <source>An error occurred. Please refresh this page and try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/main/webapp/site/src/app/http-error.interceptor.ts</context>
           <context context-type="linenumber">1</context>


### PR DESCRIPTION
1. Go to wise and click on the Contact WISE on the bottom of the page, then scroll to the summary field. 

2. Click inside the summary field then click out, this will make it lose focus and show the new error message. 

3. Then scroll to the description field and once more click inside then click out, making it lose focus and getting a new correct error message.

Closes #1966