### PR TITLE
Fixed bug that caused duplicate users to be added to unit authors

### DIFF
--- a/src/main/webapp/wise5/services/projectService.ts
+++ b/src/main/webapp/wise5/services/projectService.ts
@@ -1147,7 +1147,6 @@ class ProjectService {
     let exists = false;
     for (let author of authors) {
       if (author.id === userInfo.id) {
-        author = userInfo;
         exists = true;
         break;
       }

--- a/src/main/webapp/wise5/services/projectService.ts
+++ b/src/main/webapp/wise5/services/projectService.ts
@@ -1154,7 +1154,9 @@ class ProjectService {
     if (!exists) {
       authors.push(userInfo);
     }
-    this.project.metadata.authors = authors;
+    this.project.metadata.authors = authors.filter((obj, pos, arr) => {
+      return arr.map(mapObj => mapObj['id']).indexOf(obj['id']) === pos;
+    });
     const httpParams = {
       method: 'POST',
       url: this.ConfigService.getConfigParam('saveProjectURL'),

--- a/src/main/webapp/wise5/services/projectService.ts
+++ b/src/main/webapp/wise5/services/projectService.ts
@@ -1145,7 +1145,7 @@ class ProjectService {
     const authors = this.project.metadata.authors ? this.project.metadata.authors : [];
     const userInfo = this.ConfigService.getMyUserInfo();
     let exists = false;
-    for (let author of authors) {
+    for (const author of authors) {
       if (author.id === userInfo.id) {
         exists = true;
         break;
@@ -1154,9 +1154,7 @@ class ProjectService {
     if (!exists) {
       authors.push(userInfo);
     }
-    this.project.metadata.authors = authors.filter((obj, pos, arr) => {
-      return arr.map(mapObj => mapObj['id']).indexOf(obj['id']) === pos;
-    });
+    this.project.metadata.authors = this.getUniqueAuthors(authors);
     const httpParams = {
       method: 'POST',
       url: this.ConfigService.getConfigParam('saveProjectURL'),
@@ -1178,6 +1176,18 @@ class ProjectService {
       }
       return response;
     });
+  }
+
+  getUniqueAuthors(authors) {
+    const idToAuthor = {};
+    const uniqueAuthors = [];
+    for (const author of authors) {
+      if (idToAuthor[author.id] == null) {
+        uniqueAuthors.push(author);
+        idToAuthor[author.id] = author;
+      }
+    }
+    return uniqueAuthors;
   }
 
   /**

--- a/src/main/webapp/wise5/services/projectService.ts
+++ b/src/main/webapp/wise5/services/projectService.ts
@@ -1145,7 +1145,7 @@ class ProjectService {
     const authors = this.project.metadata.authors ? this.project.metadata.authors : [];
     const userInfo = this.ConfigService.getMyUserInfo();
     let exists = false;
-    for (let [index, author] of authors.entries()) {
+    for (let author of authors) {
       if (author.id === userInfo.id) {
         author = userInfo;
         exists = true;

--- a/src/main/webapp/wise5/test-unit/services/projectService.spec.js
+++ b/src/main/webapp/wise5/test-unit/services/projectService.spec.js
@@ -76,6 +76,7 @@ describe('ProjectService', () => {
   shouldDeleteAnActivityThatIsNotTheFirstFromTheProject();
   calculateNodeOrder();
   getGroupNodesIdToOrder();
+  getUniqueAuthors();
   // TODO: add test for ProjectService.getFlattenedProjectAsNodeIds()
   // TODO: add test for ProjectService.getAllPaths()
   // TODO: add test for ProjectService.consolidatePaths()
@@ -892,6 +893,68 @@ function getGroupNodesIdToOrder() {
         group1: { order: 1 },
         group2: { order: 21 }
       });
+    });
+  });
+}
+
+function getUniqueAuthors() {
+  describe('getUniqueAuthors', () => {
+    it('should get unique authors when there are no authors', () => {
+      const authors = [];
+      const uniqueAuthors = ProjectService.getUniqueAuthors(authors);
+      expect(uniqueAuthors.length).toEqual(0);
+    });
+
+    it('should get unique authors when there is one author', () => {
+      const authors = [
+        { id: 1, firstName: 'a', lastName: 'a' }
+      ];
+      const uniqueAuthors = ProjectService.getUniqueAuthors(authors);
+      expect(uniqueAuthors.length).toEqual(1);
+      expect(uniqueAuthors[0].id).toEqual(1);
+      expect(uniqueAuthors[0].firstName).toEqual('a');
+      expect(uniqueAuthors[0].lastName).toEqual('a');
+    });
+
+    it('should get unique authors when there are multiple duplicates', () => {
+      const authors = [
+        { id: 1, firstName: 'a', lastName: 'a' },
+        { id: 2, firstName: 'b', lastName: 'b' },
+        { id: 1, firstName: 'a', lastName: 'a' },
+        { id: 3, firstName: 'c', lastName: 'c' },
+        { id: 3, firstName: 'c', lastName: 'c' },
+        { id: 1, firstName: 'a', lastName: 'a' }
+      ];
+      const uniqueAuthors = ProjectService.getUniqueAuthors(authors);
+      expect(uniqueAuthors.length).toEqual(3);
+      expect(uniqueAuthors[0].id).toEqual(1);
+      expect(uniqueAuthors[0].firstName).toEqual('a');
+      expect(uniqueAuthors[0].lastName).toEqual('a');
+      expect(uniqueAuthors[1].id).toEqual(2);
+      expect(uniqueAuthors[1].firstName).toEqual('b');
+      expect(uniqueAuthors[1].lastName).toEqual('b');
+      expect(uniqueAuthors[2].id).toEqual(3);
+      expect(uniqueAuthors[2].firstName).toEqual('c');
+      expect(uniqueAuthors[2].lastName).toEqual('c');
+    });
+
+    it('should get unique authors when there are no duplicates', () => {
+      const authors = [
+        { id: 1, firstName: 'a', lastName: 'a' },
+        { id: 2, firstName: 'b', lastName: 'b' },
+        { id: 3, firstName: 'c', lastName: 'c' }
+      ];
+      const uniqueAuthors = ProjectService.getUniqueAuthors(authors);
+      expect(uniqueAuthors.length).toEqual(3);
+      expect(uniqueAuthors[0].id).toEqual(1);
+      expect(uniqueAuthors[0].firstName).toEqual('a');
+      expect(uniqueAuthors[0].lastName).toEqual('a');
+      expect(uniqueAuthors[1].id).toEqual(2);
+      expect(uniqueAuthors[1].firstName).toEqual('b');
+      expect(uniqueAuthors[1].lastName).toEqual('b');
+      expect(uniqueAuthors[2].id).toEqual(3);
+      expect(uniqueAuthors[2].firstName).toEqual('c');
+      expect(uniqueAuthors[2].lastName).toEqual('c');
     });
   });
 }


### PR DESCRIPTION
To test:
- Open a project in the authoring tool and make multiple changes.
- Ensure that the user making the changes is only listed once in the `metadata.authors` field in the project json.

Closes #2279. 