### PR TITLE
Period names with a space do not work properly in manage students view

### DIFF
--- a/src/main/webapp/portal/teacher/management/viewmystudents.jsp
+++ b/src/main/webapp/portal/teacher/management/viewmystudents.jsp
@@ -474,7 +474,7 @@ function changeWorkgroupPeriod(workgroupId) {
 						<ul>
 						<li><a style="color:#FFF;padding: 2px 0;text-decoration: none !important;cursor: text !important;margin-left: 0;"><spring:message code="teacher.management.viewmystudents.changePeriodLabel"/> </a></li>
 						<c:forEach var="viewmystudentsperiod" varStatus="periodStatus" items="${viewmystudentsallperiods}">
-							<li><a href="#period_${viewmystudentsperiod.period.name}" class="periodChoice"><spring:message code="run_period"/> ${viewmystudentsperiod.period.name}</a></li>
+							<li><a href='#period_${fn:replace(viewmystudentsperiod.period.name, " ", "_")}' class="periodChoice"><spring:message code="run_period"/> ${viewmystudentsperiod.period.name}</a></li>
 						</c:forEach>
 						</ul>
 					</div>
@@ -483,7 +483,7 @@ function changeWorkgroupPeriod(workgroupId) {
 			</div>
 
 				<c:forEach var="viewmystudentsperiod" varStatus="periodStatus" items="${viewmystudentsallperiods}">
-					<div id="period_${viewmystudentsperiod.period.name}">
+					<div id='period_${fn:replace(viewmystudentsperiod.period.name, " ", "_")}'>
 					<c:choose>
 						<c:when test="${fn:length(viewmystudentsperiod.period.members) == 0}">
 							<div class="gradingHeader studentManageHeader">


### PR DESCRIPTION
1. Create a run with at least 3 periods (or add periods to an existing run). Make sure you have a period without a space, a period with a space, and a period without a space in that order.
1. Add a student to each period and have the student launch the run
1. Open the Classroom Monitor for the run
1. Go to the Manage Students view
1. Click on each of the periods to view the students in each period. When you click the period with a space in its name, it should display the students in the period (previously it would not display the students for that period).

Closes #2584