### PR TITLE
Table not editable cell styling

### DIFF
--- a/src/main/webapp/wise5/components/table/index.html
+++ b/src/main/webapp/wise5/components/table/index.html
@@ -93,14 +93,15 @@
             <tr ng-repeat='row in tableController.getTableDataRows()'>
               <td ng-repeat='cell in row'
                   ng-class='{ "inactive" : !cell.editable }'>
-                <md-input-container>
+                <span ng-if='!cell.editable || tableController.isDisabled'>
+                  {{ cell.text }}
+                </span>
+                <md-input-container ng-if='cell.editable && !tableController.isDisabled'>
                   <input type='text'
                       ng-model='cell.text'
                       ng-change='tableController.studentDataChanged()'
-                      ng-disabled='tableController.isDisabled'
                       aria-label='Text'
-                      size='{{cell.size || tableController.componentContent.globalCellSize}}'
-                      ng-disabled='!cell.editable || tableController.isDisabled''/>
+                      size='{{cell.size || tableController.componentContent.globalCellSize}}'/>
                 </md-input-container>
               </td>
             </tr>


### PR DESCRIPTION
1. Author a table component with a cell that is not editable by the student
1. Preview the project and make sure the student can't edit it
1. Also make sure the styling of the not editable cell looks like the styling in the authoring preview. Before, the text looked faded and had a dotted underline. Now the text should not be faded and not contain any underline.

Closes #2029