### PR TITLE
Export select steps checkbox bug

### DIFF
--- a/src/main/webapp/wise5/classroomMonitor/dataExport/dataExport.html
+++ b/src/main/webapp/wise5/classroomMonitor/dataExport/dataExport.html
@@ -26,24 +26,24 @@
     <div class="l-constrained" layout="column">
         <div style="float:right">
             <div ng-if="dataExportController.exportType == null">
-                <md-button class="md-raised" ng-click="dataExportController.exportOneWorkgroupPerRowClicked()" translate="exportOneWorkgroupPerRow" id="downloadOneWorkgroupPerRowButton"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.exportOneWorkgroupPerRowClicked()" translate="exportOneWorkgroupPerRow" id="downloadOneWorkgroupPerRowButton" aria-label="{{ ::'exportOneWorkgroupPerRow' | translate }}"></md-button>
                 <br/>
-                <md-button class="md-raised" ng-click="dataExportController.exportType = 'latestStudentWork'" translate="exportLatestStudentWork" id="downloadLatestStudentWorkButton"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.exportType = 'latestStudentWork'" translate="exportLatestStudentWork" id="downloadLatestStudentWorkButton" aria-label="{{ ::'exportLatestStudentWork' | translate }}"></md-button>
                 <br/>
-                <md-button class="md-raised" ng-click="dataExportController.exportType = 'allStudentWork'" translate="exportAllStudentWork" id="downloadStudentWorkButton"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.exportType = 'allStudentWork'" translate="exportAllStudentWork" id="downloadStudentWorkButton" aria-label="{{ ::'exportAllStudentWork' | translate }}"></md-button>
                 <br/>
-                <md-button class="md-raised" ng-click="dataExportController.exportType = 'events'" translate="exportEvents" id="downloadStudentEventsButton"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.exportType = 'events'" translate="exportEvents" id="downloadStudentEventsButton" aria-label="{{ ::'exportEvents' | translate }}"></md-button>
                 <br/>
-                <md-button class="md-raised" ng-click="dataExportController.export('latestNotebookItems')" translate="exportLatestNotebookItems" id="downloadLatestNotebookButton"></md-button>
-                <md-button class="md-raised" ng-click="dataExportController.export('allNotebookItems')" translate="exportAllNotebookItems" id="downloadAllNotebookButton"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.export('latestNotebookItems')" translate="exportLatestNotebookItems" id="downloadLatestNotebookButton" aria-label="{{ ::'exportLatestNotebookItems' | translate }}"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.export('allNotebookItems')" translate="exportAllNotebookItems" id="downloadAllNotebookButton" aria-label="{{ ::'exportAllNotebookItems' | translate }}"></md-button>
                 <br/>
-                <md-button class="md-raised" ng-click="dataExportController.export('notifications')" translate="exportNotifications" id="downloadNotificationsButton"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.export('notifications')" translate="exportNotifications" id="downloadNotificationsButton" aria-label="{{ ::'exportNotifications' | translate }}"></md-button>
                 <br/>
-                <md-button class="md-raised" ng-click="dataExportController.export('studentAssets')" translate="exportStudentAssets" id="downloadStudentAssetsButton"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.export('studentAssets')" translate="exportStudentAssets" id="downloadStudentAssetsButton" aria-label="{{ ::'exportStudentAssets' | translate }}"></md-button>
                 <br/>
-                <md-button class="md-raised" ng-click="dataExportController.showExportComponentDataPage()" translate="exportComponentData" id="downloadComponentDataButton"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.showExportComponentDataPage()" translate="exportComponentData" id="downloadComponentDataButton" aria-label="{{ ::'exportComponentData' | translate }}"></md-button>
                 <br/>
-                <md-button class="md-raised" ng-click="dataExportController.rawDataExportClicked()" translate="exportRawData" id="downloadRawDataButton"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.rawDataExportClicked()" translate="exportRawData" id="downloadRawDataButton" aria-label="{{ ::'exportRawData' | translate }}"></md-button>
             </div>
             <div ng-if="dataExportController.exportType == 'latestStudentWork' || dataExportController.exportType == 'allStudentWork' || dataExportController.exportType == 'events' || dataExportController.exportType == 'oneWorkgroupPerRow' || dataExportController.exportType == 'rawData' ">
                 <h4>{{ dataExportController.exportType | translate }}</h4>
