### PR TITLE
When a user stays logged in long enough for the session to timeout, they are shown this error page

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/WISE5AuthorProjectController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/WISE5AuthorProjectController.java
@@ -811,7 +811,7 @@ public class WISE5AuthorProjectController {
   private ModelAndView authorProjectEnd(@PathVariable String projectId) throws Exception {
     User user = ControllerUtil.getSignedInUser();
     Project project = projectService.getById(projectId);
-    if (projectService.canAuthorProject(project, user)) {
+    if (user != null && projectService.canAuthorProject(project, user)) {
       sessionService.removeCurrentAuthor(project.getId(), user.getUserDetails());
       notifyCurrentAuthors(projectId);
       return null;

--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/WISE5AuthorProjectController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/WISE5AuthorProjectController.java
@@ -811,7 +811,7 @@ public class WISE5AuthorProjectController {
   private ModelAndView authorProjectEnd(@PathVariable String projectId) throws Exception {
     User user = ControllerUtil.getSignedInUser();
     Project project = projectService.getById(projectId);
-    if (user != null && projectService.canAuthorProject(project, user)) {
+    if (projectService.canAuthorProject(project, user)) {
       sessionService.removeCurrentAuthor(project.getId(), user.getUserDetails());
       notifyCurrentAuthors(projectId);
       return null;

--- a/src/main/java/org/wise/portal/spring/impl/WISELogoutHandler.java
+++ b/src/main/java/org/wise/portal/spring/impl/WISELogoutHandler.java
@@ -38,14 +38,18 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.session.Session;
 import org.wise.portal.service.session.SessionService;
 
-public class WISELogoutHandler<S extends Session> implements LogoutHandler, ApplicationListener<SessionDestroyedEvent> {
+public class WISELogoutHandler<S extends Session> implements LogoutHandler,
+    ApplicationListener<SessionDestroyedEvent> {
 
   @Autowired
   protected SessionService sessionService;
 
   @Override
-  public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-    sessionService.removeUser((UserDetails) authentication.getPrincipal());
+  public void logout(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) {
+    if (authentication != null) {
+      sessionService.removeUser((UserDetails) authentication.getPrincipal());
+    }
   }
 
   @Override

--- a/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
+++ b/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
@@ -88,6 +88,7 @@ public class WebSecurityConfig<S extends Session> extends WebSecurityConfigurerA
         .addFilterAfter(authenticationProcessingFilter(), GoogleOpenIdConnectFilter.class)
         .authorizeRequests()
         .antMatchers("/admin/**").hasAnyRole("ADMINISTRATOR,RESEARCHER")
+        .antMatchers("/project/notifyAuthor*/**").hasAnyRole("ADMINISTRATOR,TEACHER")
         .antMatchers("/teacher/**").hasAnyRole("ADMINISTRATOR,TEACHER")
         .antMatchers("/student/**").hasAnyRole("ADMINISTRATOR,STUDENT")
         .antMatchers("/").permitAll();


### PR DESCRIPTION
1. Go to sessionService.es6 and comment out line 119. This will prevent the client from forcing a log out before the session ends on the server. We want to simulate the server session ending and then after that have the client make a request to log out.
```
//this.$rootScope.$broadcast('logOut');
```
2. Go to application.properties and set
```
server.servlet.session.timeout=1m
``` 
3. Restart the server
4. Log in as a teacher
5. Open a project in the Authoring Tool
6. Wait 2 minutes for the server session to end
7. Sign out of WISE by clicking on the upper right icon and then clicking "Sign Out"
8. You should no longer see a NullPointerException on the browser

Closes #2017