### PR TITLE
Allow admins to switch back to original user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,6 @@
             </goals>
             <configuration>
               <testExcludes>
-                <exclude>**/org/wise/portal/service/**/*.java</exclude>
                 <exclude>**/org/wise/portal/domain/**/*.java</exclude>
                 <exclude>**/org/wise/portal/presentation/web/controllers/general/contactwise/*.java</exclude>
                 <exclude>**/org/wise/portal/presentation/web/controllers/teacher/**/*.java</exclude>

--- a/src/main/java/org/wise/portal/domain/RunHasEndedException.java
+++ b/src/main/java/org/wise/portal/domain/RunHasEndedException.java
@@ -26,8 +26,8 @@ package org.wise.portal.domain;
 import org.wise.portal.domain.run.Run;
 
 /**
- * A checked exception that gets thrown when the student that was to be
- * added to a <code>Run</code> was already-associated with the run.
+ * A checked exception that gets thrown when the student wants to input the code and wants to
+ * add a run that has ended
  *
  * @author Arthur Yin
  */

--- a/src/main/java/org/wise/portal/domain/RunHasEndedException.java
+++ b/src/main/java/org/wise/portal/domain/RunHasEndedException.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2007-2015 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.wise.portal.domain;
+
+import org.wise.portal.domain.run.Run;
+
+/**
+ * A checked exception that gets thrown when the student that was to be
+ * added to a <code>Run</code> was already-associated with the run.
+ *
+ * @author Hiroki Terashima
+ */
+public class RunHasEndedException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public RunHasEndedException(String message) {
+    super(message);
+  }
+
+  public RunHasEndedException(Throwable cause) {
+    super(cause);
+  }
+
+  public RunHasEndedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public RunHasEndedException(Run run) {
+    super("The run" + run + "has ended.");
+  }
+}

--- a/src/main/java/org/wise/portal/domain/RunHasEndedException.java
+++ b/src/main/java/org/wise/portal/domain/RunHasEndedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2007-2015 Regents of the University of California (Regents).
+ * Copyright (c) 2007-2019 Regents of the University of California (Regents).
  * Created by WISE, Graduate School of Education, University of California, Berkeley.
  *
  * This software is distributed under the GNU General Public License, v3,
@@ -29,7 +29,7 @@ import org.wise.portal.domain.run.Run;
  * A checked exception that gets thrown when the student that was to be
  * added to a <code>Run</code> was already-associated with the run.
  *
- * @author Hiroki Terashima
+ * @author Arthur Yin
  */
 public class RunHasEndedException extends Exception {
 

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/AddProjectController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/AddProjectController.java
@@ -98,7 +98,7 @@ public class AddProjectController {
     } catch (StudentUserAlreadyAssociatedWithRunException se) {
       result.rejectValue("projectcode", "student.index.error.studentAlreadyAssociatedWithRun");
       return modelAndView;
-    } catch (RunHasEndedException e){
+    } catch (RunHasEndedException e) {
       result.rejectValue("projectcode", "student.index.error.runHasEnded");
     }
     return modelAndView;

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/AddProjectController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/AddProjectController.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.PeriodNotFoundException;
+import org.wise.portal.domain.RunHasEndedException;
 import org.wise.portal.domain.StudentUserAlreadyAssociatedWithRunException;
 import org.wise.portal.domain.project.impl.AddProjectParameters;
 import org.wise.portal.domain.project.impl.Projectcode;
@@ -97,6 +98,8 @@ public class AddProjectController {
     } catch (StudentUserAlreadyAssociatedWithRunException se) {
       result.rejectValue("projectcode", "student.index.error.studentAlreadyAssociatedWithRun");
       return modelAndView;
+    } catch (RunHasEndedException e){
+      result.rejectValue("projectcode", "student.index.error.runHasEnded");
     }
     return modelAndView;
   }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
@@ -23,6 +23,18 @@
  */
 package org.wise.portal.presentation.web.controllers.student;
 
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hibernate.StaleObjectStateException;
 import org.json.JSONArray;
