### PR TITLE
Transfer run ownership throws an error

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherRunPermissionsAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherRunPermissionsAPIController.java
@@ -1,6 +1,5 @@
 package org.wise.portal.presentation.web.controllers.teacher;
 
-import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.wise.portal.dao.ObjectNotFoundException;
@@ -24,7 +23,7 @@ public class TeacherRunPermissionsAPIController {
 
   @RequestMapping(value = "/{runId}/{teacherUsername}", method = RequestMethod.PUT)
   protected SharedOwner addSharedOwner(@PathVariable Long runId,
-                                       @PathVariable String teacherUsername) {
+      @PathVariable String teacherUsername) {
     try {
       return runService.addSharedTeacher(runId, teacherUsername);
     } catch (ObjectNotFoundException e) {
@@ -36,7 +35,7 @@ public class TeacherRunPermissionsAPIController {
 
   @PutMapping("/transfer/{runId}/{teacherUsername}")
   protected String transferRunOwnership(@PathVariable Long runId,
-                                        @PathVariable String teacherUsername) {
+      @PathVariable String teacherUsername) {
     try {
       return runService.transferRunOwnership(runId, teacherUsername).toString();
     } catch (ObjectNotFoundException e) {
@@ -46,7 +45,7 @@ public class TeacherRunPermissionsAPIController {
 
   @RequestMapping(value = "/{runId}/{username}", method = RequestMethod.DELETE)
   protected SimpleResponse removeSharedOwner(@PathVariable Long runId,
-                                             @PathVariable String username) {
+      @PathVariable String username) {
     try {
       runService.removeSharedTeacher(username, runId);
       return new SimpleResponse("success", "successfully removed shared owner");
@@ -56,9 +55,8 @@ public class TeacherRunPermissionsAPIController {
   }
 
   @RequestMapping(value = "/{runId}/{userId}/{permissionId}", method = RequestMethod.PUT)
-  protected SimpleResponse addPermission(@PathVariable Long runId,
-                                         @PathVariable Long userId,
-                                         @PathVariable Integer permissionId) {
+  protected SimpleResponse addPermission(@PathVariable Long runId, @PathVariable Long userId,
+      @PathVariable Integer permissionId) {
     try {
       runService.addSharedTeacherPermission(runId, userId, permissionId);
       return new SimpleResponse("success", "successfully added run permission");
@@ -68,9 +66,8 @@ public class TeacherRunPermissionsAPIController {
   }
 
   @RequestMapping(value = "/{runId}/{userId}/{permissionId}", method = RequestMethod.DELETE)
-  protected SimpleResponse deletePermission(@PathVariable Long runId,
-                                            @PathVariable Long userId,
-                                            @PathVariable Integer permissionId) {
+  protected SimpleResponse deletePermission(@PathVariable Long runId, @PathVariable Long userId,
+      @PathVariable Integer permissionId) {
     try {
       runService.removeSharedTeacherPermission(runId, userId, permissionId);
       return new SimpleResponse("success", "successfully removed run permission");

--- a/src/main/webapp/site/src/app/teacher/teacher.service.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher.service.ts
@@ -14,7 +14,7 @@ export class TeacherService {
   private registerUrl = '/api/teacher/register';
   private runPermissionUrl = '/api/teacher/run/permission';
   private projectPermissionUrl = '/api/teacher/project/permission';
-  private transferRunOwnershipUrl = '//api/teacher/run/permission/transfer';
+  private transferRunOwnershipUrl = '/api/teacher/run/permission/transfer';
   private usernamesUrl = '/api/teacher/usernames';
   private createRunUrl = '/api/teacher/run/create';
   private runUrl = '/api/teacher/run';
@@ -101,7 +101,7 @@ export class TeacherService {
   transferRunOwnership(runId: number, teacherUsername: string) {
     const url = `${this.transferRunOwnershipUrl}/${runId}/${teacherUsername}`;
     const headers = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
-    return this.http.put(url, null, { headers: headers });
+    return this.http.put<Object>(url, null, { headers: headers });
   }
 
   removeSharedOwner(runId: number, username: string) {


### PR DESCRIPTION
1. Log in as a teacher
1. Find a run to share
1. Click the 3 dots to open up the run menu
1. Click "Share"
1. Click "Transfer Ownership"
1. Enter a teacher username
1. Click on the teacher username
1. Click "Proceed"
1. It used to show this message "An error occurred. Please refresh this page and try again." and fail but now it should succeed in transferring the run.

We just had an extra / in the transfer url
Before fix
```private transferRunOwnershipUrl = '//api/teacher/run/permission/transfer';```

After fix
```private transferRunOwnershipUrl = '/api/teacher/run/permission/transfer';```

This caused it to make the request to
```https://api/teacher/run/permission/transfer/28818/aa```
instead of
```https://wise.berkeley.edu/api/teacher/run/permission/transfer/28818/aa```

All other changes in this PR are just minor code cleanup.

Closes #2359