### PR TITLE
Moved project rubric authoring into its own route

### DIFF
--- a/src/main/webapp/wise5/authoringTool/authoringTool.js
+++ b/src/main/webapp/wise5/authoringTool/authoringTool.js
@@ -50,6 +50,7 @@ import ProjectAssetService from '../services/projectAssetService';
 import ProjectController from './project/projectController';
 import ProjectInfoController from './info/projectInfoController';
 import PlanningService from '../services/planningService';
+import RubricAuthoringController from './rubric/rubricAuthoringController';
 import SessionService from '../services/sessionService';
 import SockJS from 'sockjs-client';
 import Stomp from '@stomp/stompjs';
@@ -130,6 +131,7 @@ const authoringModule = angular
   .controller('ProjectAssetController', ProjectAssetController)
   .controller('ProjectController', ProjectController)
   .controller('ProjectInfoController', ProjectInfoController)
+  .controller('RubricAuthoringController', RubricAuthoringController)
   .controller('WISELinkAuthoringController', WISELinkAuthoringController)
   .config([
     '$urlRouterProvider',
@@ -258,6 +260,12 @@ const authoringModule = angular
           templateUrl: 'wise5/authoringTool/advanced/advancedAuthoring.html',
           controller: 'AdvancedAuthoringController',
           controllerAs: 'advancedAuthoringController'
+        })
+        .state('root.project.rubric', {
+          url: '/rubric',
+          templateUrl: 'wise5/authoringTool/rubric/rubricAuthoring.html',
+          controller: 'RubricAuthoringController',
+          controllerAs: 'rubricAuthoringController'
         })
         .state('root.project.notebook', {
           url: '/notebook',

--- a/src/main/webapp/wise5/authoringTool/authoringToolController.js
+++ b/src/main/webapp/wise5/authoringTool/authoringToolController.js
@@ -109,6 +109,14 @@ class AuthoringToolController {
         type: 'secondary',
         showToolbar: true,
         active: false
+      },
+      'root.project.rubric': {
+        name: '',
+        label: '',
+        icon: '',
+        type: 'secondary',
+        showToolbar: true,
+        active: false
       }
     };
 

--- a/src/main/webapp/wise5/authoringTool/project/project.html
+++ b/src/main/webapp/wise5/authoringTool/project/project.html
@@ -170,7 +170,7 @@
               </md-button>
               <md-button id='editProjectRubricButton'
                   class='topButton md-raised md-primary'
-                  ng-click='projectController.editProjectRubricClicked()'
+                  ng-click='projectController.editProjectRubric()'
                   ng-disabled='projectController.insertGroupMode || projectController.insertNodeMode || projectController.stepNodeSelected || projectController.activityNodeSelected'>
                 <md-icon>message</md-icon>
                 <md-tooltip md-direction='top' class='projectButtonTooltip'>
@@ -327,17 +327,6 @@
               <md-icon>vertical_align_bottom</md-icon>
               <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'importStepsParens' | translate }}</md-tooltip>
             </md-button>
-          </div>
-          <div ng-if='projectController.editProjectRubricMode'>
-            <h5 translate="editProjectRubric"></h5>
-            <summernote id='{{::projectController.summernoteRubricId}}'
-                  ng-model='projectController.summernoteRubricHTML'
-                  ng-change='projectController.summernoteRubricHTMLChanged()'
-                  config='projectController.summernoteRubricOptions'
-                  ng-model-options='{ debounce: 1000 }'
-                  rows='10'
-                  cols='100'>
-            </summernote>
           </div>
           <div style='margin-top: 20px; margin-left: 20px'>
             <div ng-repeat='item in projectController.items | toArray | orderBy : "order"'

