### PR TITLE
Issue 2064 allow admins to switch back to original user #2086

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
@@ -1,5 +1,10 @@
 package org.wise.portal.presentation.web.controllers.user;
 
+import java.util.Locale;
+import java.util.Properties;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -7,7 +12,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.domain.authentication.MutableUserDetails;
 import org.wise.portal.domain.authentication.impl.TeacherUserDetails;
 import org.wise.portal.domain.user.User;
@@ -17,9 +25,6 @@ import org.wise.portal.presentation.web.exception.NotAuthorizedException;
 import org.wise.portal.presentation.web.response.SimpleResponse;
 import org.wise.portal.service.mail.IMailFacade;
 import org.wise.portal.service.user.UserService;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.*;
 
 /**
  * Controller for User REST API
@@ -80,6 +85,8 @@ public class UserAPIController {
       userJSON.put("lastName", userDetails.getLastname());
       userJSON.put("username", userDetails.getUsername());
       userJSON.put("isGoogleUser", userDetails.isGoogleUser());
+
+      userJSON.put("isPreviousAdmin", ControllerUtil.isUserPreviousAdministrator());
 
       if (isStudent) {
         userJSON.put("role", "student");

--- a/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
@@ -85,7 +85,6 @@ public class UserAPIController {
       userJSON.put("lastName", userDetails.getLastname());
       userJSON.put("username", userDetails.getUsername());
       userJSON.put("isGoogleUser", userDetails.isGoogleUser());
-
       userJSON.put("isPreviousAdmin", ControllerUtil.isUserPreviousAdministrator());
 
       if (isStudent) {

--- a/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.html
+++ b/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.html
@@ -17,6 +17,9 @@
       </ng-template>
       <span>{{ firstName }} {{ lastName }}</span>
     </div>
+    <div *ngIf="isPreviousAdmin" class="user-switch">
+      <a href="/logout/impersonate" i18n>Switch back to original user</a>
+    </div>
     <mat-divider></mat-divider>
     <a *ngIf="role === 'student'"
        routerLinkActive="active"

--- a/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.scss
+++ b/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.scss
@@ -26,7 +26,7 @@
   }
 }
 
-.user-switch{
+.user-switch {
   margin: 0 16px;
   font-size: 12px;
 }

--- a/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.scss
+++ b/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.scss
@@ -25,3 +25,8 @@
     margin-right: 8px;
   }
 }
+
+.user-switch{
+  margin: 0 16px;
+  font-size: 12px;
+}

--- a/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.ts
+++ b/src/main/webapp/site/src/app/modules/header/header-account-menu/header-account-menu.component.ts
@@ -15,6 +15,7 @@ export class HeaderAccountMenuComponent implements OnInit {
   firstName: string = "";
   lastName: string = "";
   role: string = "";
+  isPreviousAdmin: boolean = false;
   logOutURL: string;
 
   constructor(private configService: ConfigService) {
@@ -36,6 +37,7 @@ export class HeaderAccountMenuComponent implements OnInit {
         this.firstName = user.firstName;
         this.lastName = user.lastName;
         this.role = user.role;
+        this.isPreviousAdmin = user.isPreviousAdmin;
       }
     }
   }

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -4430,11 +4430,17 @@
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
           <context context-type="linenumber">16</context>
         </context-group>
+      </trans-unit><trans-unit id="c48210e0360714d757f8286144200648dc140e30" datatype="html">
+        <source>Switch back to original user</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
       </trans-unit><trans-unit id="c4e3e4170654ee5a353d29a0c34b8008cd25a635" datatype="html">
         <source>Student Home</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">29</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/student-home/student-home.component.html</context>
@@ -4444,7 +4450,7 @@
         <source>Teacher Home</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/teacher-home/teacher-home.component.html</context>
@@ -4454,11 +4460,11 @@
         <source>Edit Profile</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">53</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/account/edit/edit.component.html</context>
@@ -4472,29 +4478,29 @@
         <source>Researcher Tools</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit><trans-unit id="593d1ae1c4b71457eda8476df2bb52624a3c6e74" datatype="html">
         <source>Admin Tools</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit><trans-unit id="85b79c9064aed1ead31ace985f31aa1363f6bdaf" datatype="html">
         <source>Help</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">70</context>
+          <context context-type="linenumber">73</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit><trans-unit id="640eec093c685babaa3265137215e3cc92ad704d" datatype="html">
         <source>Sign Out</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">86</context>
         </context-group>
       </trans-unit><trans-unit id="36a606470097ddf0c32a250c8a902441729ca8ca" datatype="html">
         <source>Add Unit</source>


### PR DESCRIPTION
I added a link so that when the admin user logs in as other accounts, he can switch back to the admin user through the link.

1. Log in as an admin user
2. Go to the admin tools
3. Find a teacher's/student's account and click "Log In As This User"
4. Click the Avatar on the upper right
5. In the pop-up menu, you should see the link of "Switch back to original user" under the avatar and name
6. Click the link, you should be able to go back to the admin user

closes #2064