### PR TITLE
Loading the Authoring Tool throws this.debug is not a function error

### DIFF
--- a/src/main/webapp/wise5/services/teacherWebSocketService.ts
+++ b/src/main/webapp/wise5/services/teacherWebSocketService.ts
@@ -18,6 +18,18 @@ export class TeacherWebSocketService {
       private ConfigService: ConfigService,
       private NotificationService: NotificationService,
       private StudentStatusService: StudentStatusService) {
+    if (this.upgrade.$injector != null) {
+      this.initializeStomp();
+    }
+  }
+
+  initializeStomp() {
+    this.stomp = this.upgrade.$injector.get('$stomp');
+    this.stomp.setDebug(() => {});
+  }
+
+  getStomp() {
+    return this.stomp;
   }
 
   getRootScope() {
@@ -25,14 +37,6 @@ export class TeacherWebSocketService {
       this.rootScope = this.upgrade.$injector.get('$rootScope');
     }
     return this.rootScope;
-  }
-
-  getStomp() {
-    if (this.stomp == null) {
-      this.stomp = this.upgrade.$injector.get('$stomp');
-      this.stomp.setDebug(() => {});
-    }
-    return this.stomp;
   }
 
   initialize() {


### PR DESCRIPTION
1. Load a project in the Authoring Tool and make sure the error below no longer shows up in the console.

```
core.js:6210 ERROR Error: Uncaught (in promise): TypeError: this.debug is not a function
TypeError: this.debug is not a function
    at CompatClient.<anonymous> (stomp.umd.js:358)
    at step (stomp.umd.js:166)
    at Object.next (stomp.umd.js:147)
```

2. Make sure teacher websockets still works in the Authoring Tool (when two teachers are authoring the same project at the same time) and Classroom Monitor (pause student screens).

Closes #2548