### PR TITLE
Updated styles and text to match Google branding guidelines

### DIFF
--- a/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.html
+++ b/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.html
@@ -79,8 +79,9 @@
   </mat-dialog-content>
   <mat-dialog-actions fxLayoutAlign="end">
     <button mat-button color="primary" (click)="checkClassroomAuthorization()"
-            *ngIf="isGoogleUser() && isGoogleClassroomEnabled()" i18n>Add to Google
-      Classroom</button>
+            *ngIf="isGoogleUser() && isGoogleClassroomEnabled()" i18n>
+      Share to Google Classroom
+    </button>
     <button mat-button (click)="closeAll()" i18n>Done</button>
   </mat-dialog-actions>
 </ng-container>

--- a/src/main/webapp/site/src/app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html
+++ b/src/main/webapp/site/src/app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html
@@ -3,12 +3,12 @@
     fxLayoutAlign="start center"
     fxLayoutGap="8px">
   <mat-icon svgIcon="google-classroom"></mat-icon>
-  <span i18n>Add to Google Classroom</span>
+  <span i18n>Share to Google Classroom</span>
 </h2>
 <ng-container *ngIf="!courses.length">
   <mat-dialog-content>
     <div class="info-block">
-      <p i18n>Hey there! Looks like you don't have any active Google classes.</p>
+      <p i18n>Hey there! Looks like you don't have any active Google Classroom classes.</p>
       <p i18n>Visit <a href="https://classroom.google.com" target="_blank">Google Classroom</a> to create a class and try again.</p>
     </div>
   </mat-dialog-content>
@@ -23,7 +23,7 @@
         {{ data.run.name }} <span class="mat-caption" i18n>(Run ID: {{ data.run.id }})</span>
       </p>
       <p i18n>Add an assignment for this unit in Google Classroom.</p>
-      <h3 i18n>1. Choose Google Class</h3>
+      <h3 i18n>1. Choose from your Google Classroom classes</h3>
       <div formArrayName="selectedCourses">
         <p *ngFor="let control of selectedCoursesControl.controls; let i = index">
           <mat-checkbox [formControl]="control">
@@ -61,12 +61,12 @@
       </p>
       <div *ngIf="addSuccessCount > 0">
         <br/>
-        <p i18n>The unit has been successfully added to the following Google Classroom(s)</p>
+        <p i18n>The unit has been successfully added to the following Google Classroom classes:</p>
         <p *ngFor="let course of coursesSuccessfullyAdded">{{ course.name }}</p>
       </div>
       <div *ngIf="addFailureCount > 0" style="color: red">
         <br/>
-        <p i18n>There was a problem trying to add the unit to the following Google Classroom(s)</p>
+        <p i18n>There was a problem adding the unit to the following Google Classroom classes:</p>
         <p *ngFor="let course of coursesFailedToAdd">{{ course.name }}</p>
       </div>
     </div>

--- a/src/main/webapp/site/src/app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html
+++ b/src/main/webapp/site/src/app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html
@@ -22,7 +22,7 @@
       <p class="mat-subheading-1 accent-1">
         {{ data.run.name }} <span class="mat-caption" i18n>(Run ID: {{ data.run.id }})</span>
       </p>
-      <p i18n>Add an assignment for this unit in Google Classroom.</p>
+      <p i18n>Add an assignment for this unit to Google Classroom.</p>
       <h3 i18n>1. Choose from your Google Classroom classes</h3>
       <div formArrayName="selectedCourses">
         <p *ngFor="let control of selectedCoursesControl.controls; let i = index">

--- a/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.html
+++ b/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.html
@@ -28,7 +28,7 @@
     <a mat-menu-item (click)="checkClassroomAuthorization()"
        *ngIf="isGoogleUser() && isGoogleClassroomEnabled() && !isRunCompleted() && run.project.wiseVersion !== 4">
       <mat-icon svgIcon="google-classroom"></mat-icon>
-      <span i18n>Add to Google Classroom</span>
+      <span i18n>Share to Google Classroom</span>
     </a>
     <a mat-menu-item href="{{ reportProblemLink }}">
       <mat-icon>report_problem</mat-icon>

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -1555,8 +1555,8 @@
           <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="b6d98e943848266c1ee9234245f2d1505d969d72">
-        <source>Add an assignment for this unit in Google Classroom.</source>
+      <trans-unit datatype="html" id="d02edd143baf0e3ea363a7cf9c714bbb19d88cc2">
+        <source>Add an assignment for this unit to Google Classroom.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
           <context context-type="linenumber">25</context>

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -1512,8 +1512,8 @@
           <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="a90197fbaf305621cf15da6e9f88ccff3087ea1d">
