### PR TITLE
Removed watchers in match grading view to improve performance

### DIFF
--- a/src/main/webapp/wise5/components/match/index.html
+++ b/src/main/webapp/wise5/components/match/index.html
@@ -16,43 +16,43 @@
                   layout-wrap>
                 <div class='match-bucket match-bucket--choices'
                     flex='100'
-                    flex-gt-sm='{{matchController.isHorizontal ? 50: 100}}'>
+                    flex-gt-sm='{{::matchController.isHorizontal ? 50: 100}}'>
                   <md-card>
                     <md-card-title class='match-bucket__header'>
                       <md-card-title-text>
-                        <compile data='matchController.buckets[0].value'></compile>
+                        <compile data='::matchController.buckets[0].value'></compile>
                       </md-card-title-text>
                     </md-card-title>
                     <md-card-content class='match-bucket__content'>
                       <md-list class='match-bucket__contents'
-                          ng-style='matchController.choiceStyle'>
+                          ng-style='::matchController.choiceStyle'>
                         <div class='match-bucket__item'
-                            ng-repeat='item in matchController.buckets[0].items'>
+                            ng-repeat='item in ::matchController.buckets[0].items'>
                           <md-list-item class='match-bucket__item__contents'>
                             <div class='md-list-item-text'>
                               <div flex
                                   layout='row'
                                   layout-align='start center'>
                                 <span class='match-bucket__item__contents__text'>
-                                  <compile data='item.value'></compile>
+                                  <compile data='::item.value'></compile>
                                 </span>
                                 <span flex></span>
                                 <md-icon>open_with</md-icon>
                               </div>
                               <p class='match-feedback md-body-2'
-                                  ng-show='item.feedback'
+                                  ng-if='::item.feedback'
                                   ng-class='{"success-bg": !matchController.hasCorrectAnswer || item.isCorrect, "info-bg": item.isIncorrectPosition, "warn-bg": !item.isCorrect}'>
-                                <md-icon ng-if='matchController.hasCorrectAnswer && item.isCorrect'>
+                                <md-icon ng-if='::matchController.hasCorrectAnswer && item.isCorrect'>
                                   check
                                 </md-icon>
-                                <md-icon ng-if='matchController.hasCorrectAnswer && item.isIncorrectPosition'>
+                                <md-icon ng-if='::matchController.hasCorrectAnswer && item.isIncorrectPosition'>
                                   warning
                                 </md-icon>
-                                <md-icon ng-if='matchController.hasCorrectAnswer && !item.isCorrect && !item.isIncorrectPosition'>
+                                <md-icon ng-if='::matchController.hasCorrectAnswer && !item.isCorrect && !item.isIncorrectPosition'>
                                   clear
                                 </md-icon>
                                 <span>
-                                  <compile data='item.feedback'></compile>
+                                  <compile data='::item.feedback'></compile>
                                 </span>
                               </p>
                             </div>
@@ -61,51 +61,49 @@
                       </md-list>
                     </md-card-content>
                   </md-card>
-                  <md-divider class='match-divider {{matchController.isHorizontal ? "match-divider--horizontal" : ""}}'></md-divider>
+                  <md-divider class='match-divider {{::matchController.isHorizontal ? "match-divider--horizontal" : ""}}'></md-divider>
                 </div>
                 <div layout='row'
                     layout-wrap
                     layout-align='center start'
                     flex='100'
-                    flex-gt-sm='{{matchController.isHorizontal ? 50 : 100}}'>
-                  <div ng-repeat='bucket in matchController.buckets'
+                    flex-gt-sm='{{::matchController.isHorizontal ? 50 : 100}}'>
+                  <div ng-repeat='bucket in ::matchController.buckets'
                       ng-if='$index > 0'
                       class='match-bucket'
                       flex='100'
-                      flex-gt-sm='{{matchController.isHorizontal ? 100 : matchController.bucketWidth}}'>
+                      flex-gt-sm='{{::matchController.isHorizontal ? 100 : matchController.bucketWidth}}'>
                     <md-card>
                       <md-card-title class='match-bucket__header'>
-                        <md-card-title-text><compile data='bucket.value'></compile></md-card-title-text>
+                        <md-card-title-text><compile data='::bucket.value'></compile></md-card-title-text>
                       </md-card-title>
                       <md-card-content class='match-bucket__content'>
                         <md-list class='match-bucket__contents'
-                            dragula='"match_{{matchController.componentId}}"'
-                            dragula-model='bucket.items'
-                            ng-style='matchController.bucketStyle'>
+                            ng-style='::matchController.bucketStyle'>
                           <div class='match-bucket__item'
-                              ng-repeat='item in bucket.items'>
+                              ng-repeat='item in ::bucket.items'>
                             <md-list-item class='match-bucket__item__contents'>
                               <div class='md-list-item-text'>
                                 <div flex layout='row'
                                     layout-align='start center'>
                                   <span class='match-bucket__item__contents__text'>
-                                    <compile data='item.value'></compile>
+                                    <compile data='::item.value'></compile>
                                   </span>
                                 </div>
                                 <p class='match-feedback md-body-2'
