### PR TITLE
Uploading an image larger than 1000px does not work properly

### DIFF
--- a/src/main/webapp/site/src/app/services/projectAssetService.ts
+++ b/src/main/webapp/site/src/app/services/projectAssetService.ts
@@ -74,7 +74,7 @@ export class ProjectAssetService {
   uploadAssets(files: any[]) {
     const url = this.ConfigService.getConfigParam('projectAssetURL');
     const formData = new FormData();
-    files.forEach((file: any) => formData.append('files', file));
+    files.forEach((file: any) => formData.append('files', file, file.name));
     return this.http.post(url, formData).pipe(
       map((data: any) => {
         this.setProjectAssets(data.assetDirectoryInfo);


### PR DESCRIPTION
1. Log in as a teacher
1. Open a project in the Authoring Tool
1. Go to the File Manager
1. Upload an image that has width or height larger than 1000px
1. The file should be resized and uploaded and maintain the same file name

Previous Bug Behavior
When the large dimension file was uploaded, the file name would be changed to "blob"

Closes #2475