### PR TITLE
Classroom Monitor select All Periods label bug

### DIFF
--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/periodSelect/periodSelect.ts
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/periodSelect/periodSelect.ts
@@ -77,7 +77,7 @@ class PeriodSelectController {
 
   getSelectedText() {
     if (this.currentPeriod.periodId === -1) {
-      return this.currentPeriod.periodName;
+      return this.$translate('allPeriods');
     } else {
       return this.$translate('periodLabel', { name: this.currentPeriod.periodName });
     }


### PR DESCRIPTION
1. Open the Classroom Monitor for a run that contains multiple periods
1. Click the period chooser in the upper right and choose "All Periods"
1. Once "All Periods" is selected, it should still display "All Periods" (it used to change to "allPeriods" or "[object Object]")

Closes #2591