### PR TITLE
NullPointerException is thrown when a student signs out from the VLE

### DIFF
--- a/src/main/java/org/wise/portal/spring/impl/WISELogoutHandler.java
+++ b/src/main/java/org/wise/portal/spring/impl/WISELogoutHandler.java
@@ -38,14 +38,18 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.session.Session;
 import org.wise.portal.service.session.SessionService;
 
-public class WISELogoutHandler<S extends Session> implements LogoutHandler, ApplicationListener<SessionDestroyedEvent> {
+public class WISELogoutHandler<S extends Session> implements LogoutHandler, 
+    ApplicationListener<SessionDestroyedEvent> {
 
   @Autowired
   protected SessionService sessionService;
 
   @Override
-  public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-    sessionService.removeUser((UserDetails) authentication.getPrincipal());
+  public void logout(HttpServletRequest request, HttpServletResponse response, 
+      Authentication authentication) {
+    if (authentication != null) {
+      sessionService.removeUser((UserDetails) authentication.getPrincipal());
+    }
   }
 
   @Override

--- a/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
+++ b/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
@@ -88,8 +88,10 @@ public class WebSecurityConfig<S extends Session> extends WebSecurityConfigurerA
         .addFilterAfter(authenticationProcessingFilter(), GoogleOpenIdConnectFilter.class)
         .authorizeRequests()
         .antMatchers("/admin/**").hasAnyRole("ADMINISTRATOR,RESEARCHER")
-        .antMatchers("/teacher/**").hasAnyRole("ADMINISTRATOR,TEACHER")
-        .antMatchers("/student/**").hasAnyRole("ADMINISTRATOR,STUDENT")
+        .antMatchers("/project/notifyAuthor*/**").hasAnyRole("TEACHER")
+        .antMatchers("/student/**").hasAnyRole("STUDENT")
+        .antMatchers("/studentStatus").hasAnyRole("TEACHER,STUDENT")
+        .antMatchers("/teacher/**").hasAnyRole("TEACHER")
         .antMatchers("/").permitAll();
     http.formLogin().loginPage("/login").permitAll();
     http.sessionManagement().maximumSessions(2).sessionRegistry(sessionRegistry());

--- a/src/main/java/org/wise/vle/web/StudentStatusController.java
+++ b/src/main/java/org/wise/vle/web/StudentStatusController.java
@@ -174,12 +174,9 @@ public class StudentStatusController {
 
     boolean allowedAccess = false;
 
-    /*
-     * teachers can not make a request
-     * students can make a request if they are in the run and in the workgroup
-     */
-    if (SecurityUtils.isStudent(signedInUser) && SecurityUtils.isUserInRun(signedInUser, runId) &&
-      SecurityUtils.isUserInWorkgroup(signedInUser, workgroupId)) {
+    if (signedInUser != null && SecurityUtils.isStudent(signedInUser) &&
+        SecurityUtils.isUserInRun(signedInUser, runId) &&
+        SecurityUtils.isUserInWorkgroup(signedInUser, workgroupId)) {
       allowedAccess = true;
     }
 

--- a/src/main/java/org/wise/vle/web/StudentStatusController.java
+++ b/src/main/java/org/wise/vle/web/StudentStatusController.java
@@ -174,7 +174,7 @@ public class StudentStatusController {
 
     boolean allowedAccess = false;
 
-    if (signedInUser != null && SecurityUtils.isStudent(signedInUser) &&
+    if (SecurityUtils.isStudent(signedInUser) &&
         SecurityUtils.isUserInRun(signedInUser, runId) &&
         SecurityUtils.isUserInWorkgroup(signedInUser, workgroupId)) {
       allowedAccess = true;


### PR DESCRIPTION
1. Go to sessionService.es6 and comment out line 119. This will prevent the client from forcing a log out before the session ends on the server. We want to simulate the server session ending and then after that have the client make a request to log out.
```
//this.$rootScope.$broadcast('logOut');
```
2. Go to application.properties and set
```
server.servlet.session.timeout=1m
``` 
3. Restart the server
4. Log in as a student
5. Launch a run
6. Wait 2 minutes for the server session to end
7. Sign out of WISE by clicking on the upper right icon and then clicking "Sign Out"
8. You should no longer see a NullPointerException on the browser

Closes #1986