### PR TITLE
Refactored GradeWorkController to use Authentication object

### DIFF
--- a/src/main/java/org/wise/portal/domain/authentication/MutableUserDetails.java
+++ b/src/main/java/org/wise/portal/domain/authentication/MutableUserDetails.java
@@ -259,6 +259,8 @@ public interface MutableUserDetails extends UserDetails, Persistable {
 
   void clearNumberOfRecentFailedVerificationCodeAttempts();
 
+  boolean isAdminUser();
+
   boolean isGoogleUser();
 
   String getGoogleUserId();

--- a/src/main/java/org/wise/portal/domain/authentication/impl/PersistentUserDetails.java
+++ b/src/main/java/org/wise/portal/domain/authentication/impl/PersistentUserDetails.java
@@ -46,6 +46,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.wise.portal.domain.authentication.MutableUserDetails;
+import org.wise.portal.service.authentication.UserDetailsService;
 
 /**
  * Implementation class of <code>MutableUserDetails</code> that uses an EJB3
@@ -443,6 +444,10 @@ public class PersistentUserDetails implements MutableUserDetails {
 
   public void clearNumberOfRecentFailedVerificationCodeAttempts() {
     this.numberOfRecentFailedVerificationCodeAttempts = null;
+  }
+
+  public boolean isAdminUser() {
+    return hasGrantedAuthority(UserDetailsService.ADMIN_ROLE);
   }
 
   public boolean isGoogleUser() {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/grading/GradeWorkController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/grading/GradeWorkController.java
@@ -88,8 +88,7 @@ public class GradeWorkController {
     Run run = runService.retrieveById(runId);
     if (runService.hasReadPermission(authentication, run)) {
       return new ModelAndView(
-          "forward:/wise5/classroomMonitor/dist/index.html#!/run/" + runId
-              + "/project/");
+          "forward:/wise5/classroomMonitor/dist/index.html#!/run/" + runId + "/project/");
     } else {
       return new ModelAndView("errors/accessdenied");
     }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/grading/GradeWorkController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/grading/GradeWorkController.java
@@ -23,26 +23,25 @@
  */
 package org.wise.portal.presentation.web.controllers.teacher.grading;
 
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.acls.domain.BasePermission;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
-import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.project.impl.ProjectType;
 import org.wise.portal.domain.run.Run;
-import org.wise.portal.domain.user.User;
-import org.wise.portal.presentation.web.controllers.ControllerUtil;
 import org.wise.portal.service.run.RunService;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 /**
  * A Controller for Grading Student Work
@@ -61,18 +60,19 @@ public class GradeWorkController {
    * Invokes WISE4 or WISE5 Classroom Monitor based on the specified run
    * @param runId ID of the run
    */
-  @RequestMapping(value = "/teacher/run/manage/{runId}")
+  @GetMapping(value = "/teacher/run/manage/{runId}")
   protected ModelAndView launchClassroomMonitor(@PathVariable Long runId,
-      HttpServletRequest request, HttpServletResponse response) throws Exception {
+      HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws Exception {
     Run run = runService.retrieveById(runId);
     if (5 == run.getProject().getWiseVersion()) {
-      return this.launchClassroomMonitorWISE5(request, runId);
+      return this.launchClassroomMonitorWISE5(runId, authentication);
     } else if (4 == run.getProject().getWiseVersion()) {
       String action = null;
       String gradingType = "monitor";
       String getRevisions = null;
-      return this.launchClassroomMonitorWISE4(runId.toString(), action, gradingType, getRevisions,
-          request, response);
+      return this.launchClassroomMonitorWISE4(runId, action, gradingType, getRevisions,
+          authentication, request, response);
     }
     return null;
   }
@@ -80,25 +80,19 @@ public class GradeWorkController {
   /**
    * Handles launching classroom monitor for WISE5 runs
    * @param runId ID of the run
-   * @return
    * @throws Exception
    */
-  @RequestMapping(value = "/classroomMonitor/{runId}")
-  protected ModelAndView launchClassroomMonitorWISE5(HttpServletRequest request,
-      @PathVariable Long runId) throws Exception {
-    Run run = null;
-    try {
-      run = runService.retrieveById(runId);
-    } catch (ObjectNotFoundException e) {
-      e.printStackTrace();
+  @GetMapping(value = "/classroomMonitor/{runId}")
+  protected ModelAndView launchClassroomMonitorWISE5(@PathVariable Long runId,
+      Authentication authentication) throws Exception {
+    Run run = runService.retrieveById(runId);
+    if (runService.hasReadPermission(authentication, run)) {
+      return new ModelAndView(
+          "forward:/wise5/classroomMonitor/dist/index.html#!/run/" + runId
+              + "/project/");
+    } else {
+      return new ModelAndView("errors/accessdenied");
     }
-
-    User user = ControllerUtil.getSignedInUser();
-    if (runService.hasReadPermission(run, user)) {
-      return new ModelAndView("forward:/wise5/classroomMonitor/dist/index.html#!/run/" + runId +
-          "/project/");
-    }
-    return new ModelAndView("errors/accessdenied");
   }
 
   /**
@@ -116,34 +110,32 @@ public class GradeWorkController {
     "/teacher/grading/gradework.html",
     "/teacher/classroomMonitor/classroomMonitor"})
   protected ModelAndView launchClassroomMonitorWISE4(
-      @RequestParam("runId") String runId,
+      @RequestParam("runId") Long runId,
       @RequestParam(value = "action", required = false) String action,
       @RequestParam(value = "gradingType", required = false) String gradingType,
       @RequestParam(value = "getRevisions", required = false) String getRevisions,
+      Authentication authentication,
       HttpServletRequest request,
       HttpServletResponse response) throws Exception {
-    Run run = runService.retrieveById(new Long(runId));
-    if (action != null) {
-      if (action.equals("postMaxScore")) {
-        return handlePostMaxScore(request, response, run);
-      }
+    Run run = runService.retrieveById(runId);
+    if ("postMaxScore".equals(action)) {
+      return handlePostMaxScore(request, response, run);
     } else {
       ProjectType projectType = run.getProject().getProjectType();
       if (projectType.equals(ProjectType.LD)) {
-        User user = ControllerUtil.getSignedInUser();
-        if (runService.hasReadPermission(run, user)) {
+        if (runService.hasReadPermission(authentication, run)) {
           String contextPath = request.getContextPath();
           String getGradeWorkUrl = contextPath + "/vle/gradework.html";
-          String getGradingConfigUrl = contextPath + "/vleconfig?runId=" + run.getId().toString() +
+          String getGradingConfigUrl = contextPath + "/vleconfig?runId=" + runId.toString() +
               "&gradingType=" + gradingType + "&mode=grading&getRevisions=" + getRevisions;
           String getClassroomMonitorUrl = contextPath + "/vle/classroomMonitor.html";
-          String getClassroomMonitorConfigUrl = contextPath + "/vleconfig?runId=" + 
-              run.getId().toString() + "&gradingType=" + gradingType + 
+          String getClassroomMonitorConfigUrl = contextPath + "/vleconfig?runId=" +
+              run.getId().toString() + "&gradingType=" + gradingType +
               "&mode=grading&getRevisions=" + getRevisions;
-          if (runService.hasRunPermission(run, user, BasePermission.WRITE)) {
+          if (runService.hasWritePermission(authentication, run)) {
             getGradeWorkUrl += "?loadScriptsIndividually&permission=write";
             getClassroomMonitorUrl += "?loadScriptsIndividually&permission=write";
-          } else if (runService.hasRunPermission(run, user, BasePermission.READ)) {
+          } else {
             getGradeWorkUrl += "?loadScriptsIndividually&permission=read";
             getClassroomMonitorUrl += "?loadScriptsIndividually&permission=read";
           }

--- a/src/main/java/org/wise/portal/service/acl/AclService.java
+++ b/src/main/java/org/wise/portal/service/acl/AclService.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.acls.model.Permission;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.wise.portal.domain.user.User;
 
 /**
@@ -68,10 +69,10 @@ public interface AclService<T> extends PermissionEvaluator {
    * Gets a list of Permissions that the user has on the specified object.
    *
    * @param object The object to retrieve the permission on.
-   * @param user The <code>User</code> who is granted permissions on the object.
+   * @param userDetails The <code>UserDetails</code> who is granted permissions on the object.
    * @return A <code>Permission</code> containing the
    */
-  List<Permission> getPermissions(T object, User user);
+  List<Permission> getPermissions(T object, UserDetails userDetails);
 
   /**
    * Returns <code>boolean</code> true if the given <code>User</code> principle
@@ -79,4 +80,11 @@ public interface AclService<T> extends PermissionEvaluator {
    * fale otherwise.
    */
   boolean hasPermission(T object, Permission permission, User user);
+
+  /**
+   * Returns <code>boolean</code> true if the given <code>User</code> principle
+   * has the given <code>Permission</code> on the give <code>Object</code>, returns
+   * fale otherwise.
+   */
+  boolean hasPermission(T object, Permission permission, UserDetails userDetails);
 }

--- a/src/main/java/org/wise/portal/service/project/impl/ProjectServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/project/impl/ProjectServiceImpl.java
@@ -160,7 +160,7 @@ public class ProjectServiceImpl implements ProjectService {
   }
 
   private void removePermissions(Project project, User user) {
-    List<Permission> permissions = aclService.getPermissions(project, user);
+    List<Permission> permissions = aclService.getPermissions(project, user.getUserDetails());
     for (Permission permission : permissions) {
       aclService.removePermission(project, permission, user);
     }
@@ -277,7 +277,7 @@ public class ProjectServiceImpl implements ProjectService {
   }
 
   public String getSharedTeacherRole(Project project, User user) {
-    List<Permission> permissions = aclService.getPermissions(project, user);
+    List<Permission> permissions = aclService.getPermissions(project, user.getUserDetails());
     // for projects, a user can have at most one permission per project
     if (!permissions.isEmpty()) {
       if (permissions.contains(BasePermission.ADMINISTRATION)) {
@@ -575,7 +575,7 @@ public class ProjectServiceImpl implements ProjectService {
   }
 
   public List<Permission> getSharedTeacherPermissions(Project project, User sharedTeacher) {
-    return aclService.getPermissions(project, sharedTeacher);
+    return aclService.getPermissions(project, sharedTeacher.getUserDetails());
   }
 
   SharedOwner createNewSharedOwner(String username) {

--- a/src/main/java/org/wise/portal/service/run/RunService.java
+++ b/src/main/java/org/wise/portal/service/run/RunService.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.json.JSONObject;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.acls.model.Permission;
+import org.springframework.security.core.Authentication;
 import org.springframework.transaction.annotation.Transactional;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.announcement.Announcement;
@@ -351,6 +352,24 @@ public interface RunService {
   void setExtras(Run run, String extras) throws Exception;
 
   /**
+   * Returns <code>boolean</code> true iff the given <code>User</code> user has the
+   * read permission for the given <code>Run</code> run.
+   * @param authentication
+   * @param run
+   * @return boolean
+   */
+  public boolean hasReadPermission(Authentication authentication, Run run);
+
+  /**
+   * Returns <code>boolean</code> true iff the given <code>User</code> user has the
+   * write permission for the given <code>Run</code> run.
+   * @param authentication
+   * @param run
+   * @return boolean
+   */
+  public boolean hasWritePermission(Authentication authentication, Run run);
+
+  /**
    * Returns <code>boolean</code> true if the given <code>User</code> user has the
    * given <code>Permission</code> permission for the given <code>Run</code> run,
    * returns false otherwise.
@@ -360,16 +379,6 @@ public interface RunService {
    * @return boolean
    */
   boolean hasRunPermission(Run run, User user, Permission permission);
-
-  /**
-   * Returns <code>boolean</code> true if the given <code>User</code> user has the
-   * read <code>Permission</code> permission for the given <code>Run</code> run,
-   * returns false otherwise.
-   * @param run
-   * @param user
-   * @return boolean
-   */
-  boolean hasReadPermission(Run run, User user);
 
   /**
    * Returns <code>boolean</code> true if the run with the given

--- a/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
@@ -445,7 +445,8 @@ public class RunServiceImpl implements RunService {
         for (Permission runPermission : runPermissions) {
           aclService.removePermission(run, runPermission, user);
         }
-        List<Permission> projectPermissions = aclService.getPermissions(runProject, user.getUserDetails());
+        List<Permission> projectPermissions = aclService.getPermissions(runProject,
+            user.getUserDetails());
         for (Permission projectPermission : projectPermissions) {
           aclService.removePermission(runProject, projectPermission, user);
         }

--- a/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
@@ -39,6 +39,7 @@ import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.acls.domain.BasePermission;
 import org.springframework.security.acls.model.Permission;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.wise.portal.dao.ObjectNotFoundException;
@@ -49,6 +50,7 @@ import org.wise.portal.dao.user.UserDao;
 import org.wise.portal.domain.PeriodNotFoundException;
 import org.wise.portal.domain.Persistable;
 import org.wise.portal.domain.announcement.Announcement;
+import org.wise.portal.domain.authentication.MutableUserDetails;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.group.impl.PersistentGroup;
 import org.wise.portal.domain.impl.AddSharedTeacherParameters;
@@ -342,7 +344,7 @@ public class RunServiceImpl implements RunService {
   }
 
   private void removePermissions(Run run, User user) {
-    List<Permission> permissions = aclService.getPermissions(run, user);
+    List<Permission> permissions = aclService.getPermissions(run, user.getUserDetails());
     for (Permission permission : permissions) {
       aclService.removePermission(run, permission, user);
     }
@@ -439,11 +441,11 @@ public class RunServiceImpl implements RunService {
 
       try {
         List<Permission> runPermissions =
-          aclService.getPermissions(run, user);
+          aclService.getPermissions(run, user.getUserDetails());
         for (Permission runPermission : runPermissions) {
           aclService.removePermission(run, runPermission, user);
         }
-        List<Permission> projectPermissions = aclService.getPermissions(runProject, user);
+        List<Permission> projectPermissions = aclService.getPermissions(runProject, user.getUserDetails());
         for (Permission projectPermission : projectPermissions) {
           aclService.removePermission(runProject, projectPermission, user);
         }
@@ -455,7 +457,7 @@ public class RunServiceImpl implements RunService {
   }
 
   public String getSharedTeacherRole(Run run, User user) {
-    List<Permission> permissions = aclService.getPermissions(run, user);
+    List<Permission> permissions = aclService.getPermissions(run, user.getUserDetails());
     // for runs, a user can have at most one permission per run
     if (!permissions.isEmpty()) {
       Permission permission = permissions.get(0);
@@ -469,7 +471,7 @@ public class RunServiceImpl implements RunService {
   }
 
   public List<Permission> getSharedTeacherPermissions(Run run, User sharedTeacher) {
-    return aclService.getPermissions(run, sharedTeacher);
+    return aclService.getPermissions(run, sharedTeacher.getUserDetails());
   }
 
   private String generateUniqueRunCode(Locale locale) {
@@ -603,13 +605,19 @@ public class RunServiceImpl implements RunService {
     runDao.save(run);
   }
 
-  public boolean hasRunPermission(Run run, User user, Permission permission) {
-    return aclService.hasPermission(run, permission, user);
+  public boolean hasReadPermission(Authentication authentication, Run run) {
+    return ((MutableUserDetails) authentication.getPrincipal()).isAdminUser() ||
+        aclService.hasPermission(authentication, run, BasePermission.READ) ||
+        aclService.hasPermission(authentication, run, BasePermission.WRITE);
   }
 
-  public boolean hasReadPermission(Run run, User user) {
-    return user.isAdmin() || hasRunPermission(run, user, BasePermission.READ) ||
-        hasRunPermission(run, user, BasePermission.WRITE);
+  public boolean hasWritePermission(Authentication authentication, Run run) {
+    return ((MutableUserDetails) authentication.getPrincipal()).isAdminUser() ||
+        aclService.hasPermission(authentication, run, BasePermission.WRITE);
+  }
+
+  public boolean hasRunPermission(Run run, User user, Permission permission) {
+    return aclService.hasPermission(run, permission, user.getUserDetails());
   }
 
   public boolean canDecreaseMaxStudentsPerTeam(Long runId) {

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
@@ -43,7 +43,7 @@ export class TeacherRunListItemComponent implements OnInit {
     this.editLink = `${this.configService.getContextPath()}/author/authorproject.html?projectId=${this.run.project.id}`;
     if (this.run != null) {
       this.gradeAndManageLink = `${this.configService.getContextPath()}/teacher/run/manage/${this.run.id}#!/run/${this.run.id}/project/`;
-      this.manageStudentsLink = `${this.configService.getContextPath()}/teacher/run/manage/${ this.run.id }#!/run/${this.run.id}/manageStudents`;
+      this.manageStudentsLink = `${this.configService.getContextPath()}/teacher/run/manage/${this.run.id}#!/run/${this.run.id}/manageStudents`;
       if (this.run.isHighlighted) {
         this.animateDuration = '2s';
         this.animateDelay = '1s';

--- a/src/test/java/org/wise/portal/presentation/web/controllers/teacher/grading/GradeWorkControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/teacher/grading/GradeWorkControllerTest.java
@@ -78,28 +78,13 @@ public class GradeWorkControllerTest {
     TeacherUserDetails adminUserDetails = new TeacherUserDetails();
     adminUserDetails.setAuthorities(new GrantedAuthority[] { adminAuthority });
     Object credentials = null;
-    adminAuthentication = new TestingAuthenticationToken(adminUserDetails,
-        credentials);
+    adminAuthentication = new TestingAuthenticationToken(adminUserDetails, credentials);
   }
 
   @After
   public void tearDown() {
     runService = null;
     controller = null;
-  }
-
-  @Test
-  public void launchClassroomMonitorWISE5_AdminUser_ShouldReturnCMView() throws Exception {
-    Run run = new RunImpl();
-    Long runId = 1l;
-    run.setId(runId);
-    expect(runService.retrieveById(runId)).andReturn(run);
-    expect(runService.hasReadPermission(adminAuthentication, run)).andReturn(true);
-    replay(runService);
-    ModelAndView modelAndView = controller.launchClassroomMonitorWISE5(runId, adminAuthentication);
-    assertEquals("forward:/wise5/classroomMonitor/dist/index.html#!/run/" + runId + "/project/",
-        modelAndView.getViewName());
-    verify(runService);
   }
 
   @Test

--- a/src/test/java/org/wise/portal/presentation/web/controllers/teacher/grading/GradeWorkControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/teacher/grading/GradeWorkControllerTest.java
@@ -44,7 +44,6 @@ import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.run.impl.RunImpl;
 import org.wise.portal.service.authentication.UserDetailsService;
 import org.wise.portal.service.run.RunService;
-import org.wise.portal.service.student.StudentService;
 import org.wise.portal.service.user.UserService;
 
 /**
@@ -60,25 +59,22 @@ public class GradeWorkControllerTest {
   private UserService userService;
 
   @Mock
-  private StudentService studentService;
-
-  @Mock
   private RunService runService;
 
-  private Authentication adminAuthentication;
+  private Authentication teacherAuthentication;
 
   @Before
   public void setUp() {
-    initializeAdminAuthentication();
+    initializeTeacherAuthentication();
   }
 
-  protected void initializeAdminAuthentication() {
-    PersistentGrantedAuthority adminAuthority = new PersistentGrantedAuthority();
-    adminAuthority.setAuthority(UserDetailsService.ADMIN_ROLE);
-    TeacherUserDetails adminUserDetails = new TeacherUserDetails();
-    adminUserDetails.setAuthorities(new GrantedAuthority[] { adminAuthority });
+  protected void initializeTeacherAuthentication() {
+    PersistentGrantedAuthority teacherAuthority = new PersistentGrantedAuthority();
+    teacherAuthority.setAuthority(UserDetailsService.TEACHER_ROLE);
+    TeacherUserDetails teacherUserDetails = new TeacherUserDetails();
+    teacherUserDetails.setAuthorities(new GrantedAuthority[] { teacherAuthority });
     Object credentials = null;
-    adminAuthentication = new TestingAuthenticationToken(adminUserDetails, credentials);
+    teacherAuthentication = new TestingAuthenticationToken(teacherUserDetails, credentials);
   }
 
   @After
@@ -93,9 +89,10 @@ public class GradeWorkControllerTest {
     Long runId = 1l;
     run.setId(runId);
     expect(runService.retrieveById(runId)).andReturn(run);
-    expect(runService.hasReadPermission(adminAuthentication, run)).andReturn(true);
+    expect(runService.hasReadPermission(teacherAuthentication, run)).andReturn(true);
     replay(runService);
-    ModelAndView modelAndView = controller.launchClassroomMonitorWISE5(runId, adminAuthentication);
+    ModelAndView modelAndView =
+        controller.launchClassroomMonitorWISE5(runId, teacherAuthentication);
     assertEquals("forward:/wise5/classroomMonitor/dist/index.html#!/run/" + runId + "/project/",
         modelAndView.getViewName());
     verify(runService);
@@ -108,9 +105,10 @@ public class GradeWorkControllerTest {
     Long runId = 1l;
     run.setId(runId);
     expect(runService.retrieveById(runId)).andReturn(run);
-    expect(runService.hasReadPermission(adminAuthentication, run)).andReturn(false);
+    expect(runService.hasReadPermission(teacherAuthentication, run)).andReturn(false);
     replay(runService);
-    ModelAndView modelAndView = controller.launchClassroomMonitorWISE5(runId, adminAuthentication);
+    ModelAndView modelAndView =
+        controller.launchClassroomMonitorWISE5(runId, teacherAuthentication);
     assertEquals("errors/accessdenied", modelAndView.getViewName());
     verify(runService);
   }


### PR DESCRIPTION
We no longer use ControllerUtil.getSignedInUser() but instead use the Authentication object that Spring passes in to the method. This makes the code easier to read and test.

Test that the owner and shared owner of the run can launch the grading tool as before from the teacher homepage.

Closes #2141