### PR TITLE
Fixed public notebook

### DIFF
--- a/src/main/webapp/wise5/components/componentController.js
+++ b/src/main/webapp/wise5/components/componentController.js
@@ -1207,6 +1207,15 @@ class ComponentController {
   updateLatestCommentAnnotation(annotation) {
     this.latestAnnotations.comment = annotation;
   }
+
+  registerNotebookItemChosenListener() {
+    this.$scope.$on('notebookItemChosen', (event, {requester, notebookItem}) => {
+      if (requester === `${this.nodeId}-${this.componentId}`) {
+        const studentWorkId = notebookItem.content.studentWorkIds[0];
+        this.importWorkByStudentWorkId(studentWorkId);
+      }
+    });
+  }
 }
 
 ComponentController.$inject = [];

--- a/src/main/webapp/wise5/components/draw/drawController.js
+++ b/src/main/webapp/wise5/components/draw/drawController.js
@@ -89,14 +89,7 @@ class DrawController extends ComponentController {
       }
     });
 
-    this.$scope.$on('notebookItemChosen', (event, args) => {
-      if (args.requester == this.nodeId + '-' + this.componentId) {
-        const notebookItem = args.notebookItem;
-        const studentWorkId = notebookItem.content.studentWorkIds[0];
-        this.importWorkByStudentWorkId(studentWorkId);
-      }
-    });
-
+    this.registerNotebookItemChosenListener();
     this.broadcastDoneRenderingComponent();
   }
 

--- a/src/main/webapp/wise5/components/openResponse/openResponseController.js
+++ b/src/main/webapp/wise5/components/openResponse/openResponseController.js
@@ -214,13 +214,7 @@ class OpenResponseController extends ComponentController {
 
     }.bind(this));
 
-    this.$scope.$on('notebookItemChosen', (event, args) => {
-      if (args.requester == this.nodeId + '-' + this.componentId) {
-        const notebookItem = args.notebookItem;
-        const studentWorkId = notebookItem.content.studentWorkIds[0];
-        this.importWorkByStudentWorkId(studentWorkId);
-      }
-    });
+    this.registerNotebookItemChosenListener();
 
     // load script for this component, if any
     let script = this.componentContent.script;
@@ -277,7 +271,7 @@ class OpenResponseController extends ComponentController {
   }
 
   hasFeedback() {
-    return (this.componentContent.cRater.showFeedback || this.componentContent.cRater.showScore) 
+    return (this.componentContent.cRater.showFeedback || this.componentContent.cRater.showScore)
         && this.isCRaterEnabled() ;
   }
 

--- a/src/main/webapp/wise5/themes/default/notebook/notebook/notebook.js
+++ b/src/main/webapp/wise5/themes/default/notebook/notebook/notebook.js
@@ -94,7 +94,7 @@ class NotebookController {
     });
 
     this.notebook = this.NotebookService.getNotebookByWorkgroup(this.workgroupId);
-    this.publicNotebookItems = this.NotebookService.publicNotebookItemspublicNotebookItems;
+    this.publicNotebookItems = this.NotebookService.publicNotebookItems;
 
     // assume only 1 report for now
     this.reportId = this.config.itemTypes.report.notes[0].reportId;
@@ -230,7 +230,7 @@ const Notebook = {
                visible="$ctrl.reportVisible"
                workgroup-id="::$ctrl.workgroupId"
                on-collapse="$ctrl.insertMode=false"
-               on-set-insert-mode="$ctrl.setInsertMode(value, requester)"></notebook-report>               
+               on-set-insert-mode="$ctrl.setInsertMode(value, requester)"></notebook-report>
     </div>
     <notebook-notes ng-if="::$ctrl.config.enabled"
             notebook="$ctrl.notebook"

--- a/src/main/webapp/wise5/themes/default/notebook/notebookNotes/notebookNotes.js
+++ b/src/main/webapp/wise5/themes/default/notebook/notebookNotes/notebookNotes.js
@@ -13,7 +13,6 @@ class NotebookNotesController {
     this.groups = [];
     this.selectedTabIndex = 0;
     this.$scope = $scope;
-    this.publicNotebookItems = this.NotebookService.publicNotebookItems;
     this.groupNameToGroup = {};
   }
 
@@ -64,7 +63,7 @@ class NotebookNotesController {
     this.$rootScope.$on('publicNotebookItemsRetrieved', (event, args) => {
       for (let group of this.groups) {
         if (group.name !== 'private') {
-          group.items = this.publicNotebookItems[group.name];
+          group.items = this.NotebookService.publicNotebookItems[group.name];
         }
       }
     });
@@ -169,7 +168,6 @@ const NotebookNotes = {
     config: '<',
     insertMode: '<',
     notebook: '<',
-    publicNotebookItems: '<',
     notesVisible: '<',
     workgroupId: '<',
     onClose: '&',


### PR DESCRIPTION
Fixed saving, copying, and importing public notes.

How to verify:
1. Enable notebook for the project
2. Enable public notebook in the project by adding spaces to Project JSON as top-level field
```
...
"spaces": [
{
      "id": "public",
      "name": "Public Space",
      "isPublic": true,
      "isShowInNotebook": true
    }
    ],
...
```
3. In Match component, enable importing work as choices
4. As student A, post a public note. It can be text or drawing.
5. As student B, copy the public note. 

The public note should show up as a choice in the match component for student B. Student B should also be able to import a public student drawing into their own drawing canvas.