### PR TITLE
Fixed disappearing workgroups in Classroom Monitor

### DIFF
--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/workgroupSelect/workgroupSelect.ts
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/workgroupSelect/workgroupSelect.ts
@@ -110,7 +110,7 @@ class WorkgroupSelectController {
       for (let workgroup of this.workgroups) {
         if (currentWorkgroup.workgroupId === workgroup.workgroupId) {
           if (this.byStudent) {
-            if (currentWorkgroup.userId === workgroup.userId) {
+            if (currentWorkgroup.userIds.indexOf(workgroup.userId) > -1) {
               localGroup = workgroup;
               break;
             }

--- a/src/main/webapp/wise5/classroomMonitor/studentGrading/studentGradingController.ts
+++ b/src/main/webapp/wise5/classroomMonitor/studentGrading/studentGradingController.ts
@@ -130,6 +130,10 @@ class StudentGradingController {
       }
     });
 
+    this.$scope.$on('$destroy', () => {
+      this.TeacherDataService.setCurrentWorkgroup(null);
+    });
+
     const context = 'ClassroomMonitor',
       nodeId = null,
       componentId = null,


### PR DESCRIPTION
To test:
1. Open the Classroom Monitor for a run that contains two or more workgroups.
1. Go to the "Grade By Team" view by clicking the icon on the left nav bar.
1. Click on one of the workgroups.
1. Click the "Grade By Team" icon on the left nav bar again.
1. Verify that all the workgroups are visible.

Fixes #2549. 