### PR TITLE
Grade and Manage run sharing permission incorrectly granted in specific case

### DIFF
--- a/src/main/java/org/wise/portal/service/acl/AclService.java
+++ b/src/main/java/org/wise/portal/service/acl/AclService.java
@@ -87,4 +87,6 @@ public interface AclService<T> extends PermissionEvaluator {
    * fale otherwise.
    */
   boolean hasPermission(T object, Permission permission, UserDetails userDetails);
+
+  boolean hasSpecificPermission(T object, Permission permission, UserDetails userDetails);
 }

--- a/src/main/java/org/wise/portal/service/acl/impl/AclServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/acl/impl/AclServiceImpl.java
@@ -168,6 +168,16 @@ public class AclServiceImpl<T extends Persistable> implements AclService<T> {
     return false;
   }
 
+  public boolean hasSpecificPermission(T object, Permission permission, UserDetails userDetails) {
+    List<Permission> permissions = getPermissions(object, userDetails);
+    for (Permission p : permissions) {
+      if (p.getMask() == permission.getMask()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public boolean hasPermission(

--- a/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
@@ -612,6 +612,10 @@ public class RunServiceImpl implements RunService {
     return aclService.hasPermission(run, permission, user.getUserDetails());
   }
 
+  public boolean hasSpecificPermission(Run run, User user, Permission permission) {
+    return aclService.hasSpecificPermission(run, permission, user.getUserDetails()); 
+  }
+
   public boolean canDecreaseMaxStudentsPerTeam(Long runId) {
     List<Workgroup> workgroups = getWorkgroups(runId);
     if (workgroups != null) {
@@ -763,15 +767,15 @@ public class RunServiceImpl implements RunService {
   }
 
   public boolean isAllowedToViewStudentWork(Run run, User user) {
-    return hasRunPermission(run, user, RunPermission.VIEW_STUDENT_WORK);
+    return hasSpecificPermission(run, user, RunPermission.VIEW_STUDENT_WORK);
   }
 
   public boolean isAllowedToGradeStudentWork(Run run, User user) {
-    return hasRunPermission(run, user, RunPermission.GRADE_AND_MANAGE);
+    return hasSpecificPermission(run, user, RunPermission.GRADE_AND_MANAGE);
   }
 
   public boolean isAllowedToViewStudentNames(Run run, User user) {
-    return hasRunPermission(run, user, RunPermission.VIEW_STUDENT_NAMES);
+    return hasSpecificPermission(run, user, RunPermission.VIEW_STUDENT_NAMES);
   }
 
 }


### PR DESCRIPTION
1. Log in as a teacher and share a run with another teacher using the "Share Unit Dialog".
1. Check the "View Student Names" permission for the teacher and leave "Grade & Manage" unchecked.
1. Log in as the shared teacher and open the Classroom Monitor.
1. The shared teacher should not be able to give scores or comments.

Try all these combinations and make sure they work correctly
View Student Names: off, Grade and Manage: off
View Student Names: on, Grade and Manage: off
View Student Names: off, Grade and Manage: on
View Student Names: on, Grade and Manage: on

Closes #2295