### PR TITLE
Fixed issue not being able to create run with MySQL8 

### DIFF
--- a/src/main/java/org/wise/portal/domain/group/impl/PersistentGroup.java
+++ b/src/main/java/org/wise/portal/domain/group/impl/PersistentGroup.java
@@ -54,7 +54,7 @@ import org.wise.portal.domain.user.impl.UserImpl;
 public class PersistentGroup implements Group {
 
   @Transient
-  public static final String DATA_STORE_NAME = "groups";
+  public static final String DATA_STORE_NAME = "`groups`";
 
   @Transient
   public static final String USERS_JOIN_TABLE_NAME = "groups_related_to_users";


### PR DESCRIPTION
This was because "groups" became a keyword in MySQL8.0.2 (https://dev.mysql.com/doc/refman/8.0/en/keywords.html)

Test that you can create a new run from the teacher library using MySQL8.

Resolves #2259