-                                    ng-show='item.feedback'
-                                    ng-class='{"success-bg": !matchController.hasCorrectAnswer || item.isCorrect, "info-bg": item.isIncorrectPosition, "warn-bg": !item.isCorrect}'>
-                                  <md-icon ng-if='matchController.hasCorrectAnswer && item.isCorrect'>
+                                    ng-show='::item.feedback'
+                                    ng-class='::{"success-bg": !matchController.hasCorrectAnswer || item.isCorrect, "info-bg": item.isIncorrectPosition, "warn-bg": !item.isCorrect}'>
+                                  <md-icon ng-if='::matchController.hasCorrectAnswer && item.isCorrect'>
                                     check
                                   </md-icon>
-                                  <md-icon ng-if='matchController.hasCorrectAnswer && item.isIncorrectPosition'>
+                                  <md-icon ng-if='::matchController.hasCorrectAnswer && item.isIncorrectPosition'>
                                     warning
                                   </md-icon>
-                                  <md-icon ng-if='matchController.hasCorrectAnswer && !item.isCorrect && !item.isIncorrectPosition'>
+                                  <md-icon ng-if='::matchController.hasCorrectAnswer && !item.isCorrect && !item.isIncorrectPosition'>
                                     clear
                                   </md-icon>
                                   <span>
-                                    <compile data='item.feedback'></compile>
+                                    <compile data='::item.feedback'></compile>
                                   </span>
                                 </p>
                               </div>
@@ -120,49 +118,49 @@
             </div>
             <div>
               <div class='md-caption'
-                  ng-if='matchController.hasCorrectAnswer && matchController.componentContent.maxSubmitCount != null && matchController.componentContent.maxSubmitCount == 1'
-                  ng-show='matchController.componentContent.maxSubmitCount != null'
+                  ng-if='::matchController.hasCorrectAnswer && matchController.componentContent.maxSubmitCount != null && matchController.componentContent.maxSubmitCount == 1'
+                  ng-show='::matchController.componentContent.maxSubmitCount != null'
                   translate='YOU_HAVE_USED_X_OF_Y_ATTEMPT'
-                  translate-values='{x: matchController.submitCounter, y: matchController.componentContent.maxSubmitCount}'>
+                  translate-values='{x: ::matchController.submitCounter, y: ::matchController.componentContent.maxSubmitCount}'>
               </div>
               <div class='md-caption'
-                  ng-if='matchController.hasCorrectAnswer && matchController.componentContent.maxSubmitCount != null && matchController.componentContent.maxSubmitCount > 1'
-                  ng-show='matchController.componentContent.maxSubmitCount != null'
+                  ng-if='::matchController.hasCorrectAnswer && matchController.componentContent.maxSubmitCount != null && matchController.componentContent.maxSubmitCount > 1'
+                  ng-show='::matchController.componentContent.maxSubmitCount != null'
                   translate='YOU_HAVE_USED_X_OF_Y_ATTEMPTS'
-                  translate-values='{x: matchController.submitCounter, y: matchController.componentContent.maxSubmitCount}'>
+                  translate-values='{x: ::matchController.submitCounter, y: ::matchController.componentContent.maxSubmitCount}'>
               </div>
-              <div ng-if='matchController.isLatestComponentStateSubmit == false || !matchController.hasCorrectAnswer'>
+              <div ng-if='::matchController.isLatestComponentStateSubmit == false || !matchController.hasCorrectAnswer'>
                 &nbsp
               </div>
-              <div ng-if='matchController.isLatestComponentStateSubmit && matchController.hasCorrectAnswer && matchController.isCorrect === true'
+              <div ng-if='::matchController.isLatestComponentStateSubmit && matchController.hasCorrectAnswer && matchController.isCorrect === true'
                   style='color: green'>
                 {{ 'CORRECT' | translate }}!
               </div>
-              <div ng-if='matchController.isLatestComponentStateSubmit && matchController.hasCorrectAnswer && matchController.isCorrect === false'
+              <div ng-if='::matchController.isLatestComponentStateSubmit && matchController.hasCorrectAnswer && matchController.isCorrect === false'
                   style='color: red'>
                 {{ 'INCORRECT' | translate }}
               </div>
             </div>
           </div>
           <span flex></span>
-          <component-revisions-info node-id='matchController.nodeId'
-              component-id='matchController.componentId'
+          <component-revisions-info node-id='::matchController.nodeId'
+              component-id='::matchController.componentId'
               to-workgroup-id='workgroupId'
               component-state='componentState'
-              active='matchController.mode === "grading"'>
+              active='::matchController.mode === "grading"'>
           </component-revisions-info>
         </div>
         <div flex='100'
             flex-gt-sm='33'
             class='component--grading__annotations'>
           <component-grading node-id='matchController.nodeId'
-              component-id='matchController.componentId'
-              max-score='matchController.componentContent.maxScore'
+              component-id='::matchController.componentId'
+              max-score='::matchController.componentContent.maxScore'
               from-workgroup-id='teacherWorkgroupId'
               to-workgroup-id='workgroupId'
               component-state-id='componentState.id'
-              show-all-annotations='matchController.mode !== "grading"'
-              is-disabled='matchController.mode !== "grading"'>
+              show-all-annotations='::matchController.mode !== "grading"'
+              is-disabled='::matchController.mode !== "grading"'>
           </component-grading>
         </div>
       </div>


### PR DESCRIPTION
This commit brings the number of watchers from 139 to 59 on a match component with 4 choices and 4 target buckets.

Check that grading match component works as before.

Resolves #2320