### PR TITLE
One Workgroup Per Row export contains empty columns

### DIFF
--- a/src/main/webapp/wise5/services/projectService.ts
+++ b/src/main/webapp/wise5/services/projectService.ts
@@ -1600,7 +1600,7 @@ export class ProjectService {
     const consumedNodes = [];
     for (const path of paths) {
       if (path.includes(nodeId)) {
-        const subPath = path.slice(0, path.indexOf(nodeId));
+        const subPath = path.splice(0, path.indexOf(nodeId));
         for (const nodeIdInPath of subPath) {
           if (!consumedNodes.includes(nodeIdInPath)) {
             consumedNodes.push(nodeIdInPath);


### PR DESCRIPTION
1. Go to any run that has branching or create a run that has branching. The run does not require any student data.
1. Open the "Teacher Tools" for the run.
1. Go to the "Data Export" view.
1. Click "Export One Workgroup Per Row".
1. Click "Export"
1. There should be no columns that are empty. Before the fix, there were columns with data and then completely empty columns and then more columns with data. There should no longer be any gaps of empty columns.

Closes #2412