### PR TITLE
Resize images before uploading as student assets

### DIFF
--- a/src/main/webapp/wise5/themes/default/notebook/editNotebookItem.html
+++ b/src/main/webapp/wise5/themes/default/notebook/editNotebookItem.html
@@ -28,6 +28,8 @@
                  ngf-drop
                  ngf-select
                  ngf-change="editNotebookItemController.attachStudentAssetToNote($files)"
+                 ngf-resize="{quality: .8, width: 1000, height: 1000, pattern:'image/*', restoreExif: true}"
+                 ngf-resize-if="$width > 1000 || $height > 1000"
                  class="notebook-item__upload"
                  drag-over-class="dragover" allow-dir="false"
                  accept="image/*,application/pdf,text/csv">

--- a/src/main/webapp/wise5/themes/default/studentAsset/studentAsset.html
+++ b/src/main/webapp/wise5/themes/default/studentAsset/studentAsset.html
@@ -68,6 +68,8 @@
 <div>
     <div ng-if="::studentAssetController.mode != 'preview'" ngf-drop ngf-select ngf-change="studentAssetController.uploadStudentAssets($files)" class="drop-box"
          drag-over-class="dragover" ngf-multiple="true" allow-dir="false"
+         ngf-resize="{quality: .8, width: 1000, height: 1000, centerCrop: true, pattern:'image/*', restoreExif: true}"
+         ngf-resize-if="$width > 1000 || $height > 1000"
          accept="image/*,application/pdf,text/csv" translate="dropAssetMessage"></div>
     <!-- TODO: ask researchers if we should display usage information to students. we'll hide it for now.
     You are using {{studentAssetController.notebook.totalSize | appropriateSizeText }} out of {{studentAssetController.notebook.totalSizeMax | appropriateSizeText}} ({{studentAssetController.notebook.usagePercentage | roundToDecimal:0 }}%)

--- a/src/main/webapp/wise5/themes/default/studentAsset/studentAsset.html
+++ b/src/main/webapp/wise5/themes/default/studentAsset/studentAsset.html
@@ -68,7 +68,7 @@
 <div>
     <div ng-if="::studentAssetController.mode != 'preview'" ngf-drop ngf-select ngf-change="studentAssetController.uploadStudentAssets($files)" class="drop-box"
          drag-over-class="dragover" ngf-multiple="true" allow-dir="false"
-         ngf-resize="{quality: .8, width: 1000, height: 1000, centerCrop: true, pattern:'image/*', restoreExif: true}"
+         ngf-resize="{quality: .8, width: 1000, height: 1000, pattern:'image/*', restoreExif: true}"
          ngf-resize-if="$width > 1000 || $height > 1000"
          accept="image/*,application/pdf,text/csv" translate="dropAssetMessage"></div>
     <!-- TODO: ask researchers if we should display usage information to students. we'll hide it for now.


### PR DESCRIPTION
Test that images bigger than 1000x1000 are resized and reduced in quality before being uploaded onto the server.

When testing locally, you can see the uploaded images in src/main/webapp/studentuploads directory.