--- a/src/main/webapp/wise5/authoringTool/rubric/rubricAuthoring.html
+++ b/src/main/webapp/wise5/authoringTool/rubric/rubricAuthoring.html
@@ -1,0 +1,19 @@
+<div>
+  <md-button id='backToProjectButton' class='topButton md-raised md-primary'
+      ng-click='rubricAuthoringController.goBack()'>
+    <md-icon>arrow_back</md-icon>
+    <md-tooltip md-direction='top'
+        class='projectButtonTooltip'>
+      {{ ::'backToProjectView' | translate }}
+    </md-tooltip>
+  </md-button>
+</div><br/>
+<h5 translate="editProjectRubric"></h5>
+<summernote id='{{::rubricAuthoringController.summernoteRubricId}}'
+      ng-model='rubricAuthoringController.summernoteRubricHTML'
+      ng-change='rubricAuthoringController.summernoteRubricHTMLChanged()'
+      config='rubricAuthoringController.summernoteRubricOptions'
+      ng-model-options='{ debounce: 1000 }'
+      rows='10'
+      cols='100'>
+</summernote>

--- a/src/main/webapp/wise5/authoringTool/rubric/rubricAuthoringController.js
+++ b/src/main/webapp/wise5/authoringTool/rubric/rubricAuthoringController.js
@@ -1,0 +1,83 @@
+class RubricAuthoringController {
+  constructor(
+    $filter,
+    $mdDialog,
+    $rootScope,
+    $scope,
+    $state,
+    $stateParams,
+    ConfigService,
+    ProjectService,
+    UtilService
+  ) {
+    this.$mdDialog = $mdDialog;
+    this.$rootScope = $rootScope;
+    this.$scope = $scope;
+    this.$state = $state;
+    this.$translate = $filter('translate');
+    this.ConfigService = ConfigService;
+    this.ProjectService = ProjectService;
+    this.UtilService = UtilService;
+    this.projectId = $stateParams.projectId;
+    this.summernoteRubricId = `summernoteRubric_${this.projectId}`;
+    this.summernoteRubricOptions = {
+      toolbar: [
+        ['style', ['style']],
+        ['font', ['bold', 'underline', 'clear']],
+        ['fontname', ['fontname']],
+        ['fontsize', ['fontsize']],
+        ['color', ['color']],
+        ['para', ['ul', 'ol', 'paragraph']],
+        ['table', ['table']],
+        ['insert', ['link', 'video']],
+        ['view', ['fullscreen', 'codeview', 'help']],
+        ['customButton', ['insertAssetButton']]
+      ],
+      height: 300,
+      disableDragAndDrop: true,
+      buttons: {
+        insertAssetButton: this.UtilService.createInsertAssetButton(
+          this, null, this.nodeId, null, 'rubric', this.$translate('INSERT_ASSET'))
+      }
+    };
+    this.summernoteRubricHTML =
+      this.ProjectService.replaceAssetPaths(this.ProjectService.getProjectRubric());
+  }
+
+  $onInit() {
+    this.$scope.$on('assetSelected', (event, {assetItem, target}) => {
+      if (target === 'rubric') {
+        const fileName = assetItem.fileName;
+        const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
+        this.UtilService.insertFileInSummernoteEditor(this.summernoteRubricId, fullFilePath,
+          fileName);
+          this.$mdDialog.hide();
+        }
+    });
+  }
+
+  summernoteRubricHTMLChanged() {
+    const html = this.UtilService.insertWISELinks(
+        this.ConfigService.removeAbsoluteAssetPaths(this.summernoteRubricHTML));
+    this.ProjectService.setProjectRubric(html);
+    this.ProjectService.saveProject();
+  }
+
+  goBack() {
+    this.$state.go('root.project');
+  }
+}
+
+RubricAuthoringController.$inject = [
+  '$filter',
+  '$mdDialog',
+  '$rootScope',
+  '$scope',
+  '$state',
+  '$stateParams',
+  'ConfigService',
+  'ProjectService',
+  'UtilService'
+];
+
+export default RubricAuthoringController;

--- a/src/main/webapp/wise5/services/projectService.js
+++ b/src/main/webapp/wise5/services/projectService.js
@@ -4783,10 +4783,6 @@ class ProjectService {
     return branchPathTakenConstraints;
   }
 
-  /**
-   * Get the project level rubric
-   * @return the project level rubric
-   */
   getProjectRubric() {
     return this.project.rubric;
   }


### PR DESCRIPTION
Test that AT project rubric editing works as before, but in its own route (/project/id/rubric)

You should be able to

- go to project rubric route (/project/id/rubric) by clicking on the rubric button
- edit and save the rubric using the editor, including adding assets
- go back to the project view with the back button

Closes #2223