### PR TITLE
When a student clicks the Go Home button, save a nodeExited event

### DIFF
--- a/src/main/webapp/wise5/services/sessionService.js
+++ b/src/main/webapp/wise5/services/sessionService.js
@@ -36,6 +36,7 @@ class SessionService {
   }
 
   goHome() {
+    this.$rootScope.$broadcast('exit');
     this.$location.url(this.ConfigService.getConfigParam('userType'));
   }
 


### PR DESCRIPTION
1. Log in as a student
1. Launch a run
1. Click the upper right avatar and then click the "Go Home" button
1. We previously did not save a nodeExited event when this occurred but now a nodeExited event should be saved. You can check in the database events table.

Closes #2355