### PR TITLE
Fix shared teacher permissions in the Classroom Monitor

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
@@ -238,6 +238,7 @@ public class InformationController {
     }
     config.put("canViewStudentNames", isAllowedToViewStudentNames(run, signedInUser));
     config.put("canGradeStudentWork", runService.isAllowedToGradeStudentWork(run, signedInUser));
+    config.put("canAuthorProject", projectService.canAuthorProject(project, signedInUser));
     addCommonConfigParameters(request, config, project);
     printConfigToResponse(response, config);
   }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
@@ -220,27 +220,24 @@ public class InformationController {
       throws ObjectNotFoundException, IOException, JSONException {
     JSONObject config = new JSONObject();
     config.put("mode", "classroomMonitor");
-
     Run run = runService.retrieveById(runId);
     getRunConfigParameters(request, config, run);
-
     User signedInUser = ControllerUtil.getSignedInUser();
     String contextPath = request.getContextPath();
-
     if (hasRunReadAccess(signedInUser, run)) {
       config.put("runCode", run.getRuncode());
       config.put("teacherDataURL", contextPath + "/teacher/data");
       config.put("runDataExportURL", contextPath + "/teacher/export");
       config.put("studentNotebookURL", contextPath + "/teacher/notebook/" + runId);
     }
-
     Project project = run.getProject();
     if (hasRunWriteAccess(signedInUser, run)) {
       String projectId = project.getId().toString();
       String saveProjectURL = contextPath + "/project/save/" + projectId;
       config.put("saveProjectURL", saveProjectURL);
     }
-
+    config.put("canViewStudentNames", isAllowedToViewStudentNames(run, signedInUser));
+    config.put("canGradeStudentWork", runService.isAllowedToGradeStudentWork(run, signedInUser));
     addCommonConfigParameters(request, config, project);
     printConfigToResponse(response, config);
   }

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneDetails/milestoneDetails.js
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneDetails/milestoneDetails.js
@@ -86,8 +86,8 @@ class MilestoneDetailsController {
    * @param workgroupId the workgroup id
    * @return the user names in the workgroup
    */
-  getDisplayUsernamesByWorkgroupId(workgroupId) {
-    return this.ConfigService.getDisplayUsernamesByWorkgroupId(workgroupId);
+  getDisplayNamesByWorkgroupId(workgroupId) {
+    return this.ConfigService.getDisplayNamesByWorkgroupId(workgroupId);
   }
 
   /**
@@ -229,7 +229,7 @@ const MilestoneDetails = {
             <div class="md-avatar" hide-xs>
               <md-icon class="md-36" style="color: {{ $ctrl.getAvatarColorForWorkgroupId(workgroup.workgroupId) }};"> account_circle </md-icon>
             </div>
-            <p class="heavy">{{ $ctrl.getDisplayUsernamesByWorkgroupId(workgroup.workgroupId) }}</p>
+            <p class="heavy">{{ $ctrl.getDisplayNamesByWorkgroupId(workgroup.workgroupId) }}</p>
             <div class="md-secondary-container heavy">
               <span ng-if="workgroup.achievementTime !== null" class="success">
                 {{ workgroup.achievementTime | amTimeAgo }}

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.html
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.html
@@ -25,7 +25,7 @@
                    placeholder="0"
                    min="0"
                    ng-model="$ctrl.maxScore"
-                   ng-disabled="$ctrl.isDisabled || !$ctrl.canGradeStudentWork"
+                   ng-disabled="$ctrl.isDisabled || !$ctrl.canAuthorProject"
                    ng-change="$ctrl.updateMaxScore()"
                    ng-model-options="{ debounce: 1000 }">
         </md-input-container>

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.html
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.html
@@ -13,7 +13,7 @@
                    placeholder="0"
                    min="0"
                    ng-model="$ctrl.score"
-                   ng-disabled="$ctrl.isDisabled"
+                   ng-disabled="$ctrl.isDisabled || !$ctrl.canGradeStudentWork"
                    ng-change="$ctrl.postAnnotation('score')"
                    ng-model-options="{ debounce: 1000 }">
         </md-input-container>
@@ -25,7 +25,7 @@
                    placeholder="0"
                    min="0"
                    ng-model="$ctrl.maxScore"
-                   ng-disabled="$ctrl.isDisabled"
+                   ng-disabled="$ctrl.isDisabled || !$ctrl.canGradeStudentWork"
                    ng-change="$ctrl.updateMaxScore()"
                    ng-model-options="{ debounce: 1000 }">
         </md-input-container>
@@ -38,7 +38,7 @@
                           md-detect-hidden
                           placeholder="{{ ::'enterCommentHere' | translate }}"
                           ng-model="$ctrl.comment"
-                          ng-disabled="$ctrl.isDisabled"
+                          ng-disabled="$ctrl.isDisabled || !$ctrl.canGradeStudentWork"
                           ng-change="$ctrl.postAnnotation('comment')"
                           ng-model-options="{ debounce: 5000 }"></textarea>
             </div>

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.js
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.js
@@ -24,7 +24,9 @@ class ComponentGradingController {
 
         this.$onInit = () => {
             this.runId = this.ConfigService.getRunId();
-            this.canGradeStudentWork = this.ConfigService.getPermissions().canGradeStudentWork;
+            const permissions = this.ConfigService.getPermissions();
+            this.canGradeStudentWork = permissions.canGradeStudentWork;
+            this.canAuthorProject = permissions.canAuthorProject;
             let toUserInfo = this.ConfigService.getUserInfoByWorkgroupId(this.toWorkgroupId);
             if (toUserInfo) {
                 // set the period id

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.js
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.js
@@ -24,7 +24,7 @@ class ComponentGradingController {
 
         this.$onInit = () => {
             this.runId = this.ConfigService.getRunId();
-
+            this.canGradeStudentWork = this.ConfigService.getPermissions().canGradeStudentWork;
             let toUserInfo = this.ConfigService.getUserInfoByWorkgroupId(this.toWorkgroupId);
             if (toUserInfo) {
                 // set the period id

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/componentRevisionsInfo/componentRevisionsInfo.js
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/componentRevisionsInfo/componentRevisionsInfo.js
@@ -16,18 +16,12 @@ class ComponentRevisionsInfoController {
 
         this.$onInit = () => {
             this.runId = this.ConfigService.getRunId();
-
             let toUserInfo = this.ConfigService.getUserInfoByWorkgroupId(this.toWorkgroupId);
             if (toUserInfo) {
                 // set the period id
                 this.periodId = toUserInfo.periodId;
             }
-
-            // get the workgroup user names
-            let usernamesArray = this.ConfigService.getUsernamesByWorkgroupId(this.toWorkgroupId);
-            this.usernames = usernamesArray.map( (obj) => {
-                return obj.name;
-            }).join(', ');
+            this.usernames = this.ConfigService.getDisplayNamesByWorkgroupId(this.toWorkgroupId);
         };
 
         this.$onChanges = (changes) => {

--- a/src/main/webapp/wise5/classroomMonitor/notebook/notebookGradingController.js
+++ b/src/main/webapp/wise5/classroomMonitor/notebook/notebookGradingController.js
@@ -34,26 +34,6 @@ class NotebookGradingController {
             this.showReportForWorkgroup[workgroup.workgroupId] = false;
         }
 
-        this.canViewStudentNames = true;
-        this.canGradeStudentWork = true;
-
-        // get the role of the teacher for the run e.g. 'owner', 'write', 'read'
-        let role = this.ConfigService.getTeacherRole(this.teacherWorkgroupId);
-
-        if (role === 'owner') {
-            // the teacher is the owner of the run and has full access
-            this.canViewStudentNames = true;
-            this.canGradeStudentWork = true;
-        } else if (role === 'write') {
-            // the teacher is a shared teacher that can grade the student work
-            this.canViewStudentNames = true;
-            this.canGradeStudentWork = true;
-        } else if (role === 'read') {
-            // the teacher is a shared teacher that can only view the student work
-            this.canViewStudentNames = false;
-            this.canGradeStudentWork = false;
-        }
-
         // save event when notebook grading view is displayed
         let context = "ClassroomMonitor", nodeId = null, componentId = null, componentType = null,
             category = "Navigation", event = "notebookViewDisplayed", data = {};

--- a/src/main/webapp/wise5/classroomMonitor/notebook/notebookItemGrading/notebookItemGrading.html
+++ b/src/main/webapp/wise5/classroomMonitor/notebook/notebookItemGrading/notebookItemGrading.html
@@ -12,7 +12,8 @@
                               placeholder="Enter comment here"
                               ng-model="$ctrl.comment"
                               ng-change="$ctrl.postAnnotation('comment')"
-                              ng-model-options="{ debounce: 10000 }"></textarea>
+                              ng-model-options="{ debounce: 10000 }"
+                              ng-disabled="!$ctrl.canGradeStudentWork"></textarea>
                 </div>
             </md-input-container>
         </div>
@@ -28,7 +29,8 @@
                        placeholder="0"
                        ng-model="$ctrl.score"
                        ng-change="$ctrl.postAnnotation('score')"
-                       ng-model-options="{ debounce: 5000 }">
+                       ng-model-options="{ debounce: 5000 }"
+                       ng-disabled="!$ctrl.canGradeStudentWork">
                 <span class="annotations--grading__score__max md-subhead text-secondary"> /{{$ctrl.maxScore}}</span>
             </md-input-container>
         </div>

--- a/src/main/webapp/wise5/classroomMonitor/notebook/notebookItemGrading/notebookItemGrading.js
+++ b/src/main/webapp/wise5/classroomMonitor/notebook/notebookItemGrading/notebookItemGrading.js
@@ -37,6 +37,7 @@ class NotebookItemGradingController {
               // set the period id
               this.periodId = toUserInfo.periodId;
           }
+          this.canGradeStudentWork = this.ConfigService.getPermissions().canGradeStudentWork;
 
           // get the workgroup user names
           let usernamesArray = this.ConfigService.getUsernamesByWorkgroupId(this.toWorkgroupId);

--- a/src/main/webapp/wise5/services/configService.js
+++ b/src/main/webapp/wise5/services/configService.js
@@ -358,7 +358,8 @@ class ConfigService {
     // a switched user (admin/researcher user impersonating a teacher) should not be able to view/grade
     return {
       canViewStudentNames: this.config.canViewStudentNames && !this.isSwitchedUser(),
-      canGradeStudentWork: this.config.canGradeStudentWork && !this.isSwitchedUser()
+      canGradeStudentWork: this.config.canGradeStudentWork && !this.isSwitchedUser(),
+      canAuthorProject: this.config.canAuthorProject && !this.isSwitchedUser()
     };
   }
 

--- a/src/main/webapp/wise5/services/configService.js
+++ b/src/main/webapp/wise5/services/configService.js
@@ -13,7 +13,6 @@ class ConfigService {
   setConfig(config) {
     this.config = config;
     this.sortClassmateUserInfosAlphabeticallyByName();
-    this.setPermissions();
     this.setClassmateDisplayNames();
   }
 
@@ -353,27 +352,6 @@ class ConfigService {
       }
     }
     return 0;
-  }
-
-  setPermissions() {
-    let role = this.getTeacherRole(this.getWorkgroupId());
-    if (role === 'owner') {
-      // the teacher is the owner of the run and has full access
-      this.config.canViewStudentNames = true;
-      this.config.canGradeStudentWork = true;
-    } else if (role === 'write') {
-      // the teacher is a shared teacher that can grade the student work
-      this.config.canViewStudentNames = true;
-      this.config.canGradeStudentWork = true;
-    } else if (role === 'read') {
-      // the teacher is a shared teacher that can only view the student work
-      this.config.canViewStudentNames = false;
-      this.config.canGradeStudentWork = false;
-    } else {
-      // teacher role is null, so assume we're in student mode
-      this.config.canViewStudentNames = true;
-      this.config.canGradeStudentWork = false;
-    }
   }
 
   getPermissions() {


### PR DESCRIPTION
To test:
- Log in as a teacher and share a run with another teacher using the "Share Classroom Unit" dialog.
- Check the "View Student Names" and "Grade & Manage" permissions.
- Log in as the shared teacher and open the Classroom Monitor for the shared run. Verify that student names are displayed and shared teacher can send feedback and scores (including notebook annotations).
- Log in as first teacher and uncheck the "View Student Names" and "Grade & Manage" permissions for the shared teacher in the "Share Classroom Unit" dialog.
- Log in as the shared teacher and open the Classroom Monitor for the shared run. Verify that teacher can't view student names and can't grade or send feedback.


Closes #2292. 