### PR TITLE
Upgraded ComponentService to Angular

### DIFF
--- a/src/main/webapp/wise5/components/animation/animationService.ts
+++ b/src/main/webapp/wise5/components/animation/animationService.ts
@@ -1,10 +1,13 @@
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 
 class AnimationService extends ComponentService {
+  $translate: any;
+
   static $inject = ['$filter', 'StudentDataService', 'UtilService'];
 
   constructor($filter, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
+    this.$translate = $filter('translate');
   }
 
   getComponentTypeLabel() {

--- a/src/main/webapp/wise5/components/audioOscillator/audioOscillatorService.ts
+++ b/src/main/webapp/wise5/components/audioOscillator/audioOscillatorService.ts
@@ -1,10 +1,13 @@
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 
 class AudioOscillatorService extends ComponentService {
+  $translate: any;
+
   static $inject = ['$filter', 'StudentDataService', 'UtilService'];
 
   constructor($filter, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
+    this.$translate = $filter('translate');
   }
 
   getComponentTypeLabel() {

--- a/src/main/webapp/wise5/components/componentService.ts
+++ b/src/main/webapp/wise5/components/componentService.ts
@@ -1,14 +1,18 @@
-class ComponentService {
-  $filter: any;
-  $translate: any;
-  StudentDataService: any;
-  UtilService: any;
+'use strict';
+
+import { Injectable } from '@angular/core';
+import { StudentDataService } from "../services/studentDataService";
+import { UtilService } from "../services/utilService";
+
+@Injectable()
+export class ComponentService {
   
-  constructor($filter, StudentDataService, UtilService) {
-    this.$filter = $filter;
+  constructor(
+    protected StudentDataService: StudentDataService, 
+    protected UtilService: UtilService
+  ) {
     this.StudentDataService = StudentDataService;
     this.UtilService = UtilService;
-    this.$translate = this.$filter('translate');
   }
 
   /**
@@ -109,5 +113,3 @@ class ComponentService {
     return false;
   }
 }
-
-export default ComponentService;

--- a/src/main/webapp/wise5/components/conceptMap/conceptMapService.ts
+++ b/src/main/webapp/wise5/components/conceptMap/conceptMapService.ts
@@ -1,5 +1,5 @@
 import * as angular from 'angular';
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 import { ConfigService } from '../../services/configService';
 import { StudentAssetService } from '../../services/studentAssetService';
 import ConceptMapNode from './conceptMapNode';
@@ -10,6 +10,7 @@ class ConceptMapService extends ComponentService {
   $location: any;
   $q: any;
   $timeout: any;
+  $translate: any;
   ConfigService: ConfigService;
   StudentAssetService: StudentAssetService;
 
@@ -36,13 +37,14 @@ class ConceptMapService extends ComponentService {
     StudentDataService,
     UtilService
   ) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
     this.$anchorScroll = $anchorScroll;
     this.$location = $location;
     this.$q = $q;
     this.$timeout = $timeout;
     this.ConfigService = ConfigService;
     this.StudentAssetService = StudentAssetService;
+    this.$translate = $filter('translate');
   }
 
   getComponentTypeLabel() {

--- a/src/main/webapp/wise5/components/discussion/discussionService.ts
+++ b/src/main/webapp/wise5/components/discussion/discussionService.ts
@@ -1,4 +1,4 @@
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 import { ConfigService } from '../../services/configService';
 import TeacherDataService from '../../services/teacherDataService';
 
@@ -7,6 +7,7 @@ class DiscussionService extends ComponentService {
   $injector: any;
   $rootScope: any;
   $q: any;
+  $translate: any;
   ConfigService: ConfigService;
   TeacherDataService: TeacherDataService;
 
@@ -31,11 +32,12 @@ class DiscussionService extends ComponentService {
     StudentDataService,
     UtilService
   ) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
     this.$http = $http;
     this.$rootScope = $rootScope;
     this.$q = $q;
     this.$injector = $injector;
+    this.$translate = $filter('translate');
     this.ConfigService = ConfigService;
     if (['classroomMonitor', 'author'].includes(this.ConfigService.getMode())) {
       /*

--- a/src/main/webapp/wise5/components/draw/drawService.ts
+++ b/src/main/webapp/wise5/components/draw/drawService.ts
@@ -1,18 +1,20 @@
 'use strict';
 
 import * as angular from 'angular';
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
 
 class DrawService extends ComponentService {
   $q: any;
+  $translate: any;
   StudentAssetService: StudentAssetService;
 
   static $inject = ['$filter', '$q', 'StudentAssetService', 'StudentDataService', 'UtilService'];
 
   constructor($filter, $q, StudentAssetService, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
     this.$q = $q;
+    this.$translate = $filter('translate');
     this.StudentAssetService = StudentAssetService;
   }
 

--- a/src/main/webapp/wise5/components/embedded/embeddedService.ts
+++ b/src/main/webapp/wise5/components/embedded/embeddedService.ts
@@ -1,17 +1,19 @@
 import * as $ from 'jquery';
 import * as html2canvas from 'html2canvas';
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
 
 class EmbeddedService extends ComponentService {
   $q: any;
+  $translate: any;
   StudentAssetService: StudentAssetService;
 
   static $inject = ['$filter', '$q', 'StudentAssetService', 'StudentDataService', 'UtilService'];
 
   constructor($filter, $q, StudentAssetService, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
     this.$q = $q;
+    this.$translate = $filter('translate');
     this.StudentAssetService = StudentAssetService;
   }
 

--- a/src/main/webapp/wise5/components/graph/graphService.js
+++ b/src/main/webapp/wise5/components/graph/graphService.js
@@ -1,10 +1,11 @@
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 import * as html2canvas from 'html2canvas';
 
 class GraphService extends ComponentService {
   constructor($filter, $q, StudentAssetService, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
     this.$q = $q;
+    this.$translate = $filter('translate');
     this.StudentAssetService = StudentAssetService;
   }
 

--- a/src/main/webapp/wise5/components/html/htmlService.ts
+++ b/src/main/webapp/wise5/components/html/htmlService.ts
@@ -1,10 +1,13 @@
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 
 class HTMLService extends ComponentService {
+  $translate: any;
+
   static $inject = ['$filter', 'StudentDataService', 'UtilService'];
 
   constructor($filter, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
+    this.$translate = $filter('translate');
   }
 
   getComponentTypeLabel() {

--- a/src/main/webapp/wise5/components/label/labelService.ts
+++ b/src/main/webapp/wise5/components/label/labelService.ts
@@ -1,16 +1,18 @@
 import * as angular from 'angular';
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
 
 class LabelService extends ComponentService {
   $q: any;
+  $translate: any;
   StudentAssetService: StudentAssetService;
 
   static $inject = ['$filter', '$q', 'StudentAssetService', 'StudentDataService', 'UtilService'];
 
   constructor($filter, $q, StudentAssetService, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
     this.$q = $q;
+    this.$translate = $filter('translate');
     this.StudentAssetService = StudentAssetService;
   }
 

--- a/src/main/webapp/wise5/components/match/matchService.ts
+++ b/src/main/webapp/wise5/components/match/matchService.ts
@@ -1,10 +1,13 @@
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 
 class MatchService extends ComponentService {
+  $translate: any;
+
   static $inject = ['$filter', 'StudentDataService', 'UtilService'];
 
   constructor($filter, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
+    this.$translate = $filter('translate');
   }
 
   getComponentTypeLabel() {

--- a/src/main/webapp/wise5/components/multipleChoice/multipleChoiceService.ts
+++ b/src/main/webapp/wise5/components/multipleChoice/multipleChoiceService.ts
@@ -1,10 +1,13 @@
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 
 class MultipleChoiceService extends ComponentService {
+  $translate: any;
+
   static $inject = ['$filter', 'StudentDataService', 'UtilService'];
 
   constructor($filter, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
+    this.$translate = $filter('translate');
   }
 
   getComponentTypeLabel() {

--- a/src/main/webapp/wise5/components/openResponse/openResponseService.ts
+++ b/src/main/webapp/wise5/components/openResponse/openResponseService.ts
@@ -1,10 +1,13 @@
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 
 class OpenResponseService extends ComponentService {
+  $translate: any;
+
   static $inject = ['$filter', 'StudentDataService', 'UtilService'];
 
   constructor($filter, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
+    this.$translate = $filter('translate');
   }
 
   getComponentTypeLabel() {

--- a/src/main/webapp/wise5/components/outsideURL/outsideURLService.ts
+++ b/src/main/webapp/wise5/components/outsideURL/outsideURLService.ts
@@ -1,13 +1,15 @@
-import ComponentService from '../componentService';
+  import { ComponentService } from '../componentService';
 
 class OutsideURLService extends ComponentService {
   $http: any;
+  $translate: any;
 
   static $inject = ['$filter', '$http', 'StudentDataService', 'UtilService'];
 
   constructor($filter, $http, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
     this.$http = $http;
+    this.$translate = $filter('translate');
   }
 
   getComponentTypeLabel() {

--- a/src/main/webapp/wise5/components/summary/summaryService.ts
+++ b/src/main/webapp/wise5/components/summary/summaryService.ts
@@ -1,13 +1,15 @@
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 
 class SummaryService extends ComponentService {
+  $translate: any;
   componentsWithScoresSummary: string[];
   componentsWithResponsesSummary: string[];
 
   static $inject = ['$filter', 'ConfigService', 'UtilService'];
 
   constructor($filter, ConfigService, UtilService) {
-    super($filter, ConfigService, UtilService);
+    super(ConfigService, UtilService);
+    this.$translate = $filter('translate');
     this.componentsWithScoresSummary = [
       'Animation',
       'AudioOscillator',

--- a/src/main/webapp/wise5/components/table/tableService.ts
+++ b/src/main/webapp/wise5/components/table/tableService.ts
@@ -1,17 +1,19 @@
 import * as angular from 'angular';
 import * as html2canvas from 'html2canvas';
-import ComponentService from '../componentService';
+import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
 
 class TableService extends ComponentService {
   $q: any;
+  $translate: any;
   StudentAssetService: StudentAssetService;
 
   static $inject = ['$filter', '$q', 'StudentAssetService', 'StudentDataService', 'UtilService'];
 
   constructor($filter, $q, StudentAssetService, StudentDataService, UtilService) {
-    super($filter, StudentDataService, UtilService);
+    super(StudentDataService, UtilService);
     this.$q = $q;
+    this.$translate = $filter('translate');
     this.StudentAssetService = StudentAssetService;
   }
 

--- a/src/main/webapp/wise5/teacher/teacher.ts
+++ b/src/main/webapp/wise5/teacher/teacher.ts
@@ -27,7 +27,7 @@ import '../components/conceptMap/conceptMapComponentModule';
 import { ConfigService } from '../services/configService';
 import { CRaterService } from '../services/cRaterService';
 import '../directives/components';
-import ComponentService from '../components/componentService';
+import { ComponentService } from '../components/componentService';
 import '../classroomMonitor/dashboard/dashboardController';
 import DataExportController from '../classroomMonitor/dataExport/dataExportController';
 import ExportController from '../classroomMonitor/dataExport/exportController';
@@ -174,7 +174,7 @@ const teacherModule = angular
   .service('AchievementService', AchievementService)
   .factory('AnnotationService', downgradeInjectable(AnnotationService))
   .factory('AudioRecorderService', downgradeInjectable(AudioRecorderService))
-  .service('ComponentService', ComponentService)
+  .factory('ComponentService', downgradeInjectable(ComponentService))
   .factory('ConfigService', downgradeInjectable(ConfigService))
   .factory('CRaterService', downgradeInjectable(CRaterService))
   .service('HttpInterceptor', HttpInterceptor)

--- a/src/main/webapp/wise5/vle/vlePreviewCommonModule.ts
+++ b/src/main/webapp/wise5/vle/vlePreviewCommonModule.ts
@@ -24,7 +24,7 @@ import '../components/conceptMap/conceptMapComponentModule';
 import { ConfigService } from '../services/configService';
 import { CRaterService } from '../services/cRaterService';
 import '../directives/components';
-import ComponentService from '../components/componentService';
+import { ComponentService } from '../components/componentService';
 import '../components/discussion/discussionComponentModule';
 import '../components/draw/drawComponentModule';
 import '../components/embedded/embeddedComponentModule';
@@ -116,7 +116,7 @@ export function createModule(type = 'preview') {
   .factory('AnnotationService', downgradeInjectable(AnnotationService))
   .factory('AudioRecorderService', downgradeInjectable(AudioRecorderService))
   .factory('ConfigService', downgradeInjectable(ConfigService))
-  .service('ComponentService', ComponentService)
+  .factory('ComponentService', downgradeInjectable(ComponentService))
   .factory('CRaterService', downgradeInjectable(CRaterService))
   .service('HttpInterceptor', HttpInterceptor)
   .service('NodeService', NodeService)


### PR DESCRIPTION
Upgraded the ComponentService to Angular and removed UpgradeModule dependency so that the WISE component services can still extend the downgraded ComponentService. Moved AngularJS $filter dependency to the component services so they can still use $translate.

To test:
- Make sure all components still work in vle, classroom monitor, authoring tool.

Closes #2473.