@@ -32,10 +44,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.orm.hibernate5.HibernateOptimisticLockingFailureException;
 import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.AccountQuestion;
 import org.wise.portal.domain.PeriodNotFoundException;
+import org.wise.portal.domain.RunHasEndedException;
 import org.wise.portal.domain.StudentUserAlreadyAssociatedWithRunException;
 import org.wise.portal.domain.authentication.Gender;
 import org.wise.portal.domain.authentication.MutableUserDetails;
@@ -59,9 +76,6 @@ import org.wise.portal.service.run.RunService;
 import org.wise.portal.service.student.StudentService;
 import org.wise.portal.service.user.UserService;
 import org.wise.portal.service.workgroup.WorkgroupService;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.*;
 
 /**
  * Controller for Student REST API
@@ -295,7 +309,7 @@ public class StudentAPIController {
   private JSONObject performLaunchRun(Long runId, Long workgroupId, String presentUserIds,
       String absentUserIds, HttpServletRequest request, Run run, Set<User> presentMembers,
       Workgroup workgroup) throws ObjectNotFoundException, PeriodNotFoundException,
-      StudentUserAlreadyAssociatedWithRunException, JSONException {
+      StudentUserAlreadyAssociatedWithRunException,RunHasEndedException, JSONException {
     addStudentsToRunIfNecessary(run, presentMembers, workgroup);
     if (!run.isEnded()) {
       saveStudentAttendance(runId, workgroupId, presentUserIds, absentUserIds);
@@ -306,7 +320,7 @@ public class StudentAPIController {
   }
 
   private void addStudentsToRunIfNecessary(Run run, Set<User> presentMembers, Workgroup workgroup)
-      throws ObjectNotFoundException, PeriodNotFoundException, StudentUserAlreadyAssociatedWithRunException {
+      throws ObjectNotFoundException, PeriodNotFoundException, RunHasEndedException, StudentUserAlreadyAssociatedWithRunException {
     Projectcode projectcode = new Projectcode(run.getRuncode(), workgroup.getPeriod().getName());
     for (User presentMember : presentMembers) {
       if (!run.isStudentAssociatedToThisRun(presentMember)) {
@@ -402,6 +416,8 @@ public class StudentAPIController {
       error = "periodNotFound";
     } catch (StudentUserAlreadyAssociatedWithRunException se) {
       error = "studentAlreadyAssociatedWithRun";
+    } catch (RunHasEndedException e){
+      error = "runHasEnded";
     }
 
     if (!error.equals("")) {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
@@ -416,7 +416,7 @@ public class StudentAPIController {
       error = "periodNotFound";
     } catch (StudentUserAlreadyAssociatedWithRunException se) {
       error = "studentAlreadyAssociatedWithRun";
-    } catch (RunHasEndedException e){
+    } catch (RunHasEndedException e) {
       error = "runHasEnded";
     }
 

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
@@ -309,7 +309,7 @@ public class StudentAPIController {
   private JSONObject performLaunchRun(Long runId, Long workgroupId, String presentUserIds,
       String absentUserIds, HttpServletRequest request, Run run, Set<User> presentMembers,
       Workgroup workgroup) throws ObjectNotFoundException, PeriodNotFoundException,
-      StudentUserAlreadyAssociatedWithRunException,RunHasEndedException, JSONException {
+      StudentUserAlreadyAssociatedWithRunException, RunHasEndedException, JSONException {
     addStudentsToRunIfNecessary(run, presentMembers, workgroup);
     if (!run.isEnded()) {
       saveStudentAttendance(runId, workgroupId, presentUserIds, absentUserIds);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAccountController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAccountController.java
@@ -176,7 +176,7 @@ public class StudentAccountController {
         bindingResult.rejectValue("projectCode",
             "student.index.error.studentAlreadyAssociatedWithRun");
         return "student/join";
-      } catch (RunHasEndedException e){
+      } catch (RunHasEndedException e) {
         bindingResult.rejectValue("projectCode", "student.index.error.RunHasEnded");
         return "student/join";
       }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAccountController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAccountController.java
@@ -54,6 +54,7 @@ import org.springframework.web.servlet.view.RedirectView;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.AccountQuestion;
 import org.wise.portal.domain.PeriodNotFoundException;
+import org.wise.portal.domain.RunHasEndedException;
 import org.wise.portal.domain.StudentUserAlreadyAssociatedWithRunException;
 import org.wise.portal.domain.authentication.Gender;
 import org.wise.portal.domain.authentication.impl.StudentUserDetails;
@@ -174,6 +175,9 @@ public class StudentAccountController {
       } catch (StudentUserAlreadyAssociatedWithRunException e) {
         bindingResult.rejectValue("projectCode",
             "student.index.error.studentAlreadyAssociatedWithRun");
+        return "student/join";
+      } catch (RunHasEndedException e){
+        bindingResult.rejectValue("projectCode", "student.index.error.RunHasEnded");
         return "student/join";
       }
       // if it reaches here, it means there were no issues, so we can exit the loop.

--- a/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
@@ -1,5 +1,10 @@
 package org.wise.portal.presentation.web.controllers.user;
 
+import java.util.Locale;
+import java.util.Properties;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -7,7 +12,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.domain.authentication.MutableUserDetails;
 import org.wise.portal.domain.authentication.impl.TeacherUserDetails;
 import org.wise.portal.domain.user.User;
@@ -17,9 +25,6 @@ import org.wise.portal.presentation.web.exception.NotAuthorizedException;
 import org.wise.portal.presentation.web.response.SimpleResponse;
 import org.wise.portal.service.mail.IMailFacade;
 import org.wise.portal.service.user.UserService;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.*;
 
 /**
  * Controller for User REST API
@@ -80,6 +85,8 @@ public class UserAPIController {
       userJSON.put("lastName", userDetails.getLastname());
       userJSON.put("username", userDetails.getUsername());
       userJSON.put("isGoogleUser", userDetails.isGoogleUser());
+
+      userJSON.put("isPreviousAdmin", ControllerUtil.isUserPreviousAdministrator());
 
       if (isStudent) {
         userJSON.put("role", "student");

--- a/src/main/java/org/wise/portal/service/student/StudentService.java
+++ b/src/main/java/org/wise/portal/service/student/StudentService.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.springframework.transaction.annotation.Transactional;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.PeriodNotFoundException;
+import org.wise.portal.domain.RunHasEndedException;
 import org.wise.portal.domain.StudentUserAlreadyAssociatedWithRunException;
 import org.wise.portal.domain.project.impl.Projectcode;
 import org.wise.portal.domain.run.Run;
@@ -58,7 +59,7 @@ public interface StudentService {
   @Transactional
   void addStudentToRun(User studentUser, Projectcode projectcode)
       throws ObjectNotFoundException, PeriodNotFoundException,
-      StudentUserAlreadyAssociatedWithRunException;
+      StudentUserAlreadyAssociatedWithRunException, RunHasEndedException;
 
   /**
    * Returns a list of teachers that this student is associated with through runs.

--- a/src/main/java/org/wise/portal/service/student/impl/StudentServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/student/impl/StudentServiceImpl.java
@@ -24,6 +24,7 @@
 package org.wise.portal.service.student.impl;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -32,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.PeriodNotFoundException;
+import org.wise.portal.domain.RunHasEndedException;
 import org.wise.portal.domain.StudentUserAlreadyAssociatedWithRunException;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.project.impl.Projectcode;
@@ -61,7 +63,7 @@ public class StudentServiceImpl implements StudentService {
 
   public synchronized void addStudentToRun(User studentUser, Projectcode projectcode)
       throws ObjectNotFoundException, PeriodNotFoundException,
-      StudentUserAlreadyAssociatedWithRunException {
+      StudentUserAlreadyAssociatedWithRunException, RunHasEndedException{
     // TODO HT: figure out if we need a Transactional annotation for this method
     // possible problem: groupService.addMembers is transactional
     // we probably need a rollback though
@@ -69,6 +71,10 @@ public class StudentServiceImpl implements StudentService {
     String periodName = projectcode.getRunPeriod();
 
     Run run = runService.retrieveRunByRuncode(runcode);
+    //run.getEndtime() 
+    if(run.getEndtime().compareTo(new Date()) < 0){
+      throw new RunHasEndedException(run);
+    }
     if (!run.isStudentAssociatedToThisRun(studentUser)) {
       Group period = run.getPeriodByName(periodName);
       Long groupId = period.getId();

--- a/src/main/java/org/wise/portal/service/student/impl/StudentServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/student/impl/StudentServiceImpl.java
@@ -63,7 +63,7 @@ public class StudentServiceImpl implements StudentService {
 
   public synchronized void addStudentToRun(User studentUser, Projectcode projectcode)
       throws ObjectNotFoundException, PeriodNotFoundException,
-      StudentUserAlreadyAssociatedWithRunException, RunHasEndedException{
+      StudentUserAlreadyAssociatedWithRunException, RunHasEndedException {
     // TODO HT: figure out if we need a Transactional annotation for this method
     // possible problem: groupService.addMembers is transactional
     // we probably need a rollback though
@@ -71,8 +71,8 @@ public class StudentServiceImpl implements StudentService {
     String periodName = projectcode.getRunPeriod();
 
     Run run = runService.retrieveRunByRuncode(runcode);
-    //run.getEndtime() 
-    if(run.getEndtime().compareTo(new Date()) < 0){
+    Date currentTime = new Date();
+    if (run.getEndtime().before(currentTime)) {
       throw new RunHasEndedException(run);
     }
     if (!run.isStudentAssociatedToThisRun(studentUser)) {

--- a/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.html
+++ b/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.html
@@ -17,6 +17,9 @@
       </ng-template>
       <span>{{ firstName }} {{ lastName }}</span>
     </div>
+    <div *ngIf="isPreviousAdmin" class="user-switch">
+      <a href="/logout/impersonate" i18n>Switch back to original user</a>
+    </div>
     <mat-divider></mat-divider>
     <a *ngIf="role === 'student'"
        routerLinkActive="active"

--- a/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.scss
+++ b/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.scss
@@ -25,3 +25,8 @@
     margin-right: 8px;
   }
 }
+
+.user-switch{
+  margin: 0 16px;
+  font-size: 12px;
+}

--- a/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.ts
+++ b/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.ts
@@ -15,6 +15,7 @@ export class HeaderAccountMenuComponent implements OnInit {
   firstName: string = "";
   lastName: string = "";
   role: string = "";
+  isPreviousAdmin: boolean = false;
   logOutURL: string;
 
   constructor(private configService: ConfigService) {
@@ -36,6 +37,7 @@ export class HeaderAccountMenuComponent implements OnInit {
         this.firstName = user.firstName;
         this.lastName = user.lastName;
         this.role = user.role;
+        this.isPreviousAdmin = user.isPreviousAdmin;
       }
     }
   }

--- a/src/main/webapp/site/src/app/student/add-project-dialog/add-project-dialog.component.html
+++ b/src/main/webapp/site/src/app/student/add-project-dialog/add-project-dialog.component.html
@@ -7,6 +7,7 @@
         <input formControlName="runCode" matInput value="{{ accessCode }}" (keyup)="checkRunCode()">
         <mat-error *ngIf="runCodeFormControl.hasError('invalidRunCodeSyntax') || runCodeFormControl.hasError('invalidRunCode')" i18n>Invalid Access Code</mat-error>
         <mat-error *ngIf="runCodeFormControl.hasError('alreadyAddedRun')" i18n>You have already added this unit.</mat-error>
+        <mat-error *ngIf="runCodeFormControl.hasError('runHasEnded')" i18n>This run has ended. Please talk to your teacher.</mat-error>
       </mat-form-field>
     </p>
     <p>

--- a/src/main/webapp/site/src/app/student/add-project-dialog/add-project-dialog.component.ts
+++ b/src/main/webapp/site/src/app/student/add-project-dialog/add-project-dialog.component.ts
@@ -42,8 +42,13 @@ export class AddProjectDialogComponent implements OnInit {
     this.isAdding = true;
     this.studentService.addRun(this.registerRunRunCode, this.selectedPeriod).subscribe((studentRun) => {
       if (studentRun.error) {
-        this.addProjectForm.controls['runCode'].setErrors({'alreadyAddedRun': true});
+        if (studentRun.error == "alreadyAddedRun") {
+          this.addProjectForm.controls['runCode'].setErrors({'alreadyAddedRun': true});
+        } else if (studentRun.error == "runHasEnded") {
+          this.addProjectForm.controls['runCode'].setErrors({'runHasEnded': true});
+        }
         this.isAdding = false;
+
       } else {
         this.studentService.addNewProject(studentRun);
         this.dialog.closeAll();

--- a/src/main/webapp/site/src/app/student/add-project-dialog/add-project-dialog.component.ts
+++ b/src/main/webapp/site/src/app/student/add-project-dialog/add-project-dialog.component.ts
@@ -42,13 +42,12 @@ export class AddProjectDialogComponent implements OnInit {
     this.isAdding = true;
     this.studentService.addRun(this.registerRunRunCode, this.selectedPeriod).subscribe((studentRun) => {
       if (studentRun.error) {
-        if (studentRun.error == "alreadyAddedRun") {
+        if (studentRun.error == 'alreadyAddedRun') {
           this.addProjectForm.controls['runCode'].setErrors({'alreadyAddedRun': true});
-        } else if (studentRun.error == "runHasEnded") {
+        } else if (studentRun.error == 'runHasEnded') {
           this.addProjectForm.controls['runCode'].setErrors({'runHasEnded': true});
         }
         this.isAdding = false;
-
       } else {
         this.studentService.addNewProject(studentRun);
         this.dialog.closeAll();

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -1452,7 +1452,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/add-project-dialog/add-project-dialog.component.html</context>
-          <context context-type="linenumber">22</context>
+          <context context-type="linenumber">23</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/team-sign-in-dialog/team-sign-in-dialog.component.html</context>
@@ -1470,7 +1470,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/add-project-dialog/add-project-dialog.component.html</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit><trans-unit id="e9a74cfea4f80b5d5c656bd147bdf4588c98572e" datatype="html">
         <source>The unit has been successfully added to the following Google Classroom(s)</source>
@@ -4524,11 +4524,17 @@
           <context context-type="sourcefile">app/student/add-project-dialog/add-project-dialog.component.html</context>
           <context context-type="linenumber">9</context>
         </context-group>
+      </trans-unit><trans-unit id="2ac78802200564a04e42b0c60d0283d32e04060e" datatype="html">
+        <source>This run has ended. Please talk to your teacher.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/student/add-project-dialog/add-project-dialog.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
       </trans-unit><trans-unit id="38b627ddc0611e9f2027cb255872829f3c7917fc" datatype="html">
         <source>Choose Period</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/add-project-dialog/add-project-dialog.component.html</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">15</context>
         </context-group>
       </trans-unit><trans-unit id="a118959daf55b5584609654f7d5ee9e443b961d0" datatype="html">
         <source>Add unit</source>

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -4430,11 +4430,17 @@
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
           <context context-type="linenumber">16</context>
         </context-group>
+      </trans-unit><trans-unit id="c48210e0360714d757f8286144200648dc140e30" datatype="html">
+        <source>Switch back to original user</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
       </trans-unit><trans-unit id="c4e3e4170654ee5a353d29a0c34b8008cd25a635" datatype="html">
         <source>Student Home</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">29</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/student-home/student-home.component.html</context>
@@ -4444,7 +4450,7 @@
         <source>Teacher Home</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/teacher-home/teacher-home.component.html</context>
@@ -4454,11 +4460,11 @@
         <source>Edit Profile</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">53</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/account/edit/edit.component.html</context>
@@ -4472,29 +4478,29 @@
         <source>Researcher Tools</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit><trans-unit id="593d1ae1c4b71457eda8476df2bb52624a3c6e74" datatype="html">
         <source>Admin Tools</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit><trans-unit id="85b79c9064aed1ead31ace985f31aa1363f6bdaf" datatype="html">
         <source>Help</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">70</context>
+          <context context-type="linenumber">73</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit><trans-unit id="640eec093c685babaa3265137215e3cc92ad704d" datatype="html">
         <source>Sign Out</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">86</context>
         </context-group>
       </trans-unit><trans-unit id="36a606470097ddf0c32a250c8a902441729ca8ca" datatype="html">
         <source>Add Unit</source>

--- a/src/test/java/org/wise/portal/service/student/impl/StudentServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/student/impl/StudentServiceImplTest.java
@@ -37,6 +37,7 @@ import java.util.TreeSet;
 import junit.framework.TestCase;
 
 import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.RunHasEndedException;
 import org.wise.portal.domain.PeriodNotFoundException;
 import org.wise.portal.domain.StudentUserAlreadyAssociatedWithRunException;
 import org.wise.portal.domain.group.Group;
@@ -118,7 +119,7 @@ public class StudentServiceImplTest extends TestCase {
 	
 	public void testAddStudentToRun_success() 
 	     throws ObjectNotFoundException, PeriodNotFoundException, 
-	     StudentUserAlreadyAssociatedWithRunException {
+	     StudentUserAlreadyAssociatedWithRunException, RunHasEndedException {
   	    expect(mockRunService.retrieveRunByRuncode(RUNCODE)).andReturn(run);
   	    replay(mockRunService);
   	    Group period = run.getPeriodByName(PERIODNAME);
@@ -150,6 +151,8 @@ public class StudentServiceImplTest extends TestCase {
 			fail("PeriodNotFoundException was not expected to be thrown");
 		} catch (StudentUserAlreadyAssociatedWithRunException se) {
 			fail("StudentUserAlreadyAssociatedWithRunException was not expected to be thrown");
+		} catch (RunHasEndedException e){
+			fail("RunHasEndedException was not expected to be thrown.");
 		}
   	    
   	    verify(mockRunService);
@@ -178,6 +181,8 @@ public class StudentServiceImplTest extends TestCase {
 		} catch (PeriodNotFoundException pe) {
 		} catch (StudentUserAlreadyAssociatedWithRunException se) {
 			fail("StudentUserAlreadyAssociatedWithRunException was not expected to be thrown");
+		} catch (RunHasEndedException e){
+			fail("RunHasEndedException was not expected to be thrown.");
 		}
   	    
   	    verify(mockRunService);
@@ -203,6 +208,8 @@ public class StudentServiceImplTest extends TestCase {
 			fail("PeriodNotFoundException was not expected to be thrown");
 		} catch (StudentUserAlreadyAssociatedWithRunException se) {
 			fail("StudentUserAlreadyAssociatedWithRunException was not expected to be thrown");
+		} catch (RunHasEndedException e){
+			fail("RunHasEndedException was not expected to be thrown.");
 		}
   	    verify(mockRunService);
   	    verify(mockGroupService);
@@ -221,6 +228,8 @@ public class StudentServiceImplTest extends TestCase {
 		} catch (PeriodNotFoundException pe) {
 			fail("PeriodNotFoundException was not expected to be thrown");
 		} catch (StudentUserAlreadyAssociatedWithRunException se) {
+		} catch (RunHasEndedException e){
+			fail("RunHasEndedException was not expected to be thrown.");
 		}
   	    verify(mockRunService);
 	}

--- a/src/test/java/org/wise/portal/service/student/impl/StudentServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/student/impl/StudentServiceImplTest.java
@@ -151,7 +151,7 @@ public class StudentServiceImplTest extends TestCase {
 			fail("PeriodNotFoundException was not expected to be thrown");
 		} catch (StudentUserAlreadyAssociatedWithRunException se) {
 			fail("StudentUserAlreadyAssociatedWithRunException was not expected to be thrown");
-		} catch (RunHasEndedException e){
+		} catch (RunHasEndedException e) {
 			fail("RunHasEndedException was not expected to be thrown.");
 		}
   	    
@@ -181,7 +181,7 @@ public class StudentServiceImplTest extends TestCase {
 		} catch (PeriodNotFoundException pe) {
 		} catch (StudentUserAlreadyAssociatedWithRunException se) {
 			fail("StudentUserAlreadyAssociatedWithRunException was not expected to be thrown");
-		} catch (RunHasEndedException e){
+		} catch (RunHasEndedException e) {
 			fail("RunHasEndedException was not expected to be thrown.");
 		}
   	    
@@ -208,7 +208,7 @@ public class StudentServiceImplTest extends TestCase {
 			fail("PeriodNotFoundException was not expected to be thrown");
 		} catch (StudentUserAlreadyAssociatedWithRunException se) {
 			fail("StudentUserAlreadyAssociatedWithRunException was not expected to be thrown");
-		} catch (RunHasEndedException e){
+		} catch (RunHasEndedException e) {
 			fail("RunHasEndedException was not expected to be thrown.");
 		}
   	    verify(mockRunService);
@@ -228,7 +228,7 @@ public class StudentServiceImplTest extends TestCase {
 		} catch (PeriodNotFoundException pe) {
 			fail("PeriodNotFoundException was not expected to be thrown");
 		} catch (StudentUserAlreadyAssociatedWithRunException se) {
-		} catch (RunHasEndedException e){
+		} catch (RunHasEndedException e) {
 			fail("RunHasEndedException was not expected to be thrown.");
 		}
   	    verify(mockRunService);

--- a/src/test/java/org/wise/portal/service/student/impl/StudentServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/student/impl/StudentServiceImplTest.java
@@ -36,6 +36,7 @@ import java.util.TreeSet;
 
 import junit.framework.TestCase;
 
+import org.junit.Test;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.RunHasEndedException;
 import org.wise.portal.domain.PeriodNotFoundException;
@@ -116,7 +117,7 @@ public class StudentServiceImplTest extends TestCase {
 		projectcode = null;		
 		studentService = null;
 	}
-	
+
 	public void testAddStudentToRun_success() 
 	     throws ObjectNotFoundException, PeriodNotFoundException, 
 	     StudentUserAlreadyAssociatedWithRunException, RunHasEndedException {
@@ -265,6 +266,35 @@ public class StudentServiceImplTest extends TestCase {
 		verify(mockGroupService);
 	}
 
+	public void testAddStudentsToRun_RunHasEndedException() 
+            throws ObjectNotFoundException, PeriodNotFoundException {
+		run.setEndtime(new Date(System.currentTimeMillis() - 1));
+  	    expect(mockRunService.retrieveRunByRuncode(RUNCODE)).andReturn(run);
+  	    replay(mockRunService);
+		Group period = run.getPeriodByName(PERIODNAME);
+  	    Set<User> membersToAdd = new HashSet<User>();
+  	    membersToAdd.add(studentUser);
+  	    mockGroupService.addMembers(period, membersToAdd);
+  	    expectLastCall();
+		replay(mockGroupService);
+		  
+  	    // now if we try to add this run that has ended, 
+		// we should get a RunHasEndedException
+  	    try {
+			studentService.addStudentToRun(studentUser, projectcode);
+			fail("Expected the RunHasEndedException to be thrown");
+		} catch (ObjectNotFoundException oe) {
+			fail("ObjectNotFoundException was not expected to be thrown");
+		} catch (PeriodNotFoundException pe) {
+			fail("PeriodNotFoundException was not expected to be thrown");
+		} catch (StudentUserAlreadyAssociatedWithRunException se) {
+			fail("StudentUserAlreadyAssociatedWithRunException was not expected to be thrown");
+		} catch (RunHasEndedException e) {
+		}
+  	    verify(mockRunService);
+  	    verify(mockGroupService);
+	}
+
 	// TODO Hiroki test getStudentRunInfo()
-	
+
 }


### PR DESCRIPTION
I added a link so that when the admin user logs in as other accounts, he can switch back to the admin user through the link.

1. Log in as an admin user
2. Go to the admin tools
3. Find a teacher's/student's account and click "Log In As This User"
4. Click the Avatar on the upper right
5. In the pop-up menu, you should see the link of "Switch back to original user" under the avatar and name
6. Click the link, you should be able to go back to the admin user

closes #2064 