### PR TITLE
Added item location display and link to view step info to milestone reports

### DIFF
--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneDetails/milestoneDetails.js
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneDetails/milestoneDetails.js
@@ -7,7 +7,8 @@ class MilestoneDetailsController {
     $state,
     ConfigService,
     ProjectService,
-    TeacherDataService
+    TeacherDataService,
+    NodeService
   ) {
     this.$filter = $filter;
     this.$scope = $scope;
@@ -15,6 +16,7 @@ class MilestoneDetailsController {
     this.ConfigService = ConfigService;
     this.ProjectService = ProjectService;
     this.TeacherDataService = TeacherDataService;
+    this.NodeService = NodeService;
     this.$translate = this.$filter("translate");
     this.periodId = this.TeacherDataService.getCurrentPeriod().periodId;
     this.$onInit = () => {
@@ -75,6 +77,10 @@ class MilestoneDetailsController {
     return this.ProjectService.getNodeTitleByNodeId(nodeId);
   }
 
+  getNodeNumberAndTitleByNodeId(nodeId) {
+    return `${this.getNodeNumberByNodeId(nodeId)}: ${this.getNodeTitleByNodeId(nodeId)}`;
+  }
+
   /**
    * Get the user names for a workgroup id
    * @param workgroupId the workgroup id
@@ -95,6 +101,10 @@ class MilestoneDetailsController {
 
   showWorkgroup(workgroup) {
     this.onShowWorkgroup({ value: workgroup });
+  }
+
+  showMilestoneStepInfo($event) {
+    this.NodeService.showNodeInfo(this.milestone.nodeId, $event);
   }
 
   visitNodeGrading() {
@@ -130,7 +140,8 @@ MilestoneDetailsController.$inject = [
   "$state",
   "ConfigService",
   "ProjectService",
-  "TeacherDataService"
+  "TeacherDataService",
+  "NodeService"
 ];
 
 const MilestoneDetails = {
@@ -153,7 +164,7 @@ const MilestoneDetails = {
           </div>
         </div>
         <p ng-if="$ctrl.milestone.description">
-          <span class="heavy">{{ ::'description' | translate }}: </span>&nbsp;
+          <span class="heavy">{{ ::'description' | translate }}: </span>
           <compile data="$ctrl.milestone.description"></compile>
         </p>
         <p ng-if="$ctrl.milestone.params.targetDate"><span class="heavy">{{ ::'dueDate' | translate }}: </span> {{ $ctrl.milestone.params.targetDate | date: 'EEE MMM d, yyyy' }}</p>
@@ -162,6 +173,11 @@ const MilestoneDetails = {
           <a ng-repeat="requirement in $ctrl.requirements" ui-sref="root.project({nodeId: \'{{ requirement }}\'})" ng-click="$ctrl.visitNodeGrading(event)">
             {{ ::$ctrl.getNodeNumberByNodeId(requirement) }}: {{ ::$ctrl.getNodeTitleByNodeId(requirement) }}<span ng-if="!$last">, </span>
           </a>
+        </p>
+        <p ng-if="$ctrl.milestone.type === 'milestoneReport'">
+          <span class="heavy">{{ ::'itemLocation' | translate }}: </span>
+          {{ $ctrl.getNodeNumberAndTitleByNodeId($ctrl.milestone.nodeId) }}
+          (<a href ng-click="$ctrl.showMilestoneStepInfo($event)">{{ ::'STEP_INFO' | translate }}</a>)
         </p>
       </section>
       <section ng-if="$ctrl.milestone.type === 'milestoneReport'"

--- a/src/main/webapp/wise5/classroomMonitor/i18n/i18n_en.json
+++ b/src/main/webapp/wise5/classroomMonitor/i18n/i18n_en.json
@@ -83,7 +83,7 @@
     "includeStudentWorkIDs": "Include Student Work IDs",
     "includeStudentWorkTimestamps": "Include Student Work Timestamps",
     "infoTipsLabel": "Info + Tips ({{ numberOfTips }})",
-    "itemInfo": "Item Info",
+    "itemLocation": "Item Location",
     "latestWork": "Latest Work:",
     "latestStudentWork": "Latest Student Work",
     "lockPeriodLabel": "Lock student screens (Period: {{ periodName }})",

--- a/src/main/webapp/wise5/classroomMonitor/milestones/milestonesController.js
+++ b/src/main/webapp/wise5/classroomMonitor/milestones/milestonesController.js
@@ -838,6 +838,7 @@ class MilestonesController {
         template: template,
         ariaLabel: title,
         fullscreen: true,
+        multiple: true,
         targetEvent: $event,
         clickOutsideToClose: true,
         escapeToClose: true,

--- a/src/main/webapp/wise5/services/nodeService.js
+++ b/src/main/webapp/wise5/services/nodeService.js
@@ -878,6 +878,7 @@ class NodeService {
     this.$mdDialog.show({
       template: dialogString,
       fullscreen: true,
+      multiple: true,
       controller: [
         '$scope',
         '$mdDialog',


### PR DESCRIPTION
To test:
- Open Classroom Monitor for a run that contains a milestone report.
- Go to Milestones view and click on a milestone report item.
- Verify that the an "Item Location" paragraph is added to the top section of the milestone details and that it shows the step number and title that contains the milestone report's target component.
- Verify that clicking on "Step Info" open the step info dialog for the target step.

Resolves #2268.