### PR TITLE
Refactored AT deleteComponent() and deleteTransition()

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "compile-sass": "node ./node_modules/gulp/bin/gulp.js compile-sass",
     "test": "node ./node_modules/karma/bin/karma start src/main/webapp/wise5/karma.conf.js --single-run --browsers ChromeHeadlessNoSandbox",
     "test-site": "ng test site --karma-config src/main/webapp/site/karma.conf.js --browsers ChromeHeadlessNoSandbox --watch=false",
-    "test-wise5-watch": "node ./node_modules/karma/bin/karma start src/main/webapp/wise5/karma.conf.js --color --browsers ChromeHeadlessNoSandbox",
+    "test-watch": "node ./node_modules/karma/bin/karma start src/main/webapp/wise5/karma.conf.js --color --browsers ChromeHeadlessNoSandbox",
     "test-e2e-comment": "test-e2e assumes wise is already running.",
     "test-e2e": "node ./node_modules/protractor/bin/protractor src/main/webapp/wise5/test-e2e/conf.js",
     "ngx-extractor": "./node_modules/.bin/ngx-extractor -i \"src/main/webapp/site/**/*.ts\" -o src/main/webapp/site/src/messages.xlf"

--- a/src/main/webapp/wise5/authoringTool/authoringTool.js
+++ b/src/main/webapp/wise5/authoringTool/authoringTool.js
@@ -22,7 +22,6 @@ import AuthoringToolController from './authoringToolController';
 import AuthoringToolMainController from './main/authoringToolMainController';
 import AuthoringToolProjectService from './authoringToolProjectService';
 import AuthorNotebookController from './notebook/authorNotebookController';
-import bootstrap from 'bootstrap';
 import '../components/conceptMap/conceptMapAuthoringComponentModule';
 import ConfigService from '../services/configService';
 import CRaterService from '../services/cRaterService';
@@ -49,7 +48,6 @@ import ProjectAssetService from '../services/projectAssetService';
 import ProjectController from './project/projectController';
 import ProjectInfoController from './info/projectInfoController';
 import PlanningService from '../services/planningService';
-import ProjectService from '../services/projectService';
 import SessionService from '../services/sessionService';
 import SockJS from 'sockjs-client';
 import Stomp from "@stomp/stompjs"

