### PR TITLE
Handle extra node exited event in export step visits

### DIFF
--- a/src/main/webapp/wise5/classroomMonitor/dataExport/exportVisits.html
+++ b/src/main/webapp/wise5/classroomMonitor/dataExport/exportVisits.html
@@ -73,12 +73,18 @@
                 </md-tooltip>
               </md-button>
             </div>
-           <div ng-repeat="(key, value) in exportVisitsController.nodes"
+            <div ng-repeat="(key, value) in exportVisitsController.nodes"
                 ng-if="key !== 0">
               <md-checkbox ng-class="{'md-primary': true, 'groupHeader': value.node.type === 'group', 'stepHeader': value.node.type === 'node'}"
                   ng-model="exportVisitsController.idToChecked[value.node.id]"
                   ng-change="exportVisitsController.nodeChecked(value.node)">
                 <h6 style="display: inline; cursor: pointer">{{exportVisitsController.idToStepNumberAndTitle[value.node.id]}}</h6>
+              </md-checkbox>
+            </div>
+            <div>
+              <md-checkbox ng-class="{'md-primary': true, 'groupHeader': 'group'}"
+                  ng-model="exportVisitsController.includeDeletedSteps">
+                <h6 style="display: inline; cursor: pointer">{{ ::'includeDeletedStepsIfAny' | translate }}</h6>
               </md-checkbox>
             </div>
           </div>

--- a/src/main/webapp/wise5/classroomMonitor/i18n/i18n_en.json
+++ b/src/main/webapp/wise5/classroomMonitor/i18n/i18n_en.json
@@ -108,6 +108,7 @@
   "includeComments": "Include Comments",
   "includeCommentTimestamps": "Include Comment Timestamps",
   "includeCorrectnessColumns": "Include Correctness Columns",
+  "includeDeletedStepsIfAny": "Include Deleted Steps (If Any)",
   "includeEvents": "Include Events",
   "includeOnlySubmits": "Include Only Submits",
   "includeScores": "Include Scores",


### PR DESCRIPTION
1. Make sure extra nodeExited events are ignored. You can look at the "Export Events" to view all the individual nodeEntered and nodeExited events to see when those occur and compare it with the "Export Step Visit Events".
1. Make sure step visits to deleted steps show up in the export
1. Make sure visits without an "Exit Time" now shows "(Unknown Exit Time)" and "(Unknown Visit Duration)"
1. Make sure the "Previous Node ID" is empty for the first visit for all workgroups in the run
1. Make sure workgroups that are empty do now show up in the export. Should we show the visits for empty workgroups?

Closes #2376