### PR TITLE
WISE4 unit preview and links to WISE4 teacher tools broken

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
@@ -151,6 +151,10 @@ public class AuthorAPIController {
         ModelAndView wise5AuthoringView = new ModelAndView(
             new RedirectView("../teacher/edit/unit/" + projectIdStr));
         return wise5AuthoringView;
+      } else if (project.getWiseVersion().equals(4)) {
+        ModelAndView wise4AuthoringView = new ModelAndView(
+            new RedirectView("/legacy/author/authorproject.html?projectId=" + projectIdStr));
+        return wise4AuthoringView;
       }
     }
     return null;

--- a/src/main/java/org/wise/portal/service/project/impl/ProjectServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/project/impl/ProjectServiceImpl.java
@@ -317,7 +317,17 @@ public class ProjectServiceImpl implements ProjectService {
 
   public ModelAndView previewProject(PreviewProjectParameters params) throws Exception {
     Project project = params.getProject();
-    return previewProjectWISE5(params, project);
+    if (project.getWiseVersion().equals(4)) {
+      return previewProjectWISE4(params, project);
+    } else {
+      return previewProjectWISE5(params, project);
+    }
+  }
+
+  private ModelAndView previewProjectWISE4(PreviewProjectParameters params, Project project) {
+    String contextPath = params.getHttpServletRequest().getContextPath();
+    String wise4URL = contextPath + "/legacy/previewproject.html?projectId=" + project.getId();
+    return new ModelAndView(new RedirectView(wise4URL));
   }
 
   private ModelAndView previewProjectWISE5(PreviewProjectParameters params, Project project) {

--- a/src/main/webapp/portal/admin/project/manageallprojects.jsp
+++ b/src/main/webapp/portal/admin/project/manageallprojects.jsp
@@ -148,7 +148,7 @@ function updateMaxTotalAssetsSize(projectId, newMaxTotalAssetsSize) {
 			</div>
 		</td>
 		<td>
-		<a href="${contextPath}/teacher/edit/unit/${project.id}">Edit Project</a><br/>
+		<a href="${contextPath}/author/authorproject.html?projectId=${project.id}">Edit Project</a><br/>
 		<a href="${contextPath}/teacher/projects/customized/shareproject.html?projectId=${project.id}">Manage Shared Teachers</a><br/>
 		<a href="${contextPath}/project/export/${project.id}">Export project as Zip</a>
 		</td>

--- a/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.ts
@@ -9,6 +9,7 @@ import { I18n } from '@ngx-translate/i18n-polyfill';
 import { Project } from "../../../domain/project";
 import { ParentProject } from "../../../domain/parentProject";
 import { Router } from '@angular/router';
+import { ConfigService } from '../../../services/config.service';
 
 @Component({
   selector: 'app-library-project-details',
@@ -33,6 +34,7 @@ export class LibraryProjectDetailsComponent implements OnInit {
   constructor(public dialog: MatDialog,
               public dialogRef: MatDialogRef<LibraryProjectDetailsComponent>,
               @Inject(MAT_DIALOG_DATA) public data: any,
+              private configService: ConfigService,
               private libraryService: LibraryService,
               private userService: UserService,
               private i18n: I18n) {
@@ -118,6 +120,10 @@ export class LibraryProjectDetailsComponent implements OnInit {
   }
 
   previewProject() {
-    window.open(`/preview/unit/${this.project.id}`);
+    if (this.project.wiseVersion === 4) {
+      window.open(`${this.configService.getWISE4Hostname()}` + `/previewproject?projectId=${this.project.id}`);
+    } else {
+      window.open(`/preview/unit/${this.project.id}`);
+    }
   }
 }

--- a/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/library-project-details/library-project-details.component.ts
@@ -121,7 +121,7 @@ export class LibraryProjectDetailsComponent implements OnInit {
 
   previewProject() {
     if (this.project.wiseVersion === 4) {
-      window.open(`${this.configService.getWISE4Hostname()}` + `/previewproject?projectId=${this.project.id}`);
+      window.open(`${this.configService.getWISE4Hostname()}` + `/previewproject.html?projectId=${this.project.id}`);
     } else {
       window.open(`/preview/unit/${this.project.id}`);
     }

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
@@ -45,7 +45,8 @@ export class TeacherRunListItemComponent implements OnInit {
     const contextPath = this.configService.getContextPath();
     this.editLink = `${contextPath}/author/authorproject.html?projectId=${this.run.project.id}`;
     if (this.run.project.wiseVersion === 4) {
-      this.gradeAndManageLink = `${this.configService.getWISE4Hostname()}/teacher/run/manage/${this.run.id}`;
+      this.gradeAndManageLink = `${this.configService.getWISE4Hostname()}` +
+          `/teacher/classroomMonitor/classroomMonitor?runId=${this.run.id}&gradingType=monitor`;
     } else {
       this.gradeAndManageLink = `${contextPath}/teacher/manage/unit/${this.run.id}`;
     }
@@ -66,7 +67,11 @@ export class TeacherRunListItemComponent implements OnInit {
   }
 
   launchGradeAndManageTool() {
-    this.router.navigateByUrl(this.gradeAndManageLink);
+    if (this.run.project.wiseVersion === 4) {
+      window.location.href = this.gradeAndManageLink;
+    } else {
+      this.router.navigateByUrl(this.gradeAndManageLink);
+    }
   }
 
   periodsString() {


### PR DESCRIPTION
Test that these links work for WISE4 projects/runs. I used a QA server to test since I don't have the legacy webapp locally and I don't have any WISE4 projects/runs locally. You can start back up the QA-2020-05-22-test instance that I used to test it.

1. Go to the teacher home. Find a WISE4 run. Click "Teacher Tools".
1. Go to the teacher home. Find a WISE4 run. Click the 3 dots for a run. Click "Preview".
1. Go to the teacher home. Find a WISE4 run. Click the 3 dots for a run. Click "Unit Info". Click "Preview".
1. Go to the admin page. Search for a WISE4 project id. Click the project title to load the preview.
1. Go to the admin page. Search for a WISE4 project id. Click the "Edit Project" link to load the authoring tool.
1. Go to the admin page. Search for a WISE4 run id. Click the "Grading Tool" link.
1. Go to the admin page. Search for a WISE4 run id. Click the "Preview" link.
1. Go to the admin page. Search for a WISE4 run id. Click the "Edit Content" link.

Also test all those links for WISE5 projects/runs to make sure they weren't broken.

Closes #2351