### PR TITLE
Added Google Analytics pageview tracking on route changes

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
@@ -126,6 +126,7 @@ public class UserAPIController {
     String contextPath = request.getContextPath();
     config.put("contextPath", contextPath);
     config.put("currentTime", System.currentTimeMillis());
+    config.put("googleAnalyticsId", appProperties.get("google_analytics_id"));
     config.put("googleClientId", googleClientId);
     config.put("isGoogleClassroomEnabled", isGoogleClassroomEnabled());
     config.put("logOutURL", contextPath + "/logout");

--- a/src/main/webapp/site/src/app/app.component.spec.ts
+++ b/src/main/webapp/site/src/app/app.component.spec.ts
@@ -4,16 +4,20 @@ import { Component } from "@angular/core";
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MediaChange, MediaObserver } from '@angular/flex-layout';
-import { Observable } from 'rxjs';
+import { Observable, config, BehaviorSubject } from 'rxjs';
 import { UtilService } from "./services/util.service";
 import { configureTestSuite } from 'ng-bullet';
 import { Announcement } from './domain/announcement';
 import { ConfigService } from './services/config.service';
+import { Config } from "./domain/config";
+import { environment } from '../environments/environment';
 
 @Component({selector: 'router-outlet', template: ''})
 class RouterOutletStubComponent { }
 
 export class MockConfigService {
+  private config$: BehaviorSubject<Config> = new BehaviorSubject<Config>(null);
+  
   getAnnouncement(): Observable<Announcement> {
     return Observable.create(observer => {
       const announcement: Announcement = new Announcement();
@@ -21,6 +25,17 @@ export class MockConfigService {
       observer.next(announcement);
       observer.complete();
     });
+  }
+
+  getConfig(): Observable<Config> {
+    const config: Config = new Config();
+    config.googleAnalyticsId = 'UA-XXXXXX-1';
+    this.config$.next(config);
+    return this.config$;
+  }
+
+  getGoogleAnalyticsId(): string {
+    return this.config$.getValue().googleAnalyticsId;
   }
 }
 
@@ -50,6 +65,7 @@ export class MockObservableMedia {
 describe('AppComponent', () => {
   let component: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
+  environment.production = true;
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
@@ -86,5 +102,9 @@ describe('AppComponent', () => {
     component.dismissAnnouncement();
     fixture.detectChanges();
     expect(shadowRoot.querySelector('app-announcement')).toBeFalsy();
+  }));
+
+  it(`should set Google Analytics tracking code`, async(() => {
+    expect(component.googleAnalyticsId).toEqual('UA-XXXXXX-1');
   }));
 });

--- a/src/main/webapp/site/src/app/app.component.ts
+++ b/src/main/webapp/site/src/app/app.component.ts
@@ -8,6 +8,7 @@ import { MediaChange, MediaObserver } from '@angular/flex-layout';
 import { UtilService } from "./services/util.service";
 import { ConfigService } from "./services/config.service";
 import { Announcement } from './domain/announcement';
+declare let gtag: Function;
 
 @Component({
   selector: 'app-root',
@@ -96,6 +97,7 @@ export class AppComponent {
   ngOnInit() {
     this.router.events.subscribe((ev: any) => {
       if (ev instanceof NavigationEnd) {
+        gtag('config', 'UA-789725-1', { 'page_path': ev.urlAfterRedirects });
         this.showDefaultMode = this.isShowDefaultMode();
         this.showHeaderAndFooter = this.isShowHeaderAndFooter();
         this.isAngularJSPath = this.isAngularJSRoute();

--- a/src/main/webapp/site/src/app/domain/config.ts
+++ b/src/main/webapp/site/src/app/domain/config.ts
@@ -1,5 +1,6 @@
 export class Config {
   contextPath: string;
+  googleAnalyticsId?: string;
   googleClientId?: string;
   isGoogleClassroomEnabled?: boolean;
   recaptchaPublicKey?: string;

--- a/src/main/webapp/site/src/app/services/config.service.ts
+++ b/src/main/webapp/site/src/app/services/config.service.ts
@@ -32,6 +32,10 @@ export class ConfigService {
     return this.config$.getValue().contextPath;
   }
 
+  getGoogleAnalyticsId() {
+    return this.config$.getValue().googleAnalyticsId;
+  }
+
   getGoogleClientId() {
     return this.config$.getValue().googleClientId;
   }

--- a/src/main/webapp/site/src/index.html
+++ b/src/main/webapp/site/src/index.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-789725-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-789725-1', { 'send_page_view': false });
+  </script>
   <base href="/" />
   <meta charset="utf-8">
   <title>WISE: Web-based Inquiry Science Environment</title>

--- a/src/main/webapp/site/src/index.html
+++ b/src/main/webapp/site/src/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-789725-1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-789725-1', { 'send_page_view': false });
-  </script>
   <base href="/" />
   <meta charset="utf-8">
   <title>WISE: Web-based Inquiry Science Environment</title>

--- a/src/test/java/org/wise/portal/presentation/web/controllers/user/UserAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/user/UserAPIControllerTest.java
@@ -61,6 +61,7 @@ public class UserAPIControllerTest extends APIControllerTest {
   public void getConfig_WISEContextPath_ReturnConfig() {
     expect(request.getContextPath()).andReturn("wise");
     replay(request);
+    expect(appProperties.get("google_analytics_id")).andReturn("UA-XXXXXX-1");
     expect(appProperties.get("recaptcha_public_key")).andReturn("recaptcha-123-abc");
     expect(appProperties.get("wise4.hostname")).andReturn("http://localhost:8080/legacy");
     replay(appProperties);
@@ -68,6 +69,7 @@ public class UserAPIControllerTest extends APIControllerTest {
     assertEquals("wise", config.get("contextPath"));
     assertEquals("wise/logout", config.get("logOutURL"));
     assertFalse((boolean) config.get("isGoogleClassroomEnabled"));
+    assertEquals("UA-XXXXXX-1", config.get("googleAnalyticsId"));
     verify(request);
     verify(appProperties);
   }


### PR DESCRIPTION
Any change in route will now generate a pageview on Google Analytics.

To test:
- Traffic from `localhost` is being filtered in GA, so testing locally won't work without modifying Analytics settings. To do so, remove the 'localhost' filter (Admin -> Filters for the 'wise.berkeley.edu' view).
- Navigate around the site and verify that pageviews are being recorded. This can be done by monitoring real-time traffic in GA (Realtime -> Overview).
- After testing, re-enable the localhost filter by adding a new filter with these settings:
![Screen Shot 2020-05-22 at 9 55 14 AM](https://user-images.githubusercontent.com/297450/82692746-19d72d80-9c15-11ea-82ce-990013f506b4.png)


Closes #2368. 