### PR TITLE
Fixed issue showing unit info dialog from run listing

### DIFF
--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectMetadataImpl.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectMetadataImpl.java
@@ -292,7 +292,6 @@ public class ProjectMetadataImpl implements ProjectMetadata, Serializable {
       }
     }
 
-    //check that the features exists and is not null
     if (metadataJSON.has("features") && !metadataJSON.isNull("features")) {
       try {
         String features = metadataJSON.getString("features");
@@ -305,7 +304,6 @@ public class ProjectMetadataImpl implements ProjectMetadata, Serializable {
       }
     }
 
-    //check that the grade range exists and is not null
     if (metadataJSON.has("gradeRange") && !metadataJSON.isNull("gradeRange")) {
       try {
         String gradeRange = metadataJSON.getString("gradeRange");
@@ -318,7 +316,6 @@ public class ProjectMetadataImpl implements ProjectMetadata, Serializable {
       }
     }
 
-    //check that grades exists and is not null
     if (metadataJSON.has("grades") && !metadataJSON.isNull("grades")) {
       try {
         JSONArray grades = metadataJSON.getJSONArray("grades");
@@ -331,7 +328,6 @@ public class ProjectMetadataImpl implements ProjectMetadata, Serializable {
       }
     }
 
-    //check that the total time exists and is not null
     if (metadataJSON.has("totalTime")  && !metadataJSON.isNull("totalTime")) {
       try {
         String totalTime = metadataJSON.getString("totalTime");
@@ -418,7 +414,6 @@ public class ProjectMetadataImpl implements ProjectMetadata, Serializable {
       }
     }
 
-    //check that standardsAddressed exists and is not null
     if (metadataJSON.has("standardsAddressed") && !metadataJSON.isNull("standardsAddressed")) {
       try {
         JSONObject standardsAddressed = metadataJSON.getJSONObject("standardsAddressed");
@@ -431,7 +426,6 @@ public class ProjectMetadataImpl implements ProjectMetadata, Serializable {
       }
     }
 
-    //check that the keywords exists and is not null
     if (metadataJSON.has("keywords") && !metadataJSON.isNull("keywords")) {
       try {
         String keywords = metadataJSON.getString("keywords");
@@ -559,63 +553,32 @@ public class ProjectMetadataImpl implements ProjectMetadata, Serializable {
       String authorsString = metadata.getString("authors");
       if (authorsString != null && authorsString != "null") {
         JSONArray authorsJSON = new JSONArray(authorsString);
-
         metadata.put("authors", authorsJSON);
       } else {
         metadata.put("authors", new JSONArray());
       }
 
-      /*
-       * we will retrieve the grades JSON string and replace it with a JSON array
-       * so that the client does not need to parse the JSON string
-       */
       String gradesString = metadata.getString("grades");
-
-      // check if the field is null or "null"
       if (gradesString != null && gradesString != "null") {
-        // create the JSON object
         JSONArray gradesJSON = new JSONArray(gradesString);
-
-        // override the existing grades string with this JSON array
         metadata.put("grades", gradesJSON);
       } else {
-        // override the existing grades string with this empty JSON array
         metadata.put("grades", new JSONArray());
       }
 
-      /*
-       * we will retrieve the techReqs JSON string and replace it with a JSON Object
-       * so that the client does not need to parse the JSON string
-       */
       String techReqsString = metadata.getString("techReqs");
-
-      // check if the field is null or "null"
       if (techReqsString != null && techReqsString != "null") {
-        // create the JSON object
         JSONObject techReqsJSON = new JSONObject(techReqsString);
-
-        // override the existing techReqs string with this JSON object
         metadata.put("techReqs", techReqsJSON);
       } else {
-        // override the existing techReqs string with this empty JSON object
         metadata.put("techReqs", new JSONObject());
       }
 
-      /*
-       * we will retrieve the tools JSON string and replace it with a JSON Object
-       * so that the client does not need to parse the JSON string
-       */
       String toolsString = metadata.getString("tools");
-
-      // check if the field is null or "null"
       if (toolsString != null && toolsString != "null") {
-        // create the JSON object
         JSONObject toolsJSON = new JSONObject(toolsString);
-
-        // override the existing techReqs string with this JSON object
         metadata.put("tools", toolsJSON);
       } else {
-        // override the existing techReqs string with this empty JSON object
         metadata.put("tools", new JSONObject());
       }
 

--- a/src/main/webapp/site/src/app/domain/project.ts
+++ b/src/main/webapp/site/src/app/domain/project.ts
@@ -1,5 +1,5 @@
-import { Run } from "./run";
-import { User } from "../domain/user";
+import { Run } from './run';
+import { User } from '../domain/user';
 
 export class Project {
   id: number;
@@ -23,16 +23,18 @@ export class Project {
   static readonly EDIT_PERMISSION: number = 2;
 
   constructor(jsonObject: any = {}) {
-    for (let key of Object.keys(jsonObject)) {
+    for (const key of Object.keys(jsonObject)) {
       const value = jsonObject[key];
-      if (key == "owner") {
+      if (key === 'owner') {
         this[key] = new User(value);
-      } else if (key == "sharedOwners") {
+      } else if (key === 'sharedOwners') {
         const sharedOwners: User[] = [];
-        for (let sharedOwner of value) {
+        for (const sharedOwner of value) {
           sharedOwners.push(new User(sharedOwner));
         }
         this[key] = sharedOwners;
+      } else if (key === 'metadata') {
+        this[key] = this.parseMetadata(value);
       } else {
         this[key] = value;
       }
@@ -54,12 +56,12 @@ export class Project {
   }
 
   isOwner(userId) {
-    return this.owner.id == userId;
+    return this.owner.id === userId;
   }
 
   isSharedOwnerWithPermission(userId, permissionId) {
-    for (let sharedOwner of this.sharedOwners) {
-      if (sharedOwner.id == userId) {
+    for (const sharedOwner of this.sharedOwners) {
+      if (sharedOwner.id === userId) {
         return this.userHasPermission(sharedOwner, permissionId);
       }
     }
@@ -68,5 +70,21 @@ export class Project {
 
   userHasPermission(user: User, permission: number) {
     return user.permissions.includes(permission);
+  }
+
+  parseMetadata(metadata) {
+    if (typeof metadata.authors === 'string') {
+      metadata.authors = JSON.parse(metadata.authors);
+    }
+    if (typeof metadata.grades === 'string') {
+      metadata.grades = JSON.parse(metadata.grades);
+    }
+    if (typeof metadata.parentProjects === 'string') {
+      metadata.parentProjects = JSON.parse(metadata.parentProjects);
+    }
+    if (typeof metadata.standardsAddressed === 'string') {
+      metadata.standardsAddressed = JSON.parse(metadata.standardsAddressed);
+    }
+    return metadata;
   }
 }


### PR DESCRIPTION
This fixes the issue where unit info was not viewable from the teacher run listing item menu. 

To verify,
1. Log in as a teacher.
1. For a run in your Class Schedule, select "Unit Info" from the run menu.

The info dialog should appear.

#2190