### PR TITLE
Importing a step that contains a lot of content fails

### DIFF
--- a/src/main/webapp/wise5/authoringTool/authoringToolProjectService.ts
+++ b/src/main/webapp/wise5/authoringTool/authoringToolProjectService.ts
@@ -1,6 +1,7 @@
 'use strict';
-import ProjectService from '../services/projectService';
 import * as angular from 'angular';
+import * as $ from 'jquery';
+import ProjectService from '../services/projectService';
 
 class AuthoringToolProjectService extends ProjectService {
   static $inject = [
@@ -458,11 +459,11 @@ class AuthoringToolProjectService extends ProjectService {
       method: 'POST',
       url: this.ConfigService.getConfigParam('importStepsURL'),
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      params: {
+      data: $.param({
         steps: angular.toJson(selectedNodes),
         fromProjectId: fromProjectId,
         toProjectId: toProjectId
-      }
+      })
     };
 
     /*


### PR DESCRIPTION
1. Log in as a teacher
1. Open a project in the Authoring Tool
1. Click the "Import Step" button
1. Choose a project to import from
1. Click the checkbox for a lot of steps (for example more than 5 steps)
1. Click the "Import Step(s)" button

This would throw an error before but now it should import the steps successfully.

Closes #2307