### PR TITLE
Upgraded spring boot to 2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.2.0.RELEASE</version>
+    <version>2.3.2.RELEASE</version>
     <relativePath/>
   </parent>
   <dependencies>


### PR DESCRIPTION
Clear the Redis database by running
$ redis-cli
> flushall

and test that WISE starts up and works as before.

Resolves #2453