### PR TITLE
Added a "default" satisfy criteria function for milestone report templates

### DIFF
--- a/src/main/webapp/wise5/classroomMonitor/milestones/milestonesController.js
+++ b/src/main/webapp/wise5/classroomMonitor/milestones/milestonesController.js
@@ -527,7 +527,7 @@ class MilestonesController {
 
   isTemplateMatch(template, aggregateAutoScores) {
     const matchedCriteria = [];
-    for (let satisfyCriterion of template.satisfyCriteria) {
+    for (const satisfyCriterion of template.satisfyCriteria) {
       if (this.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores)) {
         matchedCriteria.push(satisfyCriterion);
       }
@@ -552,6 +552,8 @@ class MilestonesController {
       return this.isPercentOfScoresEqualTo(satisfyCriterion, aggregateAutoScores);
     } else if (satisfyCriterion.function === 'percentOfScoresNotEqualTo') {
       return this.isPercentOfScoresNotEqualTo(satisfyCriterion, aggregateAutoScores);
+    } else if (satisfyCriterion.function === 'default') {
+      return true;
     }
   }
 


### PR DESCRIPTION
 Can now specify a "default" template for milestone reports.

To test, add a milestone to a unit. Use the following json for the `achievements` key in the `project.json`. (Update with the correct node and component ids you want to use.)

Create a run with the unit and make sure the milestone report shows up in the Classroom monitor.

Sample milestone json:
```
"achievements": {
		"isEnabled": true,
		"items": [{
				"satisfyCriteria": [{
					"componentId": "mukjuuf230",
					"name": "isCompleted",
					"id": "satisfyCriteria1",
					"nodeId": "node1"
				}],
				"satisfyMinPercentage": 0,
				"satisfyMinNumWorkgroups": 0,
				"satisfyConditional": "all",
				"isEnabled": true,
				"name": "Test Default",
				"icon": {
					"image": ""
				},
				"report": {
					"audience": [
						"teacher"
					],
					"isEnabled": true,
					"templates": [{
						"satisfyCriteria": [{
							"percentThreshold": 0,
							"targetVariable": "",
							"componentId": "mukjuuf230",
							"function": "default",
							"id": "template1SatisfyCriteria1",
							"type": "",
							"nodeId": "node1",
							"value": 0
						}],
						"satisfyConditional": "any",
						"description": "Default",
						"id": "template1",
						"content": "<p>This is a default template that shows up whenever the report is visible.</p>"
					}]
				},
				"description": "The item for this milestone is located in <b>Step 1.1</b>.",
				"id": "checkpoint1",
				"type": "milestoneReport"
			}]
}
```

Closes #2095.