### PR TITLE
Save a node exit event when the student refreshes the VLE

### DIFF
--- a/src/main/webapp/wise5/services/sessionService.js
+++ b/src/main/webapp/wise5/services/sessionService.js
@@ -16,8 +16,10 @@ class SessionService {
   }
 
   calculateIntervals(sessionTimeout) {
-    const forceLogoutAfterWarningInterval =
-        Math.min(sessionTimeout * 0.1, this.defaultForceLogoutAfterWarningInterval);
+    const forceLogoutAfterWarningInterval = Math.min(
+      sessionTimeout * 0.1,
+      this.defaultForceLogoutAfterWarningInterval
+    );
     const showWarningInterval = sessionTimeout - forceLogoutAfterWarningInterval;
     return {
       showWarningInterval: showWarningInterval,
@@ -41,7 +43,6 @@ class SessionService {
   }
 
   logOut() {
-    this.$rootScope.$broadcast('exit');
     window.location.href = this.ConfigService.getSessionLogOutURL();
   }
 
@@ -52,7 +53,9 @@ class SessionService {
   }
 
   startCheckMouseEvent() {
-    setInterval(() => { this.checkMouseEvent(); }, this.checkMouseEventInterval);
+    setInterval(() => {
+      this.checkMouseEvent();
+    }, this.checkMouseEventInterval);
   }
 
   convertMinutesToSeconds(minutes) {
@@ -85,12 +88,14 @@ class SessionService {
   }
 
   isActiveWithinLastMinute() {
-    return (new Date() - this.lastActivityTimestamp) < this.convertMinutesToMilliseconds(1);
+    return new Date() - this.lastActivityTimestamp < this.convertMinutesToMilliseconds(1);
   }
 
   isInactiveLongEnoughToForceLogout() {
-    return this.getInactiveTimeInSeconds() >=
-        (this.showWarningInterval + this.forceLogoutAfterWarningInterval);
+    return (
+      this.getInactiveTimeInSeconds() >=
+      this.showWarningInterval + this.forceLogoutAfterWarningInterval
+    );
   }
 
   isInactiveLongEnoughToWarn() {
@@ -126,7 +131,7 @@ class SessionService {
 
   renewSession() {
     const renewSessionURL = this.ConfigService.getConfigParam('renewSessionURL');
-    this.$http.get(renewSessionURL).then((result) => {
+    this.$http.get(renewSessionURL).then(result => {
       if (result.data === 'false') {
         this.logOut();
       }
@@ -134,11 +139,6 @@ class SessionService {
   }
 }
 
-SessionService.$inject = [
-  '$http',
-  '$location',
-  '$rootScope',
-  'ConfigService'
-];
+SessionService.$inject = ['$http', '$location', '$rootScope', 'ConfigService'];
 
 export default SessionService;

--- a/src/main/webapp/wise5/vle/vleController.ts
+++ b/src/main/webapp/wise5/vle/vleController.ts
@@ -42,6 +42,7 @@ class VLEController {
     '$mdMenu',
     '$state',
     '$transitions',
+    '$window',
     'AnnotationService',
     'ConfigService',
     'NotebookService',
@@ -55,11 +56,12 @@ class VLEController {
     private $anchorScroll: any,
     private $scope: any,
     private $rootScope: any,
-    $filter: any,
+    private $filter: any,
     private $mdDialog: any,
     private $mdMenu: any,
     private $state: any,
     private $transitions: any,
+    private $window: any,
     private AnnotationService: AnnotationService,
     private ConfigService: ConfigService,
     private NotebookService: NotebookService,
@@ -75,7 +77,8 @@ class VLEController {
     this.ProjectService = ProjectService;
     this.SessionService = SessionService;
     this.StudentDataService = StudentDataService;
-    this.$translate = $filter('translate');
+    this.$translate = this.$filter('translate');
+    this.$window.onbeforeunload = () => { this.$rootScope.$broadcast('exit'); };
 
     this.workgroupId = this.ConfigService.getWorkgroupId();
     this.currentNode = null;


### PR DESCRIPTION
1. Log in as a student
1. Launch a run
1. Refresh the VLE
1. Make sure a nodeExited event is saved to the database

Also make sure a nodeExited event is saved when the student clicks the "Go Home" button and the "Sign Out" button.

Here is a convenient database query to look at the latest events.
```select * from `wise_database`.`events` order by id desc limit 10;```

Closes #2362