### PR TITLE
Allow connected component to clear graph

### DIFF
--- a/src/main/webapp/wise5/components/graph/graphController.js
+++ b/src/main/webapp/wise5/components/graph/graphController.js
@@ -2129,6 +2129,8 @@ class GraphController extends ComponentController {
       this.parseLatestTrial(studentData, params);
     } else if (name === 'trialIdsToDelete') {
       this.deleteTrialsByTrialId(studentData.trialIdsToDelete);
+    } else if (name === 'clearGraph') {
+      this.clearGraph();
     }
   }
 
@@ -2142,6 +2144,13 @@ class GraphController extends ComponentController {
         this.deleteTrialId(trialIdToDelete);
       }
     }
+  }
+
+  clearGraph() {
+    this.trials = [];
+    this.newTrial();
+    this.resetSeriesHelper();
+    this.drawGraph();
   }
 
   /**

--- a/src/main/webapp/wise5/components/graph/graphController.js
+++ b/src/main/webapp/wise5/components/graph/graphController.js
@@ -2129,7 +2129,7 @@ class GraphController extends ComponentController {
       this.parseLatestTrial(studentData, params);
     } else if (name === 'trialIdsToDelete') {
       this.deleteTrialsByTrialId(studentData.trialIdsToDelete);
-    } else if (name === 'clearGraph') {
+    } else if (name === 'clearGraph' && studentData.clearGraph) {
       this.clearGraph();
     }
   }


### PR DESCRIPTION
Test that a component that is connected to a graph component can clear the graph by setting the "clearGraph=true" field in the student data.

See [Snap! Thermo integration demo project](https://wise-qa.berkeley.edu/project/106#!/project/106/node5) for authoring example. The graph should have connected component authored with the "clearGraph" read field.
```
"fields": [
                {
                    "name": "clearGraph",
                    "action": "read",
                    "when": "always"
                }
            ]
```