### PR TITLE
disabled closing launch unit dialog with escape or mouseclick

### DIFF
--- a/src/main/webapp/site/src/app/student/student-run-list-item/student-run-list-item.component.ts
+++ b/src/main/webapp/site/src/app/student/student-run-list-item/student-run-list-item.component.ts
@@ -59,7 +59,8 @@ export class StudentRunListItemComponent implements OnInit {
     } else {
       this.dialog.open(TeamSignInDialogComponent, {
         data: { run: this.run },
-        panelClass: 'mat-dialog--sm'
+        panelClass: 'mat-dialog--sm',
+        disableClose: true
       });
     }
   }


### PR DESCRIPTION
1. Log in a student
2. click "Launch" for run
3. press escape button or click outside the dialog
4. make sure dialog doesn't close

This resolves #2041 