### PR TITLE
Shared teachers for a run don't appear in the Share Classroom Unit dialog

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
@@ -206,6 +206,7 @@ public class TeacherAPIController extends UserAPIController {
       map.put("firstName", ud.getFirstname());
       map.put("lastName", ud.getLastname());
       map.put("permissions", getSharedOwnerPermissionsList(run, sharedOwner));
+      sharedOwners.add(map);
     }
     return sharedOwners;
   }


### PR DESCRIPTION
1. Log in as a teacher, open the Share Classroom Unit dialog for a run.
1. Share the run with a teacher.
1. Close the dialog.
1. Re-open the dialog. Shared teacher should be displayed.

Closes #2285