### PR TITLE
Previewing a project throws an error and does not load

### DIFF
--- a/src/main/webapp/wise5/vle/vlePreviewCommonModule.ts
+++ b/src/main/webapp/wise5/vle/vlePreviewCommonModule.ts
@@ -260,7 +260,11 @@ export function createModule(type = 'preview') {
               'TagService',
               'config',
               (TagService, config) => {
-                return TagService.retrieveStudentTags().toPromise();
+                if (type === 'preview') {
+                  return {};
+                } else {
+                  return TagService.retrieveStudentTags().toPromise();
+                }
               }
             ],
             webSocket: [


### PR DESCRIPTION
Preview a project and make sure it loads. It used to show an error message saying
"An error occurred. Please refresh this page and try again."
and then show a blank screen.

Closes #2470