### PR TITLE
Fixed missing delete buttons from discussion posts in the grading tool

### DIFF
--- a/src/main/webapp/wise5/components/discussion/discussionController.js
+++ b/src/main/webapp/wise5/components/discussion/discussionController.js
@@ -431,8 +431,8 @@ class DiscussionController extends ComponentController {
     return userIdsDisplay.join(', ');
   }
 
-  getLatestInappropriateFlagAnnotationByStudentWorkId(annotations, studentWorkId) {
-    for (const annotation of annotations) {
+  getLatestInappropriateFlagAnnotationByStudentWorkId(annotations = [], studentWorkId) {
+    for (const annotation of annotations.sort(this.sortByServerSaveTime).reverse()) {
       if (studentWorkId === annotation.studentWorkId && annotation.type === 'inappropriateFlag') {
         return annotation;
       }

--- a/src/main/webapp/wise5/components/discussion/index.html
+++ b/src/main/webapp/wise5/components/discussion/index.html
@@ -17,7 +17,7 @@
                   <class-response ng-repeat='componentState in discussionController.topLevelResponses.all'
                       response='componentState'
                       submitbuttonclicked='submitbuttonclicked(r)'
-                      mode='::discussionController.mode'
+                      mode='{{::discussionController.mode}}'
                       deletebuttonclicked='discussionController.deletebuttonclicked(componentState)'
                       undodeletebuttonclicked='discussionController.undodeletebuttonclicked(componentState)'
                       studentdatachanged='studentdatachanged()'


### PR DESCRIPTION
To test:
- Create a run with a discussion component.
- Add some student posts and replies to the run.
- Open the grading tool for the unit and go to the step grading view for the discussion component.
- Verify that the "Delete" button appears next to discussion posts and replies when viewing workgroup work.
- Verify that deleting posts and replies hides them from the discussion component in the VLE when logged in as a student.
- Verify that you can un-delete posts and replies and that they show up again in the VLE.

Closes #2284. 