### PR TITLE
Prevent extra nodeExited event from saving when a student enters a step

### DIFF
--- a/src/main/webapp/wise5/vle/navigation/navigationController.ts
+++ b/src/main/webapp/wise5/vle/navigation/navigationController.ts
@@ -1,22 +1,16 @@
 import VLEProjectService from '../vleProjectService';
-import StudentDataService from '../../services/studentDataService';
 
 class NavigationController {
   rootNode: any;
-  static $inject = ['$transitions', 'ProjectService', 'StudentDataService'];
+  static $inject = ['$transitions', 'ProjectService'];
 
   constructor(
     $transitions,
-    private ProjectService: VLEProjectService,
-    private StudentDataService: StudentDataService
+    private ProjectService: VLEProjectService
   ) {
     this.rootNode = this.ProjectService.rootNode;
     $transitions.onSuccess({}, $transition => {
       const toNodeId = $transition.params('to').nodeId;
-      const fromNodeId = $transition.params('from').nodeId;
-      if (toNodeId && fromNodeId && toNodeId !== fromNodeId) {
-        this.StudentDataService.endCurrentNodeAndSetCurrentNodeByNodeId(toNodeId);
-      }
       if ($transition.name === 'root.vle' && this.ProjectService.isApplicationNode(toNodeId)) {
         document.getElementById('content').scrollTop = 0;
       }


### PR DESCRIPTION
1. Log in as a student
1. Launch a run
1. Click the next button to go to the next step
1. Use the step drop down to jump to another step
1. Use a WISE link in an html component to go to another step
1. Make sure these 3 ways of navigating only create a nodeExited event for the step you are leaving and a nodeEntered event for the step you are entering. It used to also create a nodeExited event for the step you are entering but it shouldn't do that anymore.

Closes #2374