### PR TITLE
Show run access code in CM and AT

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
@@ -318,9 +318,9 @@ public class AuthorAPIController {
         projectMap.put("name", project.getName());
         String projectIdString = project.getId().toString();
         Long projectId = new Long(projectIdString);
-        Long runId = getRunId(projectId, runsOwnedByUser);
-        if (runId != null) {
-          projectMap.put("runId", runId);
+        Run run = getRun(projectId, runsOwnedByUser);
+        if (run != null) {
+          projectMap.put("runId", run.getId());
         }
         if (project.isDeleted()) {
           projectMap.put("isDeleted", true);
@@ -340,9 +340,9 @@ public class AuthorAPIController {
         projectMap.put("name", project.getName());
         String projectIdString = project.getId().toString();
         Long projectId = new Long(projectIdString);
-        Long runId = getRunId(projectId, sharedRuns);
-        if (runId != null) {
-          projectMap.put("runId", runId);
+        Run run = getRun(projectId, sharedRuns);
+        if (run != null) {
+          projectMap.put("runId", run.getId());
         }
         if (projectService.canAuthorProject(project, user)) {
           projectMap.put("canEdit", true);
@@ -411,23 +411,24 @@ public class AuthorAPIController {
       Run projectRun = projectRuns.get(0);
       config.put("canGradeStudentWork", runService.isAllowedToGradeStudentWork(projectRun, user));
       config.put("runId", projectRun.getId());
+      config.put("runCode", projectRun.getRuncode());
     }
     return config;
   }
 
   /**
-   * Get the run id that uses the project id
+   * Get the run that uses the project id
    *
    * @param projectId
    *                    the project id
    * @param runs
    *                    list of runs to look in
-   * @returns the run id that uses the project if the project is used in a run
+   * @returns the run that uses the project if the project is used in a run
    */
-  private Long getRunId(Long projectId, List<Run> runs) {
+  private Run getRun(Long projectId, List<Run> runs) {
     for (Run run : runs) {
       if (run.getProject().getId().equals(projectId)) {
-        return run.getId();
+        return run;
       }
     }
     return null;

--- a/src/main/webapp/wise5/authoringTool/authoringTool.html
+++ b/src/main/webapp/wise5/authoringTool/authoringTool.html
@@ -15,7 +15,8 @@
   <at-top-bar logo-path="{{::authoringToolController.logoPath}}"
        project-id="authoringToolController.projectId"
        project-title="authoringToolController.projectTitle"
-       run-id="authoringToolController.runId"></at-top-bar>
+       run-id="authoringToolController.runId"
+       run-code="authoringToolController.runCode"></at-top-bar>
   <at-toolbar ng-if="authoringToolController.showToolbar"
        number-project="authoringToolController.numberProject"
        show-step-tools="authoringToolController.showStepTools"

--- a/src/main/webapp/wise5/authoringTool/authoringToolController.ts
+++ b/src/main/webapp/wise5/authoringTool/authoringToolController.ts
@@ -22,6 +22,7 @@ class AuthoringToolController {
   projectId: number;
   projectTitle: string;
   runId: number;
+  runCode: string;
   showStepTools: boolean = false;
   showToolbar: boolean = true;
   views: any;
@@ -312,6 +313,7 @@ class AuthoringToolController {
     }
     this.projectId = this.ConfigService.getProjectId();
     this.runId = this.ConfigService.getRunId();
+    this.runCode = this.ConfigService.getRunCode();
     if (this.projectId) {
       this.projectTitle = this.ProjectService.getProjectTitle();
     } else {

--- a/src/main/webapp/wise5/authoringTool/components/shared/topBar/topBar.ts
+++ b/src/main/webapp/wise5/authoringTool/components/shared/topBar/topBar.ts
@@ -6,15 +6,19 @@ import { SessionService } from '../../../../services/sessionService';
 import TeacherDataService from '../../../../services/teacherDataService';
 
 class TopBarController {
+  translate: any;
   avatarColor: any;
   workgroupId: number;
   userInfo: any;
   themePath: string;
   contextPath: string;
+  projectId: number;
   runId: number;
+  runCode: string;
+  projectInfo: string;
 
   static $inject = [
-    '$rootScope',
+    '$filter',
     '$state',
     '$window',
     'ConfigService',
@@ -23,7 +27,7 @@ class TopBarController {
   ];
 
   constructor(
-    private $rootScope: any,
+    private $filter: any,
     private $state: any,
     private $window: any,
     private ConfigService: ConfigService,
@@ -31,6 +35,7 @@ class TopBarController {
     private SessionService: SessionService,
     private TeacherDataService: TeacherDataService
   ) {
+    this.translate = this.$filter('translate');
     this.workgroupId = this.ConfigService.getWorkgroupId();
     if (this.workgroupId == null) {
       this.workgroupId = 100 * Math.random();
@@ -39,6 +44,19 @@ class TopBarController {
     this.userInfo = this.ConfigService.getMyUserInfo();
     this.themePath = this.ProjectService.getThemePath();
     this.contextPath = this.ConfigService.getContextPath();
+  }
+
+  $onInit() {
+    this.projectInfo = this.getProjectInfo();
+  }
+
+  getProjectInfo(): string {
+    let projectInfo = this.translate('PROJECT_ID_DISPLAY', { id: this.projectId });
+    if (this.runId) {
+      projectInfo += ` | ${this.translate('RUN_ID_DISPLAY', { id: this.runId })}
+          | ${this.translate('RUN_CODE_DISPLAY', { code: this.runCode })}`;
+    }
+    return projectInfo;
   }
 
   helpButtonClicked() {
@@ -114,14 +132,15 @@ const TopBar = {
         </span>
         <h3 layout="row" layout-align="start center">
           <span ng-if="$ctrl.projectTitle" id="projectTitleSpan">{{ $ctrl.projectTitle }}</span>
-          <span ng-if="!$ctrl.projectTitle" id="projectTitleSpan">{{ ::'authoringTool' | translate }}</span>
+          <span ng-if="!$ctrl.projectTitle" id="projectTitleSpan">{{ ::'authoringTool' | translate }}</span>&nbsp;
           <span class="md-caption" ng-if="$ctrl.projectId" layout="row" layout-align="start center">
-            &nbsp;({{ 'PROJECT_ID_DISPLAY' | translate:{id: $ctrl.projectId} }}
-            <span ng-if="$ctrl.runId">
-              &nbsp;| {{ 'RUN_ID_DISPLAY' | translate:{id: $ctrl.runId} }} | {{ 'RUN_CODE_DISPLAY' | translate:{code: $ctrl.runCode} }}
-            </span>)
+            <span hide-xs hide-sm hide-md>({{ $ctrl.projectInfo }})</span>
+            <md-button aria-label="{{ ::'PROJECT_INFO' | translate }}" hide-gt-md class="md-icon-button">
+              <md-icon>info</md-icon>
+              <md-tooltip>{{ $ctrl.projectInfo }}</md-tooltip>
+            </md-button>
             <md-button ng-if="$ctrl.runId" aria-label="{{ ::'switchToGradingView' | translate }}" class="md-icon-button" ng-click="$ctrl.switchToGradingView()">
-                <md-icon md-menu-origin> assignment_turned_in </md-icon>
+                <md-icon> assignment_turned_in </md-icon>
                 <md-tooltip>{{ ::'switchToGradingView' | translate }}</md-tooltip>
             </md-button>
           </span>

--- a/src/main/webapp/wise5/authoringTool/components/shared/topBar/topBar.ts
+++ b/src/main/webapp/wise5/authoringTool/components/shared/topBar/topBar.ts
@@ -101,7 +101,8 @@ const TopBar = {
     logoPath: '@',
     projectId: '<',
     projectTitle: '<',
-    runId: '<'
+    runId: '<',
+    runCode: '<'
   },
   controller: TopBarController,
   template: `<md-toolbar class="l-header">
@@ -116,7 +117,8 @@ const TopBar = {
           <span ng-if="!$ctrl.projectTitle" id="projectTitleSpan">{{ ::'authoringTool' | translate }}</span>
           <span class="md-caption" ng-if="$ctrl.projectId" layout="row" layout-align="start center">
             &nbsp;({{ 'PROJECT_ID_DISPLAY' | translate:{id: $ctrl.projectId} }}
-            <span class="md-caption" ng-if="$ctrl.runId">&nbsp;| {{ 'RUN_ID_DISPLAY' | translate:{id: $ctrl.runId} }}
+            <span ng-if="$ctrl.runId">
+              &nbsp;| {{ 'RUN_ID_DISPLAY' | translate:{id: $ctrl.runId} }} | {{ 'RUN_CODE_DISPLAY' | translate:{code: $ctrl.runCode} }}
             </span>)
             <md-button ng-if="$ctrl.runId" aria-label="{{ ::'switchToGradingView' | translate }}" class="md-icon-button" ng-click="$ctrl.switchToGradingView()">
                 <md-icon md-menu-origin> assignment_turned_in </md-icon>

--- a/src/main/webapp/wise5/authoringTool/components/shared/topBar/topBar.ts
+++ b/src/main/webapp/wise5/authoringTool/components/shared/topBar/topBar.ts
@@ -46,7 +46,7 @@ class TopBarController {
     this.contextPath = this.ConfigService.getContextPath();
   }
 
-  $onInit() {
+  $onChanges() {
     this.projectInfo = this.getProjectInfo();
   }
 

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitor.html
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitor.html
@@ -9,7 +9,8 @@
              notifications="classroomMonitorController.notifications"
              project-id="classroomMonitorController.projectId"
              project-title="classroomMonitorController.projectTitle"
-             run-id="classroomMonitorController.runId"></cm-top-bar>
+             run-id="classroomMonitorController.runId"
+             run-code="classroomMonitorController.runCode"></cm-top-bar>
     <cm-toolbar ng-if="classroomMonitorController.showToolbar"
              number-project="classroomMonitorController.numberProject"
              show-period-select="classroomMonitorController.showPeriodSelect"

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/topBar/topBar.ts
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/topBar/topBar.ts
@@ -6,7 +6,7 @@ import TeacherDataService from '../../../../services/teacherDataService';
 import { SessionService } from '../../../../services/sessionService';
 
 class TopBarController {
-  $translate: any;
+  translate: any;
   avatarColor: any;
   canAuthorProject: boolean;
   contextPath: string;
@@ -15,9 +15,12 @@ class TopBarController {
   notifications: any;
   projectId: number;
   runId: number;
+  runCode: string;
+  runInfo: string;
   themePath: string;
   userInfo: any;
   workgroupId: number;
+
   static $inject = [
     '$filter',
     '$rootScope',
@@ -37,7 +40,7 @@ class TopBarController {
     private TeacherDataService: TeacherDataService,
     private SessionService: SessionService
   ) {
-    this.$translate = $filter('translate');
+    this.translate = $filter('translate');
     this.workgroupId = this.ConfigService.getWorkgroupId();
     if (this.workgroupId == null) {
       this.workgroupId = 100 * Math.random();
@@ -54,12 +57,19 @@ class TopBarController {
   $onInit() {
     const permissions = this.ConfigService.getPermissions();
     this.canAuthorProject = permissions.canAuthorProject;
+    this.runInfo = this.getRunInfo();
   }
 
   $onChanges(changesObj) {
     if (changesObj.notifications) {
       this.setNotifications();
     }
+  }
+
+  getRunInfo(): string {
+    let runInfo = `${this.translate('RUN_ID_DISPLAY', { id: this.runId })}
+        | ${this.translate('RUN_CODE_DISPLAY', { code: this.runCode })}`;
+    return runInfo;
   }
 
   /**
@@ -91,7 +101,7 @@ class TopBarController {
   }
 
   switchToAuthoringView() {
-    const proceed = confirm(this.$translate('editRunUnitWarning'));
+    const proceed = confirm(this.translate('editRunUnitWarning'));
     if (proceed) {
       this.doAuthoringViewSwitch();
     }
@@ -177,10 +187,12 @@ const TopBar = {
                     </a>
                 </span>
                 <h3 layout="row" layout-align="start center">
-                  <span>{{ ::$ctrl.projectTitle }}</span>
-                  <span class="md-caption">
-                    &nbsp;({{ ::'RUN_ID_DISPLAY' | translate:{id: $ctrl.runId} }} | {{ 'RUN_CODE_DISPLAY' | translate:{code: $ctrl.runCode} }})
-                  </span>
+                  <span>{{ ::$ctrl.projectTitle }}</span>&nbsp;
+                  <span class="md-caption" hide-xs hide-sm hide-md>({{ $ctrl.runInfo }})</span>
+                  <md-button aria-label="{{ ::'PROJECT_INFO' | translate }}" hide-gt-md class="md-icon-button">
+                    <md-icon>info</md-icon>
+                    <md-tooltip>{{ $ctrl.runInfo }}</md-tooltip>
+                  </md-button>
                   <md-button ng-if="$ctrl.canAuthorProject" aria-label="{{ ::'switchToAuthoringView' | translate }}" class="md-icon-button" ng-click="$ctrl.switchToAuthoringView()">
                       <md-icon md-menu-origin> edit </md-icon>
                       <md-tooltip>{{ ::'switchToAuthoringView' | translate }}</md-tooltip>

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/topBar/topBar.ts
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/topBar/topBar.ts
@@ -13,6 +13,7 @@ class TopBarController {
   dismissedNotifications: any;
   newNotifications: any;
   notifications: any;
+  projectId: number;
   runId: number;
   themePath: string;
   userInfo: any;
@@ -99,16 +100,16 @@ class TopBarController {
   doAuthoringViewSwitch() {
     if (this.$state.current.name === 'root.cm.notebooks') {
       this.$state.go('root.at.project.notebook', {
-        projectId: this.runId
+        projectId: this.projectId
       });
     } else if (this.$state.current.name === 'root.cm.unit.node') {
       this.$state.go('root.at.project.node', {
-        projectId: this.runId,
+        projectId: this.projectId,
         nodeId: this.$state.params.nodeId
       });
     } else {
       this.$state.go('root.at.project', {
-        projectId: this.runId
+        projectId: this.projectId
       });
     }
   }

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/topBar/topBar.ts
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/topBar/topBar.ts
@@ -164,7 +164,8 @@ const TopBar = {
     notifications: '<',
     projectId: '<',
     projectTitle: '<',
-    runId: '<'
+    runId: '<',
+    runCode: '<'
   },
   controller: TopBarController,
   template: `<md-toolbar class="l-header">
@@ -175,7 +176,10 @@ const TopBar = {
                     </a>
                 </span>
                 <h3 layout="row" layout-align="start center">
-                  {{ ::$ctrl.projectTitle }}&nbsp;<span class="md-caption">({{ ::'RUN_ID_DISPLAY' | translate:{id: $ctrl.runId} }})</span>
+                  <span>{{ ::$ctrl.projectTitle }}</span>
+                  <span class="md-caption">
+                    &nbsp;({{ ::'RUN_ID_DISPLAY' | translate:{id: $ctrl.runId} }} | {{ 'RUN_CODE_DISPLAY' | translate:{code: $ctrl.runCode} }})
+                  </span>
                   <md-button ng-if="$ctrl.canAuthorProject" aria-label="{{ ::'switchToAuthoringView' | translate }}" class="md-icon-button" ng-click="$ctrl.switchToAuthoringView()">
                       <md-icon md-menu-origin> edit </md-icon>
                       <md-tooltip>{{ ::'switchToAuthoringView' | translate }}</md-tooltip>

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorController.ts
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorController.ts
@@ -19,6 +19,7 @@ class ClassroomMonitorController {
   menuOpen: boolean = false;
   notifications: any;
   numberProject: boolean = true;
+  projectId: number;
   projectTitle: string;
   runId: number;
   runCode: string;
@@ -66,6 +67,7 @@ class ClassroomMonitorController {
   ) {
     this.$translate = $filter('translate');
     this.projectTitle = this.ProjectService.getProjectTitle();
+    this.projectId = this.ConfigService.getProjectId();
     this.runId = this.ConfigService.getRunId();
     this.runCode = this.ConfigService.getRunCode();
     this.enableProjectAchievements = this.ProjectService.getAchievements().isEnabled;

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorController.ts
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorController.ts
@@ -21,6 +21,7 @@ class ClassroomMonitorController {
   numberProject: boolean = true;
   projectTitle: string;
   runId: number;
+  runCode: string;
   showGradeByStepTools: boolean = false;
   showGradeByTeamTools: boolean;
   showPeriodSelect: boolean = false;
@@ -66,6 +67,7 @@ class ClassroomMonitorController {
     this.$translate = $filter('translate');
     this.projectTitle = this.ProjectService.getProjectTitle();
     this.runId = this.ConfigService.getRunId();
+    this.runCode = this.ConfigService.getRunCode();
     this.enableProjectAchievements = this.ProjectService.getAchievements().isEnabled;
     this.views = {
       'root.cm.dashboard': {

--- a/src/main/webapp/wise5/i18n/i18n_en.json
+++ b/src/main/webapp/wise5/i18n/i18n_en.json
@@ -107,6 +107,7 @@
   "RUBRIC": "Rubric",
   "RUN_ID": "Run ID",
   "RUN_ID_DISPLAY": "Run ID: {{id}}",
+  "RUN_CODE_DISPLAY": "Access Code: {{code}}",
   "SAVE": "Save",
   "SAVED": "Saved",
   "SCORE": "Score",

--- a/src/main/webapp/wise5/services/configService.ts
+++ b/src/main/webapp/wise5/services/configService.ts
@@ -106,6 +106,10 @@ export class ConfigService {
     return this.getConfigParam('runId');
   }
 
+  getRunCode() {
+    return this.getConfigParam('runCode');
+  }
+
   getRunName() {
     return this.getConfigParam('runName');
   }


### PR DESCRIPTION
To test:
- Load CM for a run and make sure Access Code appears in the top bar.
- Switch to AT for the run and make sure Access Code appears in the top bar.
- In both CM and AT, change viewport width. For screens less than 1200px wide, unit/run info display should be replaced with an info icon. Hover over the icon and ensure a tooltip appears with the run/unit info.

Closes #2432. 