--- a/src/main/webapp/wise5/authoringTool/authoringToolProjectService.js
+++ b/src/main/webapp/wise5/authoringTool/authoringToolProjectService.js
@@ -199,7 +199,6 @@ class AuthoringToolProjectService extends ProjectService {
    */
   replaceNode(nodeId, node) {
     this.setIdToNode(nodeId, node);
-    this.setIdToElement(nodeId, node);
     const nodes = this.getNodes();
     for (let n = 0; n < nodes.length; n++) {
       if (nodeId === nodes[n].id) {
@@ -401,7 +400,6 @@ class AuthoringToolProjectService extends ProjectService {
     if (nodeId === 'inactiveNodes' || nodeId === 'inactiveGroups') {
       this.addInactiveNodeInsertAfter(node);
       this.setIdToNode(node.id, node);
-      this.setIdToElement(node.id, node);
     } else {
       this.setIdToNode(node.id, node);
       if (this.isInactive(nodeId)) {
@@ -419,51 +417,41 @@ class AuthoringToolProjectService extends ProjectService {
    * @param node the new node
    * @param nodeId the node to add after
    */
-  createNodeAfter(node, nodeId) {
+  createNodeAfter(newNode, nodeId) {
     if (this.isInactive(nodeId)) {
-      this.addInactiveNodeInsertAfter(node, nodeId);
-      this.setIdToNode(node.id, node);
-      this.setIdToElement(node.id, node);
+      this.addInactiveNodeInsertAfter(newNode, nodeId);
+      this.setIdToNode(newNode.id, newNode);
     } else {
-      this.addNode(node);
-      this.setIdToNode(node.id, node);
-      this.insertNodeAfterInGroups(node.id, nodeId);
-      this.insertNodeAfterInTransitions(node, nodeId);
+      this.addNode(newNode);
+      this.setIdToNode(newNode.id, newNode);
+      this.insertNodeAfterInGroups(newNode.id, nodeId);
+      this.insertNodeAfterInTransitions(newNode, nodeId);
     }
 
-    if (this.isGroupNode(node.id)) {
-      /*
-       * we are creating a group node so we will update/create the
-       * transitions that traverse from the previous group to this group
-       */
-      // TODO geoffreykwan oldToGroupIds is declared here and below. Refactor
-      var oldToGroupIds = [];
-
-      const transitionsFromGroup = this.getTransitionsByFromNodeId(nodeId);
-      if (transitionsFromGroup != null) {
-        /*
-         * loop through all the transitions that come out of the previous group
-         * and get the node ids that the group transitions to
-         */
-        for (const transitionFromGroup of transitionsFromGroup) {
-          const toNodeId = transitionFromGroup.to;
-          if (toNodeId != null) {
-            oldToGroupIds.push(toNodeId);
-          }
-        }
-      }
-
-      const fromGroupId = nodeId;
-      // TODO geoffreykwan oldToGroupIds is declared here and above. Refactor
-      var oldToGroupIds = oldToGroupIds;
-      const newToGroupId = node.id;
-
-      /*
-       * make the transitions point to the new group and make the new
-       * group transition to the old group
-       */
-      this.updateTransitionsForInsertingGroup(fromGroupId, oldToGroupIds, newToGroupId);
+    if (this.isGroupNode(newNode.id)) {
+      this.createNodeAfterUpdateGroupTransitions(newNode, nodeId);
     }
+  }
+
+  /**
+   * Create/update the transitions that traverse from the previous group to the new group
+   */
+  createNodeAfterUpdateGroupTransitions(newGroupNode, nodeId) {
+     const oldToGroupIds = [];
+     const transitionsFromGroup = this.getTransitionsByFromNodeId(nodeId);
+     if (transitionsFromGroup != null) {
+       for (const transitionFromGroup of transitionsFromGroup) {
+         const toNodeId = transitionFromGroup.to;
+         if (toNodeId != null) {
+           oldToGroupIds.push(toNodeId);
+         }
+       }
+     }
+     const fromGroupId = nodeId;
+     const newToGroupId = newGroupNode.id;
+
+     // make the transitions point to the new group and the new group transition to the old group
+     this.updateTransitionsForInsertingGroup(fromGroupId, oldToGroupIds, newToGroupId);
   }
 
   /**
@@ -548,36 +536,17 @@ class AuthoringToolProjectService extends ProjectService {
   /**
    * Get the node id that comes after a given node id
    * @param nodeId get the node id that comes after this node id
-   * @param the node id that comes after the one that is passed in as a parameter
+   * @return the node id that comes after the one that is passed in as a parameter, or null
+   * if this is the last node in the sequence
    */
   getNodeIdAfter(nodeId) {
-    let nodeIdAfter = null;
-    // get an array of ordered items. each item represents a node
     const orderedItems = this.$filter('orderBy')(this.$filter('toArray')(this.idToOrder), 'order');
-    if (orderedItems != null) {
-      let foundNodeId = false;
-      for (let item of orderedItems) {
-        if (item != null) {
-          const tempNodeId = item.$key;
-
-          // check if we have found the node id that was passed in as a parameter
-          if (foundNodeId) {
-            /*
-             * we have previously found the node id that was passed in which means
-             * the current temp node id is the one that comes after it
-             */
-            nodeIdAfter = tempNodeId;
-            break;
-          } else {
-            if (nodeId == tempNodeId) {
-              // we have found the node id that was passed in as a parameter
-              foundNodeId = true;
-            }
-          }
-        }
+    for (let i = 0; i < orderedItems.length - 1; i++) {
+      if (orderedItems[i].$key === nodeId) {
+        return orderedItems[i + 1].$key;
       }
     }
-    return nodeIdAfter;
+    return null;
   }
 
   /**

--- a/src/main/webapp/wise5/authoringTool/authoringToolProjectService.js
+++ b/src/main/webapp/wise5/authoringTool/authoringToolProjectService.js
@@ -427,7 +427,6 @@ class AuthoringToolProjectService extends ProjectService {
       this.insertNodeAfterInGroups(newNode.id, nodeId);
       this.insertNodeAfterInTransitions(newNode, nodeId);
     }
-
     if (this.isGroupNode(newNode.id)) {
       this.createNodeAfterUpdateGroupTransitions(newNode, nodeId);
     }
@@ -777,6 +776,37 @@ class AuthoringToolProjectService extends ProjectService {
       }
       return newComponents;
     });
+  }
+
+  /**
+   * Delete a component from a node
+   * @param nodeId the node id containing the node
+   * @param componentId the component id
+   */
+  deleteComponent(nodeId, componentId) {
+    const node = this.getNodeById(nodeId);
+    const components = node.components;
+    for (let c = 0; c < components.length; c++) {
+      if (components[c].id === componentId) {
+        components.splice(c, 1);
+        break;
+      }
+    }
+  }
+
+  deleteTransition(node, transition) {
+    const nodeTransitions = node.transitionLogic.transitions;
+    let index = nodeTransitions.indexOf(transition);
+    if (index > -1) {
+      nodeTransitions.splice(index, 1);
+    }
+    if (nodeTransitions.length <= 1) {
+      // these settings only apply when there are multiple transitions
+      node.transitionLogic.howToChooseAmongAvailablePaths = null;
+      node.transitionLogic.whenToChoosePath = null;
+      node.transitionLogic.canChangePath = null;
+      node.transitionLogic.maxPathsVisitable = null;
+    }
   }
 
   /**

--- a/src/main/webapp/wise5/authoringTool/authoringToolProjectService.js
+++ b/src/main/webapp/wise5/authoringTool/authoringToolProjectService.js
@@ -796,7 +796,7 @@ class AuthoringToolProjectService extends ProjectService {
 
   deleteTransition(node, transition) {
     const nodeTransitions = node.transitionLogic.transitions;
-    let index = nodeTransitions.indexOf(transition);
+    const index = nodeTransitions.indexOf(transition);
     if (index > -1) {
       nodeTransitions.splice(index, 1);
     }

--- a/src/main/webapp/wise5/authoringTool/node/nodeAuthoringController.js
+++ b/src/main/webapp/wise5/authoringTool/node/nodeAuthoringController.js
@@ -679,27 +679,11 @@ class NodeAuthoringController {
    * @param transition the transition to delete
    */
   deleteTransition(transition) {
-    let stepTitle = '';
-    if (transition != null) {
-      stepTitle = this.ProjectService.getNodePositionAndTitleByNodeId(transition.to);
-    }
-    const answer = confirm(this.$translate('areYouSureYouWantToDeleteThisPath', { stepTitle: stepTitle }));
+    const stepTitle = this.ProjectService.getNodePositionAndTitleByNodeId(transition.to);
+    const answer = confirm(this.$translate('areYouSureYouWantToDeleteThisPath',
+        { stepTitle: stepTitle }));
     if (answer) {
-      let nodeTransitions = this.node.transitionLogic.transitions;
-      let index = nodeTransitions.indexOf(transition);
-      if (index > -1) {
-        nodeTransitions.splice(index, 1);
-      }
-      if (nodeTransitions.length <= 1) {
-        /*
-         * there is zero or one transition so we will clear the parameters
-         * below since they only apply when there are multiple transitions
-         */
-        this.node.transitionLogic.howToChooseAmongAvailablePaths = null;
-        this.node.transitionLogic.whenToChoosePath = null;
-        this.node.transitionLogic.canChangePath = null;
-        this.node.transitionLogic.maxPathsVisitable = null;
-      }
+      this.ProjectService.deleteTransition(this.node, transition);
       this.authoringViewNodeChanged();
     }
   }

--- a/src/main/webapp/wise5/authoringTool/node/nodeAuthoringController.js
+++ b/src/main/webapp/wise5/authoringTool/node/nodeAuthoringController.js
@@ -1787,28 +1787,23 @@ class NodeAuthoringController {
    * @param branch the branch object
    */
   removeBranchPath(branch) {
-    if (branch != null) {
-      let checkedItemsInBranchPath = branch.checkedItemsInBranchPath;
-      if (checkedItemsInBranchPath != null) {
-        for (let checkedItem of checkedItemsInBranchPath) {
-          if (checkedItem != null) {
-            let nodeId = checkedItem.$key;
-            this.ProjectService.removeBranchPathTakenNodeConstraintsIfAny(nodeId);
-
-            /*
-             * update the transition of the step to point to the next step
-             * in the project. this may be different than the next step
-             * if it was still in the branch path.
-             */
-            let nodeIdAfter = this.ProjectService.getNodeIdAfter(nodeId);
-            this.ProjectService.setTransition(nodeId, nodeIdAfter);
-          }
-        }
+    const checkedItemsInBranchPath = branch.checkedItemsInBranchPath;
+    if (checkedItemsInBranchPath != null) {
+      for (const checkedItem of checkedItemsInBranchPath) {
+        const nodeId = checkedItem.$key;
+        this.ProjectService.removeBranchPathTakenNodeConstraintsIfAny(nodeId);
+        /*
+          * update the transition of the step to point to the next step
+          * in the project. this may be different than the next step
+          * if it was still in the branch path.
+          */
+        const nodeIdAfter = this.ProjectService.getNodeIdAfter(nodeId);
+        this.ProjectService.setTransition(nodeId, nodeIdAfter);
       }
-      let branchPathIndex = this.createBranchBranches.indexOf(branch);
-      this.createBranchBranches.splice(branchPathIndex, 1);
-      this.node.transitionLogic.transitions.splice(branchPathIndex, 1);
     }
+    const branchPathIndex = this.createBranchBranches.indexOf(branch);
+    this.createBranchBranches.splice(branchPathIndex, 1);
+    this.node.transitionLogic.transitions.splice(branchPathIndex, 1);
   }
 
   summernoteRubricHTMLChanged() {

--- a/src/main/webapp/wise5/authoringTool/project/projectController.js
+++ b/src/main/webapp/wise5/authoringTool/project/projectController.js
@@ -90,12 +90,6 @@ class ProjectController {
     this.summernoteRubricId = 'summernoteRubric_' + this.projectId;
     this.summernoteRubricHTML = this.ProjectService
         .replaceAssetPaths(this.ProjectService.getProjectRubric());
-
-    let insertAssetToolTipText = this.$translate('INSERT_ASSET');
-    let insertAssetButton = this.UtilService.createInsertAssetButton(this,
-          this.projectId, null, null, 'rubric', insertAssetToolTipText);
-
-    // options to display in the summernote tool
     this.summernoteRubricOptions = {
       toolbar: [
         ['style', ['style']],
@@ -112,7 +106,8 @@ class ProjectController {
       height: 300,
       disableDragAndDrop: true,
       buttons: {
-        'insertAssetButton': insertAssetButton
+        'insertAssetButton': this.UtilService.createInsertAssetButton(this, this.projectId, null,
+            null, 'rubric', this.$translate('INSERT_ASSET'))
       }
     };
 

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorProjectService.js
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorProjectService.js
@@ -5,7 +5,7 @@ class ClassroomMonitorProjectService extends ProjectService {
   constructor($filter, $http, $injector, $q, $rootScope, ConfigService, UtilService) {
     super($filter, $http, $injector, $q, $rootScope, ConfigService, UtilService);
   }
-  
+
   /**
    * Get the node ids and component ids in a node
    * @param nodeId get the node ids and component ids in this node
@@ -13,8 +13,8 @@ class ClassroomMonitorProjectService extends ProjectService {
    */
   getNodeIdsAndComponentIds(nodeId) {
     const nodeIdAndComponentIds = [];
-    const nodeContent = this.getNodeContentByNodeId(nodeId);
-    for (const component of nodeContent.components) {
+    const node = this.getNodeById(nodeId);
+    for (const component of node.components) {
       const nodeIdAndComponentId = {
         nodeId: nodeId,
         componentId: component.id

--- a/src/main/webapp/wise5/services/planningService.js
+++ b/src/main/webapp/wise5/services/planningService.js
@@ -73,7 +73,6 @@ class PlanningService {
   addPlanningNodeInstanceInside(nodeIdToInsertInside, planningNodeInstance) {
     const planningNodeInstanceNodeId = planningNodeInstance.id;
     this.ProjectService.setIdToNode(planningNodeInstanceNodeId, planningNodeInstance);
-    this.ProjectService.setIdToElement(planningNodeInstanceNodeId, planningNodeInstance);
     this.ProjectService.addNode(planningNodeInstance);
     this.ProjectService.insertNodeInsideOnlyUpdateTransitions(planningNodeInstanceNodeId, nodeIdToInsertInside);
     this.ProjectService.insertNodeInsideInGroups(planningNodeInstanceNodeId, nodeIdToInsertInside);
@@ -89,7 +88,6 @@ class PlanningService {
   addPlanningNodeInstanceAfter(nodeIdToInsertAfter, planningNodeInstance) {
     const planningNodeInstanceNodeId = planningNodeInstance.id;
     this.ProjectService.setIdToNode(planningNodeInstanceNodeId, planningNodeInstance);
-    this.ProjectService.setIdToElement(planningNodeInstanceNodeId, planningNodeInstance);
     this.ProjectService.addNode(planningNodeInstance);
     this.ProjectService.insertNodeAfterInTransitions(planningNodeInstance, nodeIdToInsertAfter);
     this.ProjectService.insertNodeAfterInGroups(planningNodeInstanceNodeId, nodeIdToInsertAfter);

--- a/src/main/webapp/wise5/services/projectService.js
+++ b/src/main/webapp/wise5/services/projectService.js
@@ -16,7 +16,6 @@ class ProjectService {
     this.inactiveGroupNodes = [];
     this.groupNodes = [];
     this.idToNode = {};
-    this.idToElement = {};
     this.metadata = {};
     this.activeConstraints = [];
     this.rootNode = null;
@@ -59,7 +58,6 @@ class ProjectService {
     this.inactiveGroupNodes = [];
     this.groupNodes = [];
     this.idToNode = {};
-    this.idToElement = {};
     this.metadata = {};
     this.activeConstraints = [];
     this.rootNode = null;
@@ -203,7 +201,6 @@ class ProjectService {
       }
 
       this.setIdToNode(nodeId, node);
-      this.setIdToElement(nodeId, node);
       this.addNode(node);
 
       if (nodeType === 'group') {
@@ -249,7 +246,6 @@ class ProjectService {
   loadPlanningNodes(planningNodes) {
     for (const planningNode of planningNodes) {
       this.setIdToNode(planningNode.id, planningNode);
-      this.setIdToElement(planningNode.id, planningNode);
       // TODO: may need to add more function calls here to add the planning
     }
   }
@@ -462,10 +458,6 @@ class ProjectService {
 
   setIdToNode(id, element) {
     this.idToNode[id] = element;
-  }
-
-  setIdToElement(id, element) {
-    this.idToElement[id] = element;
   }
 
   /**
@@ -2167,39 +2159,22 @@ class ProjectService {
     return [];
   };
 
-
-  // TODO: how is this different from straight-up calling getNodeById?
-  getNodeContentByNodeId(nodeId) {
-    if (nodeId != null) {
-      const node = this.getNodeById(nodeId);
-      if (node != null) {
-        return node;
-      }
-    }
-    return null;
-  };
-
   /**
-   * Insert the node after the given node id in the group's
-   * array of children ids
+   * Insert the node after the given node id in the group's array of children ids
    * @param nodeIdToInsert the node id we want to insert
    * @param nodeIdToInsertAfter the node id we want to insert after
    */
   insertNodeAfterInGroups(nodeIdToInsert, nodeIdToInsertAfter) {
     const groupNodes = this.getGroupNodes();
     if (groupNodes != null) {
-      for (let group of groupNodes) {
-        if (group != null) {
-          this.insertNodeAfterInGroup(group, nodeIdToInsert, nodeIdToInsertAfter);
-        }
+      for (const group of groupNodes) {
+        this.insertNodeAfterInGroup(group, nodeIdToInsert, nodeIdToInsertAfter);
       }
     }
     const inactiveGroupNodes = this.getInactiveGroupNodes();
     if (inactiveGroupNodes != null) {
-      for (let inactiveGroup of inactiveGroupNodes) {
-        if (inactiveGroup != null) {
-          this.insertNodeAfterInGroup(inactiveGroup, nodeIdToInsert, nodeIdToInsertAfter);
-        }
+      for (const inactiveGroup of inactiveGroupNodes) {
+        this.insertNodeAfterInGroup(inactiveGroup, nodeIdToInsert, nodeIdToInsertAfter);
       }
     }
   }
@@ -4364,7 +4339,6 @@ class ProjectService {
   loadInactiveNodes(nodes) {
     for (const node of nodes) {
       this.setIdToNode(node.id, node);
-      this.setIdToElement(node.id, node);
       if (node.type === 'group') {
         this.inactiveGroupNodes.push(node);
       } else {
@@ -4376,7 +4350,6 @@ class ProjectService {
   loadConstraints(constraints) {
     for (const constraint of constraints) {
       constraint.active = true;
-      this.setIdToElement(constraint.id, constraint);
     }
   }
 
@@ -4576,10 +4549,10 @@ class ProjectService {
    * @return whether the node generates work
    */
   nodeHasWork(nodeId) {
-    const nodeContent = this.getNodeContentByNodeId(nodeId);
+    const node = this.getNodeById(nodeId);
     // TODO: remove need for component null check by ensuring that node always has components
-    if (nodeContent.components != null) {
-      for (const component of nodeContent.components) {
+    if (node.components != null) {
+      for (const component of node.components) {
         if (this.componentHasWork(component)) {
           return true;
         }
@@ -5326,14 +5299,13 @@ class ProjectService {
    */
   getNumberOfRubricsByNodeId(nodeId) {
     let numRubrics = 0;
-    let nodeContent = this.getNodeContentByNodeId(nodeId);
-    if (nodeContent) {
-      let nodeRubric = nodeContent.rubric;
+    const node = this.getNodeById(nodeId);
+    if (node) {
+      const nodeRubric = node.rubric;
       if (nodeRubric != null && nodeRubric != '') {
         numRubrics++;
       }
-
-      let components = nodeContent.components;
+      const components = node.components;
       if (components && components.length) {
         for (let component of components) {
           if (component) {

--- a/src/main/webapp/wise5/services/projectService.js
+++ b/src/main/webapp/wise5/services/projectService.js
@@ -3425,24 +3425,6 @@ class ProjectService {
   }
 
   /**
-   * Delete the component
-   * @param nodeId the node id
-   * @param componentId the component id
-   */
-  deleteComponent(nodeId, componentId) {
-    // TODO refactor and move to authoringToolProjectService
-    const node = this.getNodeById(nodeId);
-    const components = node.components;
-    for (let c = 0; c < components.length; c++) {
-      const component = components[c];
-      if (component.id === componentId) {
-        components.splice(c, 1);
-        break;
-      }
-    }
-  }
-
-  /**
    * TODO: Deprecated, should be removed; replaced by getMaxScoreForWorkgroupId in
    * StudentStatusService
    * Get the max score for the project. If the project contains branches, we
@@ -3698,11 +3680,8 @@ class ProjectService {
 
         const scores = params.scores;
         if (scores != null) {
-          // get the required score
           scoresString = scores.join(', ');
         }
-
-        // generate the message
         message += this.$translate('obtainAScoreOfXOnNodeTitle',
             { score: scoresString, nodeTitle: nodeTitle });
       } else if (name === 'choiceChosen') {
@@ -3826,22 +3805,6 @@ class ProjectService {
    */
   getGroupStartId(nodeId) {
     return this.getNodeById(nodeId).startId;
-  }
-
-  /**
-   * Get the start id of the node's parent group
-   * @param nodeId we will get the parent of this node and then look
-   * for the start id of the parent
-   * @returns the start id of the parent
-   */
-  getParentGroupStartId(nodeId) {
-    if (nodeId != null) {
-      const parentGroup = this.getParentGroup(nodeId);
-      if (parentGroup != null) {
-        return parentGroup.startId;
-      }
-    }
-    return null;
   }
 
   /**

--- a/src/main/webapp/wise5/test-unit/services/authoringToolProjectService.spec.js
+++ b/src/main/webapp/wise5/test-unit/services/authoringToolProjectService.spec.js
@@ -82,9 +82,35 @@ describe('AuthoringToolProjectService Unit Test', () => {
       ProjectService.setProject(demoProjectJSON);
       expect(ProjectService.isNodeIdUsed("nodedoesnotexist")).toEqual(false);
     });
+    testDeleteComponent();
+    testDeleteTransition();
     testGetNodeIdAfter();
     testCreateNodeAfter();
   });
+
+  function testDeleteComponent() {
+    describe('deleteComponent', () => {
+      it('should delete the component from the node', () => {
+        ProjectService.setProject(demoProjectJSON);
+        expect(ProjectService.getComponentByNodeIdAndComponentId('node1', 'zh4h1urdys')).not
+            .toBeNull();
+        ProjectService.deleteComponent('node1', 'zh4h1urdys');
+        expect(ProjectService.getComponentByNodeIdAndComponentId('node1', 'zh4h1urdys')).toBeNull();
+      });
+    });
+  }
+
+  function testDeleteTransition() {
+    describe('deleteTransition', () => {
+      it('should delete existing transition from the node', () => {
+        ProjectService.setProject(demoProjectJSON);
+        const node1 = ProjectService.getNodeById('node1');
+        expect(ProjectService.nodeHasTransitionToNodeId(node1, 'node2')).toBeTruthy();
+        ProjectService.deleteTransition(node1, node1.transitionLogic.transitions[0]);
+        expect(ProjectService.nodeHasTransitionToNodeId(node1, 'node2')).toBeFalsy();
+      });
+    });
+  }
 
   function testGetNodeIdAfter() {
     describe('getNodeIdAfter', () => {

--- a/src/main/webapp/wise5/test-unit/services/authoringToolProjectService.spec.js
+++ b/src/main/webapp/wise5/test-unit/services/authoringToolProjectService.spec.js
@@ -82,5 +82,39 @@ describe('AuthoringToolProjectService Unit Test', () => {
       ProjectService.setProject(demoProjectJSON);
       expect(ProjectService.isNodeIdUsed("nodedoesnotexist")).toEqual(false);
     });
+    testGetNodeIdAfter();
+    testCreateNodeAfter();
   });
+
+  function testGetNodeIdAfter() {
+    describe('getNodeIdAfter', () => {
+      it('should return the next node in the sequence', () => {
+        ProjectService.setProject(demoProjectJSON);
+        expect(ProjectService.getNodeIdAfter('node12')).toEqual('node13');
+        expect(ProjectService.getNodeIdAfter('node19')).toEqual('group2');
+      });
+      it('should return null if the node is last', () => {
+        ProjectService.setProject(demoProjectJSON);
+        expect(ProjectService.getNodeIdAfter('node39')).toBeNull();
+      });
+    });
+  }
+
+  function testCreateNodeAfter() {
+    describe('createNodeAfter', () => {
+      it('should put a new step node after a step node', () => {
+        const newNode = {
+          id: 'node1000',
+          type: 'node'
+        };
+        ProjectService.setProject(demoProjectJSON);
+        ProjectService.createNodeAfter(newNode, 'node19');
+        ProjectService.parseProject();
+        expect(ProjectService.idToNode[newNode.id]).toEqual(newNode);
+        expect(newNode.transitionLogic.transitions[0].to).toEqual('node20');
+        expect(ProjectService.getNodeIdAfter('node19')).toEqual('node1000');
+      });
+    });
+  }
 });
+

--- a/src/main/webapp/wise5/test-unit/services/projectService.spec.js
+++ b/src/main/webapp/wise5/test-unit/services/projectService.spec.js
@@ -164,10 +164,6 @@ describe('ProjectService Unit Test', () => {
     // TODO: add test for ProjectService.pathsEqual()
 
     // TODO: add test for ProjectService.getBranchPathsByNodeId()
-
-
-    // TODO: add test for ProjectService.getNodeContentByNodeId()
-
     // TODO: add test for ProjectService.replaceComponent()
     // TODO: add test for ProjectService.createGroup()
     // TODO: add test for ProjectService.createNode()


### PR DESCRIPTION
- The deleteComponent function was moved from ProjectService to ATProjectService.
- Also wrote tests and removed unused getParentGroupStartId() function.

In the AT, make sure that you can delete components and transitions (node -> advanced -> edit path).