### PR TITLE
Ensure text remains visible during webfont load

### DIFF
--- a/src/main/webapp/site/src/index.html
+++ b/src/main/webapp/site/src/index.html
@@ -7,8 +7,8 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="assets/favicon/favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Raleway:400,500|Roboto:400,500&amp;subset=latin-ext" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Raleway:400,500|Roboto:400,500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap" rel="stylesheet">
 </head>
 <body class="mat-typography default-theme mat-app-background">
   <script>if (global === undefined) { var global = window; }</script>


### PR DESCRIPTION
Added `display=swap` parameter to Google Font urls (https://web.dev/font-display/?utm_source=lighthouse&utm_medium=unknown).

Closes #2385.