### PR TITLE
Draw Tool: Typing backspace when using the Text tool deletes the whole text element instead of deleting a character

### DIFF
--- a/src/main/webapp/wise5/lib/drawingTool/drawing-tool.js
+++ b/src/main/webapp/wise5/lib/drawingTool/drawing-tool.js
@@ -1838,8 +1838,11 @@ function DeleteTool(name, drawTool) {
   // Delete the selected object(s) with the backspace key.
   this.master.$element.on('keydown', function(e) {
     if (e.keyCode === 8) {
-      this.use();
-      e.preventDefault();
+      var activeObj = this.canvas.getActiveObject();
+      if (activeObj != null && activeObj.hoverCursor != 'text') {
+        this.use();
+        e.preventDefault();
+      }
     }
   }.bind(this));
 }


### PR DESCRIPTION
1. Preview a project with a Draw component
1. Go to the Draw component
1. Choose the Text tool
1. Create a Text element
1. Type some text into the Text element
1. Hit the backspace key
1. A character should be deleted as expected (the whole Text element used to be deleted before)

Closes #2178