@@ -51,76 +51,77 @@
                     <md-button class="md-raised" ng-click="dataExportController.defaultClicked()">{{ ::'default' | translate }}</md-button>
                     <md-button class="md-raised" ng-click="dataExportController.everythingClicked()">{{ ::'everything' | translate }}</md-button>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeStudentWork">{{ ::'includeStudentWork' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeStudentWork">{{ ::'includeStudentWork' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeStudentWorkIds">{{ ::'includeStudentWorkIDs' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeStudentWorkIds">{{ ::'includeStudentWorkIDs' | translate }}</md-checkbox>
                     <br ng-if="dataExportController.canViewStudentNames"/>
-                    <md-checkbox ng-model="dataExportController.includeStudentNames" ng-if="dataExportController.canViewStudentNames">{{ ::'includeStudentNames' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeStudentNames" ng-if="dataExportController.canViewStudentNames">{{ ::'includeStudentNames' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeStudentWorkTimestamps">{{ ::'includeStudentWorkTimestamps' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeStudentWorkTimestamps">{{ ::'includeStudentWorkTimestamps' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeBranchPathTaken">{{ ::'includeBranchPathTaken' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeBranchPathTaken">{{ ::'includeBranchPathTaken' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeBranchPathTakenNodeId">{{ ::'includeBranchPathTakenNodeId' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeBranchPathTakenNodeId">{{ ::'includeBranchPathTakenNodeId' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeBranchPathTakenStepTitle">{{ ::'includeBranchPathTakenStepTitle' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeBranchPathTakenStepTitle">{{ ::'includeBranchPathTakenStepTitle' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeScores">{{ ::'includeScores' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeScores">{{ ::'includeScores' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeScoreTimestamps">{{ ::'includeScoreTimestamps' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeScoreTimestamps">{{ ::'includeScoreTimestamps' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeComments">{{ ::'includeComments' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeComments">{{ ::'includeComments' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeCommentTimestamps">{{ ::'includeCommentTimestamps' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeCommentTimestamps">{{ ::'includeCommentTimestamps' | translate }}</md-checkbox>
                 </div>
                 <div ng-if="dataExportController.exportType == 'rawData'">
                     <md-button class="md-raised" ng-click="dataExportController.defaultClicked()">{{ ::'default' | translate }}</md-button>
                     <md-button class="md-raised" ng-click="dataExportController.everythingClicked()">{{ ::'everything' | translate }}</md-button>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeStudentWork">{{ ::'includeStudentWork' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeStudentWork">{{ ::'includeStudentWork' | translate }}</md-checkbox>
                     <br ng-if="dataExportController.canViewStudentNames"/>
-                    <md-checkbox ng-model="dataExportController.includeStudentNames" ng-if="dataExportController.canViewStudentNames">{{ ::'includeStudentNames' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeStudentNames" ng-if="dataExportController.canViewStudentNames">{{ ::'includeStudentNames' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeAnnotations">{{ ::'includeAnnotations' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeAnnotations">{{ ::'includeAnnotations' | translate }}</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeEvents">{{ ::'includeEvents' | translate }}</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeEvents">{{ ::'includeEvents' | translate }}</md-checkbox>
                     <br/>
                 </div>
                 <div ng-if="dataExportController.exportType == 'latestStudentWork' || dataExportController.exportType == 'allStudentWork'">
                   <br ng-if="dataExportController.canViewStudentNames"/>
-                  <md-checkbox ng-model="dataExportController.includeStudentNames" ng-if="dataExportController.canViewStudentNames">{{ ::'includeStudentNames' | translate }}</md-checkbox>
+                  <md-checkbox class="md-primary" ng-model="dataExportController.includeStudentNames" ng-if="dataExportController.canViewStudentNames">{{ ::'includeStudentNames' | translate }}</md-checkbox>
                 </div>
                 <div ng-if="dataExportController.exportType === 'events'">
-                    <md-checkbox ng-model="dataExportController.includeStudentEvents">Include Student Events</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeStudentEvents">Include Student Events</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeTeacherEvents">Include Teacher Events</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeTeacherEvents">Include Teacher Events</md-checkbox>
                     <br/>
-                    <md-checkbox ng-model="dataExportController.includeNames">Include Names</md-checkbox>
+                    <md-checkbox class="md-primary" ng-model="dataExportController.includeNames">Include Names</md-checkbox>
                 </div>
                 <md-radio-group ng-if="dataExportController.exportType == 'latestStudentWork' || dataExportController.exportType == 'allStudentWork' || dataExportController.exportType == 'oneWorkgroupPerRow' || dataExportController.exportType == 'rawData'"
                                 ng-model="dataExportController.exportStepSelectionType">
                     <md-radio-button value="exportAllSteps" class="md-primary">{{ ::'exportAllSteps' | translate }}</md-radio-button>
                     <md-radio-button value="exportSelectSteps" class="md-primary">{{ ::'exportSelectSteps' | translate }}</md-radio-button>
                 </md-radio-group>
-                <md-button class="md-raised" ng-click="dataExportController.export()" translate="export" id="doExportButton"></md-button>
-                <md-button class="md-raised" ng-click="dataExportController.exportType = null" translate="cancel" id="cancel"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.export()" translate="export" id="doExportButton" aria-label="{{ ::'export' | translate }}"></md-button>
+                <md-button class="md-raised" ng-click="dataExportController.exportType = null" translate="cancel" id="cancel" aria-label="{{ ::'cancel' | translate }}"></md-button>
                 <div ng-if="dataExportController.exportStepSelectionType == 'exportSelectSteps'">
-                    <md-button translate="selectAll" ng-click="dataExportController.selectAll()"></md-button>
-                    <md-button translate="deselectAll" ng-click="dataExportController.deselectAll()"></md-button><br/>
+                    <md-button translate="selectAll" ng-click="dataExportController.selectAll()" aria-label="{{ ::'selectAll' | translate }}"></md-button>
+                    <md-button translate="deselectAll" ng-click="dataExportController.deselectAll()" aria-label="{{ ::'deselectAll' | translate }}"></md-button><br/>
                     <h4 style='display:inline'>{{dataExportController.project.metadata.title}}</h4>
                     <span style="cursor:pointer" ng-click='dataExportController.previewProject()'>
                         <md-tooltip md-direction="right"><span translate="preview"></span></md-tooltip>
                         <md-icon>pageview</md-icon>
                     </span><br/>
                     <div ng-repeat='projectItem in dataExportController.projectIdToOrder'>
-                        <input type='checkbox'
-                                    ng-click="dataExportController.nodeItemClicked(projectItem)"
-                                    ng-model='projectItem.checked'
+                        <md-checkbox ng-model='projectItem.checked'
+                                    ng-change="dataExportController.nodeItemClicked(projectItem)"
                                     ng-if='projectItem.order != 0'
-                                    ng-class='{"groupHeader": dataExportController.isGroupNode(projectItem.node.id), "stepHeader": !dataExportController.isGroupNode(projectItem.node.id), "branchPathStepHeader": dataExportController.isNodeInAnyBranchPath(projectItem.node.id) && !dataExportController.isGroupNode(projectItem.node.id)}'/>
-                        <h6 style='display: inline; cursor: pointer' ng-if='projectItem.order != 0'>
-                            {{::dataExportController.getNodePositionById(projectItem.node.id)}} {{::dataExportController.getNodeTitleByNodeId(projectItem.node.id)}}
-                        </h6>
+                                    ng-class='{"md-primary": true, "groupHeader": dataExportController.isGroupNode(projectItem.node.id), "stepHeader": !dataExportController.isGroupNode(projectItem.node.id), "branchPathStepHeader": dataExportController.isNodeInAnyBranchPath(projectItem.node.id) && !dataExportController.isGroupNode(projectItem.node.id)}'
+                                    aria-label='{{ ::"step" | translate }}'>
+                            <h6 style='display: inline; cursor: pointer' ng-if='projectItem.order != 0'>
+                                {{::dataExportController.getNodePositionById(projectItem.node.id)}} {{::dataExportController.getNodeTitleByNodeId(projectItem.node.id)}}
+                            </h6>
+                        </md-checkbox>
                         <span style="cursor:pointer" ng-if='projectItem.node.type != "group"'
                                 ng-click='dataExportController.previewNode(projectItem.node)'>
                             <md-tooltip md-direction="right"><span translate="preview"></span></md-tooltip>
@@ -128,15 +129,17 @@
                         </span>
                         <div ng-if='projectItem.order != 0 && projectItem.node.type != "group" && projectItem.node.components.length > 0'
                              ng-repeat='componentItem in ::projectItem.node.components track by $index'>
-                            <input type='checkbox' ng-model='componentItem.checked' class='componentHeader'/> {{::($index + 1)}} {{::componentItem.type}}
+                            <md-checkbox ng-model='componentItem.checked' class='md-primary componentHeader' aria-label='{{ ::componentItem.type }}'>
+                                {{::($index + 1)}} {{::componentItem.type}}
+                            </md-checkbox>
                         </div>
                     </div>
-                    <md-button class="md-raised" ng-click="dataExportController.export()" translate="export" id="doExportButton2"></md-button>
-                    <md-button class="md-raised" ng-click="dataExportController.exportType = null" translate="cancel" id="cancel"></md-button>
+                    <md-button class="md-raised" ng-click="dataExportController.export()" translate="export" id="doExportButton2" aria-label="{{ ::'export' | translate }}"></md-button>
+                    <md-button class="md-raised" ng-click="dataExportController.exportType = null" translate="cancel" id="cancel" aria-label="{{ ::'cancel' | translate }}"></md-button>
                 </div>
             </div>
             <div ng-if='dataExportController.exportType == "componentData"'>
-              <md-button class="md-raised" ng-click="dataExportController.exportType = null" id="cancel">
+              <md-button class="md-raised" ng-click="dataExportController.exportType = null" id="cancel" aria-label="{{ ::'cancel' | translate }}">
                   <md-icon>arrow_back</md-icon>
                   <md-tooltip>
                       {{ ::'back' | translate }}
@@ -148,11 +151,11 @@
                   <md-radio-button value="exportAllWork" class="md-primary">{{ ::'exportAllStudentWork' | translate }}</md-radio-button>
                   <md-radio-button value="exportLatestWork" class="md-primary">{{ ::'exportLatestStudentWork' | translate }}</md-radio-button>
               </md-radio-group>
-              <md-checkbox ng-model="dataExportController.includeStudentNames" ng-if="dataExportController.canViewStudentNames">{{ ::'includeStudentNames' | translate }}</md-checkbox>
+              <md-checkbox class="md-primary" ng-model="dataExportController.includeStudentNames" ng-if="dataExportController.canViewStudentNames">{{ ::'includeStudentNames' | translate }}</md-checkbox>
               <br ng-if="dataExportController.canViewStudentNames"/>
-              <md-checkbox ng-model="dataExportController.includeCorrectnessColumns">{{ ::'includeCorrectnessColumns' | translate }}</md-checkbox>
+              <md-checkbox class="md-primary" ng-model="dataExportController.includeCorrectnessColumns">{{ ::'includeCorrectnessColumns' | translate }}</md-checkbox>
               <br/>
-              <md-checkbox ng-model="dataExportController.includeOnlySubmits">{{ ::'includeOnlySubmits' | translate }}</md-checkbox>
+              <md-checkbox class="md-primary" ng-model="dataExportController.includeOnlySubmits">{{ ::'includeOnlySubmits' | translate }}</md-checkbox>
               <br/>
               <h4 style='display:inline'>{{dataExportController.project.metadata.title}}</h4>
               <span style="cursor:pointer" ng-click='dataExportController.previewProject()'>


### PR DESCRIPTION
Test checkbox clicking
1. Sign in as a teacher
1. Open the Classroom Monitor for a run that has student work
1. Go to the "Data Export" view
1. Click "All Student Work"
1. Click "Select steps to export"
1. Click the checkbox for an activity
1. Make sure all the steps and components in the activity also become checked
1. Uncheck the checkbox for an activity
1. Make sure all the steps and components in the activity also become unchecked
1. Check some checkboxes
1. Download the export
1. Make sure the work for the checked items are included in the export and not things that are not checked

Test checkbox styling
1. Click all the checkboxes for the options like "Include..." and for activities, steps, and components in the "Select steps to export" view.
1. Make sure the checkboxes are now all blue. They used to be orange.

Test aria-labels
1. Open the browser console.
1. Reload the export page.
1. Make sure there are no more aria-label warnings in the console.

Closes #2333