-        <source>Add to Google Classroom</source>
+      <trans-unit datatype="html" id="76de164da3c441addbf9b14950150aa869b00fdb">
+        <source>Share to Google Classroom</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
           <context context-type="linenumber">6</context>
@@ -1523,8 +1523,8 @@
           <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="d559090ad7dfe99c26a7143c93579f3b768f4dd3">
-        <source>Hey there! Looks like you don't have any active Google classes.</source>
+      <trans-unit datatype="html" id="d730351c7b91474b615d35ca4357f0278194bf1d">
+        <source>Hey there! Looks like you don't have any active Google Classroom classes.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
           <context context-type="linenumber">11</context>
@@ -1562,8 +1562,8 @@
           <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="3f45dd6922690245cfed6cf0c6dd4f06f125d3ef">
-        <source>1. Choose Google Class</source>
+      <trans-unit datatype="html" id="513f7b099350e045450a1b47ee1987e7dc72d86b">
+        <source>1. Choose from your Google Classroom classes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
           <context context-type="linenumber">26</context>
@@ -1643,15 +1643,15 @@
           <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="e9a74cfea4f80b5d5c656bd147bdf4588c98572e">
-        <source>The unit has been successfully added to the following Google Classroom(s)</source>
+      <trans-unit datatype="html" id="c04678929731aad2662284b7ce56c5c75b410df5">
+        <source>The unit has been successfully added to the following Google Classroom classes:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
           <context context-type="linenumber">64</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="5864637a64f27a59e5c5ffec7481035b9d025b1b">
-        <source>There was a problem trying to add the unit to the following Google Classroom(s)</source>
+      <trans-unit datatype="html" id="c5f8f353cc72109abe1365384bb7df8af0a83f63">
+        <source>There was a problem adding the unit to the following Google Classroom classes:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
           <context context-type="linenumber">69</context>
@@ -1665,7 +1665,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">85</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
@@ -1848,8 +1848,8 @@
           <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="6d1b448d6bd57d2a29e2f8e1ea8a35aacd3101f5">
-        <source>Add to Google Classroom</source>
+      <trans-unit datatype="html" id="e57f5a8a6dae5484ae05dbdff681c11ec42c732f">
+        <source> Share to Google Classroom </source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
           <context context-type="linenumber">82</context>
@@ -5044,6 +5044,20 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/possible-score/possible-score.component.html</context>
           <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="74b04b602d4148d1cb5de4da90c0e91ec9bae5ac">
+        <source>Choose a Branch Path</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/preview/modules/choose-branch-path-dialog/choose-branch-path-dialog.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="33587ab40a459dc3058a184e39bfa93737fbbd67">
+        <source>Note: This chooser screen is only available in preview mode. Students will not see this screen in a classroom run and will instead be assigned a branch path automatically. Once you have chosen a branch, complete the current step and then click the Next arrow.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/preview/modules/choose-branch-path-dialog/choose-branch-path-dialog.component.html</context>
+          <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="36a606470097ddf0c32a250c8a902441729ca8ca">

--- a/src/main/webapp/site/src/style/abstracts/_mixins.scss
+++ b/src/main/webapp/site/src/style/abstracts/_mixins.scss
@@ -17,7 +17,7 @@
     @include mat-typography-level-to-styles($custom-typography, caption);
   }
 
-  .mat-typography, .mat-body, .mat-body-1 {
+  &.mat-typography, .mat-body, .mat-body-1 {
     @include mat-typography-level-to-styles($custom-typography, body-1);
   }
 

--- a/src/main/webapp/site/src/style/components/_buttons.scss
+++ b/src/main/webapp/site/src/style/components/_buttons.scss
@@ -53,13 +53,13 @@
   img {
     width: 18px;
     height: auto;
-    margin: 0 18px 0 -14px;
-    padding: 7px;
+    margin: 0 16px 0 -15px;
+    padding: 8px;
     background-color: #fff;
     border-radius: 2px;
   }
 }
 
 .button--google {
-  background-color: #ea4335 !important;
+  background-color: #4285F4 !important;
 }


### PR DESCRIPTION
To test:
1. Go to `/login`, `/join/teacher`, and `/join/student` and confirm that 'Sign in with Google' and 'Sign up with Google' buttons have blue background, follow https://developers.google.com/identity/branding-guidelines.
1. Log in as a teacher with a Google account.
1. Create a new run. Button at bottom of confirmation dialog should now say "Share to Google Classroom".
1. In your Class Schedule, open the run menu for the newly created run. Add to Google Classroom button should now say "Share to Google Classroom".
1. Select "Share to Google Classroom" and authenticate with Google if necessary.
1. Text relating to Google Classroom in the share dialog should now match recommended text in https://developers.google.com/classroom/brand.

Closes #2558.