### PR TITLE
Match component export throws an error

### DIFF
--- a/src/main/webapp/wise5/classroomMonitor/dataExport/dataExportController.ts
+++ b/src/main/webapp/wise5/classroomMonitor/dataExport/dataExportController.ts
@@ -2771,7 +2771,7 @@ class DataExportController {
    */
   exportMatchComponent(nodeId, component) {
     this.showDownloadingExportMessage();
-    this.TeacherDataService.getExport('allStudentWork').toPromise().then((result: any) => {
+    this.TeacherDataService.getExport('allStudentWork').then((result: any) => {
       let columnNames = [];
       let columnNameToNumber = {};
       let rows = [];


### PR DESCRIPTION
1. Open the Classroom Monitor for a run that contains Match component student data
1. Go to the "Data Export" view
1. Click "Export Component Data"
1. Find a Match component and click the "Download Export" button. This used to not download but now it should download successfully.

Closes #2562