### PR TITLE
Admin sees zero workgroups in periods when viewing Classroom Monitor

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/run/TeacherRunAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/run/TeacherRunAPIController.java
@@ -51,7 +51,7 @@ public class TeacherRunAPIController {
       throws ObjectNotFoundException {
     User user = userService.retrieveUserByUsername(auth.getName());
     Run run = runService.retrieveById(runId);
-    if (run.isTeacherAssociatedToThisRun(user)) {
+    if (run.isTeacherAssociatedToThisRun(user) || user.isAdmin()) {
       return vleService.getStudentStatusesByRunId(runId);
     }
     return new ArrayList<StudentStatus>();


### PR DESCRIPTION
1. Log in as an admin user
1. Open the Classroom Monitor for a run that has students but the admin user does not own
1. Click the Period drop down at the upper right of the Classroom Monitor. You should see periods with x teams. Previously the periods would show (0 teams) even if there were workgroups in the run.

Closes #2572