### PR TITLE
Fixed bug where inactive steps could not be deleted and added test

### DIFF
--- a/src/main/webapp/wise5/authoringTool/project/project.html
+++ b/src/main/webapp/wise5/authoringTool/project/project.html
@@ -146,7 +146,7 @@
               </md-button>
               <md-button id='moveButton' class='topButton md-raised md-primary'
                   ng-click='projectController.move()'
-                  ng-disabled='projectController.insertGroupMode || projectController.insertNodeMode'>
+                  ng-disabled='!projectController.hasSelectedNodes() || projectController.insertGroupMode || projectController.insertNodeMode'>
                 <md-icon>redo</md-icon>
                 <md-tooltip md-direction='top' class='projectButtonTooltip'>
                   {{ ::'move' | translate }}
@@ -154,15 +154,15 @@
               </md-button>
               <md-button id='copyButton' class='topButton md-raised md-primary'
                   ng-click='projectController.copy()'
-                  ng-disabled='projectController.insertGroupMode || projectController.insertNodeMode'>
+                  ng-disabled='!projectController.hasSelectedNodes() || projectController.insertGroupMode || projectController.insertNodeMode'>
                 <md-icon>content_copy</md-icon>
                 <md-tooltip md-direction='top' class='projectButtonTooltip'>
                   {{ ::'copy' | translate }}
                 </md-tooltip>
               </md-button>
               <md-button id='deleteButton' class='topButton md-raised md-primary'
-                  ng-click='projectController.delete()'
-                  ng-disabled='projectController.insertGroupMode || projectController.insertNodeMode'>
+                  ng-click='projectController.deleteSelectedNodes()'
+                  ng-disabled='!projectController.hasSelectedNodes() || projectController.insertGroupMode || projectController.insertNodeMode'>
                 <md-icon>delete</md-icon>
                 <md-tooltip md-direction='top' class='projectButtonTooltip'>
                   {{ ::'DELETE' | translate }}

--- a/src/main/webapp/wise5/authoringTool/project/projectController.js
+++ b/src/main/webapp/wise5/authoringTool/project/projectController.js
@@ -723,86 +723,61 @@ class ProjectController {
     }
   }
 
