### PR TITLE
Added .pdf to allowed file types for unit assets

### DIFF
--- a/src/main/resources/application_sample.properties
+++ b/src/main/resources/application_sample.properties
@@ -167,7 +167,7 @@ student_max_asset_size=5242880
 student_max_total_assets_size=2097152
 
 # allowed assets for projects. Reference: http://en.wikipedia.org/wiki/Internet_media_type
-normalAuthorAllowedProjectAssetContentTypes=text/plain,text/csv,text/xml,image/gif,image/jpeg,image/png,image/svg+xml,image/gif,audio/mp3,audio/mp4,audio/mpeg,audio/wav,audio/vnd.wave,audio/ogg,audio/webm,audio/x-aac,video/mpeg,video/mp4,video/ogg,video/quicktime,video/x-flv,video/avi,video/webm
+normalAuthorAllowedProjectAssetContentTypes=text/plain,text/csv,text/xml,application/pdf,image/gif,image/jpeg,image/png,image/svg+xml,image/gif,audio/mp3,audio/mp4,audio/mpeg,audio/wav,audio/vnd.wave,audio/ogg,audio/webm,audio/x-aac,video/mpeg,video/mp4,video/ogg,video/quicktime,video/x-flv,video/avi,video/webm
 trustedAuthorAllowedProjectAssetContentTypes=text/html,application/javascript,application/x-javascript,text/javascript,text/css,application/zip,application/x-zip,application/x-zip-compressed,application/gzip
 
 ########## Optional Plugins ##########


### PR DESCRIPTION
To test:
- Update value of `normalAuthorAllowedProjectAssetContentTypes` from `application_sample.properties` in your local `application.properties` and restart server.
- Open a unit in authoring tool, navigate to File Manager, and upload a pdf file.
- Ensure that the pdf file was successfully uploaded to the unit.

Closes #2314.