### PR TITLE
Added node icons to author project home view

### DIFF
--- a/src/main/webapp/wise5/authoringTool/project/project.html
+++ b/src/main/webapp/wise5/authoringTool/project/project.html
@@ -409,7 +409,10 @@
                   </md-checkbox>
                 </div>
                 <div layout='row' class='projectItemTitleDiv' ng-click='projectController.insertGroupMode == true || projectController.insertNodeMode == true || projectController.nodeClicked(item.$key)'>
-                  <div layout='row'>
+                  <div layout='row' layout-align="start center">
+                    <node-icon node-id="::item.$key" 
+                               size="18" 
+                               ng-if='::item.order!==0'></node-icon>&nbsp;
                     <h6 style='display:inline; cursor:pointer;'
                       ng-if='::item.order!==0 && projectController.isGroupNode(item.$key)'>
                       {{::projectController.getNodePositionById(item.$key)}}: {{::projectController.getNodeTitleByNodeId(item.$key)}}
@@ -470,7 +473,8 @@
                   <div layout='row'
                        class='projectItemTitleDiv'
                        ng-click='projectController.insertGroupMode == true || projectController.insertNodeMode == true || projectController.nodeClicked(inactiveNode.id)'>
-                    <div layout='row'>
+                    <div layout='row' layout-align="start center">
+                      <node-icon node-id="::inactiveNode.id" size="18"></node-icon>&nbsp;
                       <h6
                         style='display:inline; cursor:pointer;'>
                         {{::projectController.getNodeTitleByNodeId(inactiveNode.id)}}
@@ -509,9 +513,9 @@
                     <div layout='row'
                          class='projectItemTitleDiv'
                          ng-click='projectController.insertGroupMode == true || projectController.insertNodeMode == true || projectController.nodeClicked(inactiveChildId)'>
-                      <div layout='row'>
-                        <p
-                          style='display:inline; cursor:pointer;'>
+                      <div layout='row' layout-align="start center">
+                        <node-icon node-id="::inactiveChildId" size="18"></node-icon>&nbsp;
+                        <p style='display:inline; cursor:pointer;'>
                           {{::projectController.getNodeTitleByNodeId(inactiveChildId)}}
                         </p>
                       </div>
@@ -558,7 +562,8 @@
                     </md-checkbox>
                   </div>
                   <div layout='row' class='projectItemTitleDiv' ng-click='projectController.insertGroupMode == true || projectController.insertNodeMode == true || projectController.nodeClicked(inactiveNode.id)'>
-                    <div layout='row'>
+                    <div layout='row' layout-align="start center">
+                      <node-icon node-id="::inactiveNode.id" size="18"></node-icon>&nbsp;
                       <p style='display:inline; cursor:pointer;'>
                         {{::projectController.getNodeTitleByNodeId(inactiveNode.id)}}
                       </p>


### PR DESCRIPTION
To test:
- Login in as a teacher and open unit in authoring tool.
- Verify that node icons appear next to the checkbox for each node.

You can add the following to the end of a node's json to add an custom icon:
```
"icons": {
  "default": {
    "color": "#2196F3",
    "type": "font",
    "fontSet": "material-icons",
    "fontName": "chrome_reader_mode"
  }
}
```

Resolves #2213. 

