### PR TITLE
Fixed missing lastRun date from teacher run list items

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
@@ -105,6 +105,7 @@ public class TeacherAPIController extends UserAPIController {
       periods.add(period.getName());
     }
     map.put("periods", periods);
+    map.put("lastRun", run.getLastRun());
     return map;
   }
 


### PR DESCRIPTION
To test:
- Log in as a teacher.
- Verify that you see a "Last student login" display for runs which students have started using.
- Verify you see the "Edit Classroom Unit" warning dialog when selecting "Edit Content" from the run menu for these units.

Resolves #2274. 