-  /**
-   * Delete the selected nodes after asking user for confirmation
-   * TODO refactor too many nesting
-   */
-  delete() {
-    let selectedNodeIds = this.getSelectedNodeIds();
-    if (selectedNodeIds == null || selectedNodeIds.length == 0) {
-      alert(this.$translate('pleaseSelectAnItemToDeleteAndThenClickTheDeleteButtonAgain'));
+  deleteSelectedNodes() {
+    const selectedNodeIds = this.getSelectedNodeIds();
+    let confirmMessage = '';
+    if (selectedNodeIds.length === 1) {
+      confirmMessage = this.$translate('areYouSureYouWantToDeleteTheSelectedItem');
     } else {
-      let confirmMessage = '';
-      if (selectedNodeIds.length == 1) {
-        confirmMessage = this.$translate('areYouSureYouWantToDeleteTheSelectedItem');
-      } else if (selectedNodeIds.length > 1) {
-        confirmMessage = this.$translate('areYouSureYouWantToDeleteTheXSelectedItems', {
-          numItems: selectedNodeIds.length
-        });
-      }
-      if (confirm(confirmMessage)) {
-        let deletedStartNodeId = false;
-        let activityDeleted = false;
-        let stepDeleted = false;
-        let stepsDeleted = [];
-        let activitiesDeleted = [];
-        for (let nodeId of selectedNodeIds) {
-          let node = this.ProjectService.getNodeById(nodeId);
-          let tempNode = {};
-
-          if (node != null) {
-            tempNode.nodeId = node.id;
-            tempNode.title = this.ProjectService.getNodePositionAndTitleByNodeId(node.id);
-          }
-
-          if (this.ProjectService.isStartNodeId(nodeId)) {
-            deletedStartNodeId = true;
-          }
-
-          if (this.ProjectService.isGroupNode(nodeId)) {
-            activityDeleted = true;
-            let stepsInActivityDeleted = [];
-            for (let stepNodeId of node.ids) {
-              let stepTitle = this.ProjectService.getNodePositionAndTitleByNodeId(stepNodeId);
-
-              // create an object with the step id and title
-              let stepObject = {
-                nodeId: stepNodeId,
-                title: stepTitle
-              };
-              stepsInActivityDeleted.push(stepObject);
-            }
-            tempNode.stepsInActivityDeleted = stepsInActivityDeleted;
-            activitiesDeleted.push(tempNode);
-          } else {
-            stepDeleted = true;
-            stepsDeleted.push(tempNode);
-          }
-          this.ProjectService.deleteNode(nodeId);
-        }
-
-        if (deletedStartNodeId) {
-          this.updateStartNodeId();
-        }
-
-        if (activityDeleted) {
-          let activitiesDeletedEventData = {
-            activitiesDeleted: activitiesDeleted
-          };
-          this.saveEvent('activityDeleted', 'Authoring', activitiesDeletedEventData);
-        }
-
-        if (stepDeleted) {
-          let stepDeletedEventData = {
-            stepsDeleted: stepsDeleted
-          };
-          this.saveEvent('stepDeleted', 'Authoring', stepDeletedEventData);
-        }
-
-        this.ProjectService.saveProject();
-        this.refreshProject();
-      }
+      confirmMessage = this.$translate('areYouSureYouWantToDeleteTheXSelectedItems', {
+        numItems: selectedNodeIds.length
+      });
     }
+    if (confirm(confirmMessage)) {
+      this.deleteNodesById(selectedNodeIds);
+    }
+  }
+
+  deleteNodesById(nodeIds) {
+    let deletedStartNodeId = false;
+    const stepsDeleted = [];
+    const activitiesDeleted = [];
+    for (const nodeId of nodeIds) {
+      const node = this.ProjectService.getNodeById(nodeId);
+      const tempNode = {
+        nodeId: node.id,
+        title: this.ProjectService.getNodePositionAndTitleByNodeId(node.id)
+      };
+      if (this.ProjectService.isStartNodeId(nodeId)) {
+        deletedStartNodeId = true;
+      }
+      if (this.ProjectService.isGroupNode(nodeId)) {
+        const stepsInActivityDeleted = [];
+        for (const stepNodeId of node.ids) {
+          const stepObject = {
+            nodeId: stepNodeId,
+            title: this.ProjectService.getNodePositionAndTitleByNodeId(stepNodeId)
+          };
+          stepsInActivityDeleted.push(stepObject);
+        }
+        tempNode.stepsInActivityDeleted = stepsInActivityDeleted;
+        activitiesDeleted.push(tempNode);
+      } else {
+        stepsDeleted.push(tempNode);
+      }
+      this.ProjectService.deleteNode(nodeId);
+    }
+    if (deletedStartNodeId) {
+      this.updateStartNodeId();
+    }
+    if (activitiesDeleted.length > 0) {
+      this.saveEvent('activityDeleted', 'Authoring', { activitiesDeleted: activitiesDeleted });
+    }
+    if (stepsDeleted.length > 0) {
+      this.saveEvent('stepDeleted', 'Authoring', { stepsDeleted: stepsDeleted });
+    }
+    this.ProjectService.saveProject();
+    this.refreshProject();
   }
 
   /**
@@ -810,7 +785,7 @@ class ProjectController {
    * @returns an array of node ids that are selected
    */
   getSelectedNodeIds() {
-    let selectedNodeIds = [];
+    const selectedNodeIds = [];
     angular.forEach(
       this.items,
       function(value, key) {
@@ -822,8 +797,8 @@ class ProjectController {
     );
 
     if (this.inactiveNodes != null) {
-      for (let inactiveNode of this.inactiveNodes) {
-        if (inactiveNode != null && inactiveNode.checked) {
+      for (const inactiveNode of this.inactiveNodes) {
+        if (inactiveNode.checked) {
           selectedNodeIds.push(inactiveNode.id);
         }
       }
@@ -1672,6 +1647,10 @@ class ProjectController {
    */
   nodeHasRubric(nodeId) {
     return this.ProjectService.nodeHasRubric(nodeId);
+  }
+
+  hasSelectedNodes() {
+    return this.getSelectedNodeIds().length > 0;
   }
 
   subscribeToCurrentAuthors(projectId) {

--- a/src/main/webapp/wise5/services/projectService.js
+++ b/src/main/webapp/wise5/services/projectService.js
@@ -2781,27 +2781,22 @@ class ProjectService {
   /**
    * Delete a node from the project and update transitions.
    *
-   * If we are deleting the project start node id, we will need
-   * to change it to the next logical node id that will be used
-   * as the project start.
+   * If we are deleting the project start node id, we will need to change it to the
+   * next logical node id that will be used as the project start.
    *
-   * @param nodeId the node id to delete from the project. It can be a step
-   * or an activity.
+   * @param nodeId the node id to delete from the project. It can be a step or an activity.
    */
   deleteNode(nodeId) {
     const parentGroup = this.getParentGroup(nodeId);
-    if (parentGroup.startId === nodeId) {
+    if (parentGroup != null && parentGroup.startId === nodeId) {
       this.setGroupStartIdToNextChildId(parentGroup);
     }
-
     if (this.isProjectStartNodeIdOrContainsProjectStartNodeId(nodeId)) {
       this.updateProjectStartNodeIdToNextLogicalNode(nodeId);
     }
-
     if (this.isGroupNode(nodeId)) {
       this.removeChildNodes(nodeId);
     }
-
     this.removeNodeIdFromTransitions(nodeId);
     this.removeNodeIdFromGroups(nodeId);
     this.removeNodeIdFromNodes(nodeId);
@@ -3159,10 +3154,10 @@ class ProjectService {
    * @param nodeId the node id to remove
    */
   removeNodeIdFromGroups(nodeId) {
-    for (let group of this.getGroupNodes()) {
+    for (const group of this.getGroupNodes()) {
       this.removeNodeIdFromGroup(group, nodeId);
     }
-    for (let inactiveGroup of this.getInactiveGroupNodes()) {
+    for (const inactiveGroup of this.getInactiveGroupNodes()) {
       this.removeNodeIdFromGroup(inactiveGroup, nodeId);
     }
   }
@@ -4185,14 +4180,7 @@ class ProjectService {
   }
 
   getInactiveNodes() {
-    let inactiveNodes = [];
-    if (this.project != null) {
-      if (this.project.inactiveNodes == null) {
-        this.project.inactiveNodes = [];
-      }
-      inactiveNodes = this.project.inactiveNodes;
-    }
-    return inactiveNodes;
+    return this.project.inactiveNodes;
   }
 
   /**

--- a/src/main/webapp/wise5/test-unit/services/projectService.spec.js
+++ b/src/main/webapp/wise5/test-unit/services/projectService.spec.js
@@ -590,7 +590,7 @@ describe('ProjectService', () => {
   it('should delete a step from the project', () => {
     ProjectService.setProject(demoProjectJSON);
     expect(ProjectService.getNodes().length).toEqual(37);
-    expect(ProjectService.getNodeById('node5') != null).toBeTruthy();
+    expect(ProjectService.getNodeById('node5')).not.toBeNull();
     expect(
       ProjectService.nodeHasTransitionToNodeId(ProjectService.getNodeById('node4'), 'node5')
     ).toBeTruthy();
@@ -605,6 +605,15 @@ describe('ProjectService', () => {
       ProjectService.nodeHasTransitionToNodeId(ProjectService.getNodeById('node4'), 'node6')
     ).toBeTruthy();
     expect(ProjectService.getNodesWithTransitionToNodeId('node6').length).toEqual(1);
+  });
+
+  it('should delete an inactive step from the project', () => {
+    ProjectService.setProject(demoProjectJSON);
+    expect(ProjectService.getInactiveNodes().length).toEqual(1);
+    expect(ProjectService.getNodeById('node789')).not.toBeNull();
+    ProjectService.deleteNode('node789');
+    expect(ProjectService.getInactiveNodes().length).toEqual(0);
+    expect(ProjectService.getNodeById('node789')).toBeNull();
   });
 
   it('should delete a step that is the start id of the project', () => {


### PR DESCRIPTION
Also disableed buttons for move, copy and delete if no nodes are selected. 

Verify that:
1. you can delete both active and inactive steps
1. move, copy and delete buttons only become active after a node is selected

Closes #2229