### PR TITLE
Show updated unit names on student homepage run listing

### DIFF
--- a/src/main/webapp/site/src/app/student/student-run-list-item/student-run-list-item.component.html
+++ b/src/main/webapp/site/src/app/student/student-run-list-item/student-run-list-item.component.html
@@ -30,7 +30,7 @@
         <div fxLayout="column">
           <mat-card-title [class.secondary-text]="isRunCompleted(run)"
                           class="mat-body-2">
-            {{ run.name }}
+            {{ run.project.name }}
           </mat-card-title>
           <mat-card-subtitle fxHide fxShow.gt-xs>
             <ng-container *ngTemplateOutlet="runInfo"></ng-container>


### PR DESCRIPTION
To test:
1. Create a run.
2. Add run as a student.
3. As teacher, edit run's name.
4. As student, reload student homepage. Student should see updated unit name in the run listing.

Resolves #2035.