### PR TITLE
Moved sample library groups json into a JSON file

### DIFF
--- a/src/main/webapp/site/src/app/modules/library/sampleLibraryGroups.json
+++ b/src/main/webapp/site/src/app/modules/library/sampleLibraryGroups.json
@@ -1,4 +1,4 @@
-const sampleLibraryGroups = [{
+[{
   "children": [{
     "children": [{
       "metadata": {
@@ -1331,6 +1331,4 @@ const sampleLibraryGroups = [{
   "name": "DisciplineSpecific",
   "id": "disciplineSpecific",
   "type": "group"
-}];
-
-export default sampleLibraryGroups;
+}]


### PR DESCRIPTION
This file is used as reference and not used in any code, so no need to test. I move it into a JSON file so we can use editor features and exclude it from code climate analysis.

Resolves #2373