### PR TITLE
Draw tool does not repopulate student drawing if they used the arrow line tool

### DIFF
--- a/src/main/webapp/wise5/lib/drawingTool/drawing-tool.js
+++ b/src/main/webapp/wise5/lib/drawingTool/drawing-tool.js
@@ -1096,9 +1096,14 @@ var $ = jQuery;
    * @param {Object} object Object to create an instance from
    * @return {fabric.Arrow} instance of fabric.Arrow
    */
-  fabric.Arrow.fromObject = function(object) {
-    var points = [object.x1, object.y1, object.x2, object.y2];
-    return new fabric.Arrow(points, object);
+  fabric.Arrow.fromObject = function(object, callback) {
+    function _callback(instance) {
+      delete instance.points;
+      callback && callback(instance);
+    };
+    var options = fabric.util.object.clone(object, true);
+    options.points = [object.x1, object.y1, object.x2, object.y2];
+    fabric.Object._fromObject('Arrow', options, _callback, 'points');
   };
 
 })(this);


### PR DESCRIPTION
1. Create a run with a Draw component
1. Launch the run as a student
1. Go to the Draw component step
1. Draw an arrow line (to use an arrow line, click on the line tool then select the arrow line)
1. Go to another step
1. Come back to the Draw component step
1. The arrow line should be re-populated (it previously would not re-populate)

Closes #2174