### PR TITLE
Share run: add/revoke shared teacher does not update view automatically

### DIFF
--- a/src/main/webapp/site/src/app/modules/library/share-item-dialog/share-item-dialog.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/share-item-dialog/share-item-dialog.component.ts
@@ -15,6 +15,7 @@ export abstract class ShareItemDialogComponent implements OnInit {
   teacherSearchControl = new FormControl();
   allTeacherUsernames: string[] = [];
   filteredTeacherUsernames: Observable<string[]>;
+  owner: any;
   sharedOwners: any[] = [];
   private sharedOwners$: BehaviorSubject<any[]> = new BehaviorSubject<any[]>(this.sharedOwners);
 

--- a/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.html
+++ b/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.html
@@ -30,7 +30,7 @@
               (click)="teacherSearchControl.setValue('')">
         <mat-icon>close</mat-icon>
       </button>
-      <mat-hint *ngIf="duplicate && allTeacherUsernames.includes(teacherSearchControl.value)"
+      <mat-hint *ngIf="isDuplicateSharedTeacher && allTeacherUsernames.includes(teacherSearchControl.value)"
                 class="info">
         <ng-container i18n>Teacher is already on shared list.</ng-container>
       </mat-hint>

--- a/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.ts
+++ b/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.ts
@@ -91,14 +91,14 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
     if (isAddingPermission) {
       this.teacherService.addSharedOwnerRunPermission(this.runId, sharedOwnerId, permissionId)
           .subscribe((response: any) => {
-        if (response.status == "success") {
+        if (response.status === 'success') {
           this.addRunPermissionToSharedOwner(sharedOwnerId, permissionId);
         }
       });
     } else {
       this.teacherService.removeSharedOwnerRunPermission(this.runId, sharedOwnerId, permissionId)
           .subscribe((response: any) => {
-        if (response.status == "success") {
+        if (response.status === 'success') {
           this.removeRunPermissionFromSharedOwner(sharedOwnerId, permissionId);
         }
       });

--- a/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.ts
+++ b/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.ts
@@ -17,7 +17,7 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
   run: TeacherRun;
   dataSource: MatTableDataSource<any[]> = new MatTableDataSource<any[]>();
   displayedColumns: string[] = ['name', 'permissions'];
-  duplicate: boolean = false;
+  isDuplicateSharedTeacher: boolean = false;
   isOwner: boolean = false;
   isTransfer: boolean = false;
   transferRunWarning: boolean = false;
@@ -34,12 +34,12 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
       this.run = new TeacherRun(run);
       this.runId = this.run.id;
       this.project = this.run.project;
-      this.projectId = this.run.project.id;
+      this.owner = this.run.owner;
       this.isOwner = this.run.isOwner(this.userService.getUserId());
-      this.populateSharedOwners(run.sharedOwners);
+      this.populateSharedOwners(this.run.sharedOwners);
       this.getSharedOwners().subscribe(sharedOwners => {
-        sharedOwners = sharedOwners.sort(this.utilService.sortByUsername);
-        this.updateSharedOwners(sharedOwners);
+        this.sharedOwners = sharedOwners.sort(this.utilService.sortByUsername);
+        this.updateAllOwners();
       });
     });
   }
@@ -48,14 +48,14 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
     super.ngOnInit();
   }
 
-  updateSharedOwners(owners: any[]) {
-    if (this.run.owner) {
-      owners.unshift({
-        sharedOwner: this.run.owner,
-        isOwner: true
-      });
-    }
-    this.dataSource = new MatTableDataSource(owners);
+  updateAllOwners() {
+    let allOwners = [];
+    allOwners.push({
+      sharedOwner: this.run.owner,
+      isOwner: true
+    });
+    allOwners = allOwners.concat(this.sharedOwners);
+    this.dataSource = new MatTableDataSource(allOwners);
   }
 
   populatePermissions(sharedOwner) {
@@ -91,16 +91,16 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
     if (isAddingPermission) {
       this.teacherService.addSharedOwnerRunPermission(this.runId, sharedOwnerId, permissionId)
           .subscribe((response: any) => {
-            if (response.status == "success") {
-              this.addRunPermissionToSharedOwner(sharedOwnerId, permissionId);
-            }
+        if (response.status == "success") {
+          this.addRunPermissionToSharedOwner(sharedOwnerId, permissionId);
+        }
       });
     } else {
       this.teacherService.removeSharedOwnerRunPermission(this.runId, sharedOwnerId, permissionId)
-        .subscribe((response: any) => {
-          if (response.status == "success") {
-            this.removeRunPermissionFromSharedOwner(sharedOwnerId, permissionId);
-          }
+          .subscribe((response: any) => {
+        if (response.status == "success") {
+          this.removeRunPermissionFromSharedOwner(sharedOwnerId, permissionId);
+        }
       });
     }
   }
@@ -118,7 +118,7 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
   }
 
   shareRun() {
-    this.duplicate = false;
+    this.isDuplicateSharedTeacher = false;
     const sharedOwnerUsername = this.teacherSearchControl.value;
     if (this.run.owner.username !== sharedOwnerUsername &&
         (!this.isSharedOwner(sharedOwnerUsername) || this.isTransfer)) {
@@ -130,13 +130,12 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
           this.setDefaultRunPermissions(newSharedOwner);
           this.setDefaultProjectPermissions(newSharedOwner);
           this.addSharedOwner(newSharedOwner);
-          this.data.run.sharedOwners = this.sharedOwners;
           this.teacherSearchControl.setValue('');
         });
         document.getElementById('share-run-dialog-search').blur();
       }
     } else {
-      this.duplicate = true;
+      this.isDuplicateSharedTeacher = true;
     }
   }
 
@@ -155,26 +154,23 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
   updateRunAndProjectPermissions(run) {
     this.run = new TeacherRun(run);
     this.transferRunOwnership(this.run);
-    this.data.run.shared = true;
-    this.data.run.owner = run.owner;
-    this.data.run.sharedOwners = run.sharedOwners;
   }
 
   transferRunOwnership(run: TeacherRun) {
     this.sharedOwners = [];
     this.project = run.project;
+    this.owner = run.owner;
+    this.isOwner = run.isOwner(this.userService.getUserId());
     this.populateSharedOwners(run.sharedOwners);
-    run.sharedOwners = this.sharedOwners;
-    run.shared = true;
-    this.snackBar.open(this.i18n('Transferred classroom unit ownership to {{firstName}} {{lastName}}.', 
-      {firstName: run.owner.firstName, lastName: run.owner.lastName}));
+    this.snackBar.open(
+        this.i18n('Transferred classroom unit ownership to {{firstName}} {{lastName}}.', 
+        {firstName: run.owner.firstName, lastName: run.owner.lastName}));
   }
 
   unshareRun(sharedOwner) {
     this.teacherService.removeSharedOwner(this.runId, sharedOwner.username)
         .subscribe((response) => {
       this.removeSharedOwner(sharedOwner);
-      this.data.run.sharedOwners = this.sharedOwners;
     });
   }
 


### PR DESCRIPTION
1. Create a run
1. Share the run with another teacher. The shared teacher should immediately show up as a shared teacher.
1. Revoke the shared teacher. The shared teacher should immediately be removed from the shared teachers.
1. Transfer the run to another teacher. The share run dialog should immediately update to show the new owner and also show the previous owner as a shared owner.

Closes #2045