### PR TITLE
getMaxProjectID to catch NullPointerException when creating a new project/run

### DIFF
--- a/src/main/java/org/wise/portal/dao/project/impl/HibernateProjectDao.java
+++ b/src/main/java/org/wise/portal/dao/project/impl/HibernateProjectDao.java
@@ -280,6 +280,10 @@ public class HibernateProjectDao extends AbstractHibernateDao<Project> implement
     Criteria crit = session.createCriteria(ProjectImpl.class);
     crit.setProjection(Projections.max("id"));
     List<Long> results = crit.list();
-    return results.get(0);
+    try {
+      return results.get(0);
+    } catch (NullPointerException npe) {
+      return 1;
+    }
   }
 }

--- a/src/main/java/org/wise/portal/dao/project/impl/HibernateProjectDao.java
+++ b/src/main/java/org/wise/portal/dao/project/impl/HibernateProjectDao.java
@@ -283,7 +283,7 @@ public class HibernateProjectDao extends AbstractHibernateDao<Project> implement
     try {
       return results.get(0);
     } catch (NullPointerException npe) {
-      return 1;
+      return 0;
     }
   }
 }

--- a/src/main/java/org/wise/portal/dao/run/impl/HibernateRunDao.java
+++ b/src/main/java/org/wise/portal/dao/run/impl/HibernateRunDao.java
@@ -224,7 +224,7 @@ public class HibernateRunDao extends AbstractHibernateDao<Run> implements RunDao
     try {
       return results.get(0);
     } catch (NullPointerException npe) {
-      return 1;
+      return 0;
     }
   }
 }

--- a/src/main/java/org/wise/portal/dao/run/impl/HibernateRunDao.java
+++ b/src/main/java/org/wise/portal/dao/run/impl/HibernateRunDao.java
@@ -221,6 +221,10 @@ public class HibernateRunDao extends AbstractHibernateDao<Run> implements RunDao
     Criteria crit = session.createCriteria(RunImpl.class);
     crit.setProjection(Projections.max("id"));
     List<Long> results = crit.list();
-    return results.get(0);
+    try {
+      return results.get(0);
+    } catch (NullPointerException npe) {
+      return 1;
+    }
   }
 }


### PR DESCRIPTION
 Made changes to HibernateProjectDao.java and HibernateRunDao.java so that getMaxProjectI/Rund will create assign a new run/project ID of 1 for a new run or project.

Steps to verify.
1. Start out with a fresh WISE database instance. Database should be set to its original state
2. Login as a teacher and create a new project.
3. Make sure that there are no exceptions and the project is created.
4. Try creating a run with a new project.
5. Make sure that there are no exceptions and the run is created.

Closes #2037 