### PR TITLE
Extracted edit node rubric feature

### DIFF
--- a/src/main/webapp/wise5/authoringTool/authoringToolController.ts
+++ b/src/main/webapp/wise5/authoringTool/authoringToolController.ts
@@ -168,6 +168,14 @@ class AuthoringToolController {
         type: 'secondary',
         showToolbar: true,
         active: false
+      },
+      'root.at.project.node.edit-rubric': {
+        name: '',
+        label: '',
+        icon: '',
+        type: 'secondary',
+        showToolbar: true,
+        active: false
       }
     };
     this.processUI();

--- a/src/main/webapp/wise5/authoringTool/node/editRubric/edit-rubric.component.html
+++ b/src/main/webapp/wise5/authoringTool/node/editRubric/edit-rubric.component.html
@@ -1,0 +1,17 @@
+<md-button id='backToStepButton' class='createButton md-raised md-primary'
+    ng-click='$ctrl.goBack()'>
+  <md-icon>arrow_back</md-icon>
+  <md-tooltip md-direction='top' class='projectButtonTooltip'>
+    {{ ::'back' | translate }}
+  </md-tooltip>
+</md-button>
+<br/>
+<h5 translate="editStepRubric"></h5>
+<summernote id='{{$ctrl.summernoteRubricId}}'
+    ng-model='$ctrl.summernoteRubricHTML'
+    ng-change='$ctrl.summernoteRubricHTMLChanged()'
+    config='$ctrl.summernoteRubricOptions'
+    ng-model-options='{ debounce: 1000 }'
+    rows='10'
+    cols='100'>
+</summernote>

--- a/src/main/webapp/wise5/authoringTool/node/editRubric/edit-rubric.component.ts
+++ b/src/main/webapp/wise5/authoringTool/node/editRubric/edit-rubric.component.ts
@@ -1,0 +1,77 @@
+import { ConfigService } from "../../../services/configService";
+import { ProjectService } from "../../../services/projectService";
+import { TeacherDataService } from "../../../services/teacherDataService";
+import { UtilService } from "../../../services/utilService";
+
+class EditRubricComponentController {
+
+  node: any;
+  nodeId: string;
+  summernoteRubricHTML: string;
+  summernoteRubricId: string;
+  summernoteRubricOptions: any;
+
+  static $inject = ['$filter', '$mdDialog', '$scope', '$state', 'ConfigService', 'ProjectService',
+      'TeacherDataService', 'UtilService'];
+
+  constructor(private $filter: any, private $mdDialog: any, private $scope: any,
+      private $state: any, private ConfigService: ConfigService,
+      private ProjectService: ProjectService, private TeacherDataService: TeacherDataService,
+      private UtilService: UtilService) {
+  }
+
+  $onInit() {
+    this.nodeId = this.TeacherDataService.getCurrentNodeId();
+    this.node = this.ProjectService.getNodeById(this.nodeId);
+    this.summernoteRubricId = `summernoteRubric_${this.nodeId}`;
+    this.summernoteRubricOptions = {
+      toolbar: [
+        ['style', ['style']],
+        ['font', ['bold', 'underline', 'clear']],
+        ['fontname', ['fontname']],
+        ['fontsize', ['fontsize']],
+        ['color', ['color']],
+        ['para', ['ul', 'ol', 'paragraph']],
+        ['table', ['table']],
+        ['insert', ['link', 'video']],
+        ['view', ['fullscreen', 'codeview', 'help']],
+        ['customButton', ['insertAssetButton']]
+      ],
+      height: 300,
+      disableDragAndDrop: true,
+      buttons: {
+        insertAssetButton: this.UtilService.createInsertAssetButton(null, this.nodeId, null,
+          'rubric', this.$filter('translate')('INSERT_ASSET'))
+      },
+      dialogsInBody: true
+    };
+    this.summernoteRubricHTML = this.ProjectService.replaceAssetPaths(this.node.rubric);
+    this.$scope.$on('assetSelected', (event, { assetItem, target }) => {
+      if (target === 'rubric') {
+        this.UtilService.insertFileInSummernoteEditor(
+          `summernoteRubric_${this.nodeId}`,
+          `${this.ConfigService.getProjectAssetsDirectoryPath()}/${assetItem.fileName}`,
+          assetItem.fileName
+        );
+      }
+      this.$mdDialog.hide();
+    });
+  }
+
+  summernoteRubricHTMLChanged() {
+    let html = this.ConfigService.removeAbsoluteAssetPaths(this.summernoteRubricHTML);
+    html = this.UtilService.insertWISELinks(html);
+    this.node.rubric = html;
+    this.ProjectService.saveProject();
+  }
+
+  goBack() {
+    this.$state.go('root.at.project.node', { projectId: this.ConfigService.getProjectId(),
+        nodeId: this.nodeId });
+  }
+}
+
+export const EditRubricComponent = {
+  templateUrl: `/wise5/authoringTool/node/editRubric/edit-rubric.component.html`,
+  controller: EditRubricComponentController
+}

--- a/src/main/webapp/wise5/authoringTool/node/editRubric/editRubricModule.ts
+++ b/src/main/webapp/wise5/authoringTool/node/editRubric/editRubricModule.ts
@@ -1,0 +1,13 @@
+import * as angular from 'angular';
+import { EditRubricComponent } from "./edit-rubric.component";
+
+export default angular.module('editRubricModule', ['ui.router'])
+  .component('editRubricComponent', EditRubricComponent)
+  .config(['$stateProvider', $stateProvider => {
+    $stateProvider
+      .state('root.at.project.node.edit-rubric', {
+        url: '/edit-rubric',
+        component: 'editRubricComponent'
+      });
+    }
+  ]);

--- a/src/main/webapp/wise5/authoringTool/node/node.html
+++ b/src/main/webapp/wise5/authoringTool/node/node.html
@@ -72,7 +72,7 @@
     <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'DELETE' | translate }}</md-tooltip>
   </md-button>
   <md-button id='editStepRubricButton' class='topButton md-raised md-primary'
-         ng-click='nodeAuthoringController.showEditRubricView()'
+         ng-click='nodeAuthoringController.editRubric()'
          ng-disabled='nodeAuthoringController.getSelectedComponentIds().length != 0 || nodeAuthoringController.insertComponentMode'
          ng-if='nodeAuthoringController.showStepButtons'>
     <md-icon>message</md-icon>
@@ -803,17 +803,6 @@
             style='width: 90%; border: 1px solid black;'></textarea>
       </md-input-container>
     </div>
-  </div>
-
-  <div ng-if='nodeAuthoringController.showRubric'>
-    <summernote id='{{nodeAuthoringController.summernoteRubricId}}'
-          ng-model='nodeAuthoringController.summernoteRubricHTML'
-          ng-change='nodeAuthoringController.summernoteRubricHTMLChanged()'
-          config='nodeAuthoringController.summernoteRubricOptions'
-          ng-model-options='{ debounce: 1000 }'
-          rows='10'
-          cols='100'>
-    </summernote>
   </div>
 
   <div ng-if='nodeAuthoringController.insertComponentMode' layout='row' style='margin-left: 10px; height:50px'>

--- a/src/main/webapp/wise5/authoringTool/node/nodeAuthoringController.ts
+++ b/src/main/webapp/wise5/authoringTool/node/nodeAuthoringController.ts
@@ -54,12 +54,7 @@ class NodeAuthoringController {
   showEditTransitions: boolean = false;
   showGeneralAdvanced: boolean = false;
   showJSON: boolean = false;
-  showRubric: boolean = false;
-  showRubricButton: boolean = true;
   showStepButtons: boolean = true;
-  summernoteRubricHTML: string;
-  summernoteRubricId: string;
-  summernoteRubricOptions: any;
   transitionCriterias: any;
   undoStack: any[] = [];
   whenToChoosePathOptions = [null, 'enterNode', 'exitNode', 'scoreChanged', 'studentDataChanged'];
@@ -420,47 +415,6 @@ class NodeAuthoringController {
     this.originalNodeCopy = this.UtilService.makeCopyOfJSONObject(this.node);
     this.currentNodeCopy = this.UtilService.makeCopyOfJSONObject(this.node);
     this.populateBranchAuthoring();
-    this.summernoteRubricId = 'summernoteRubric_' + this.nodeId;
-    let insertAssetString = this.$translate('INSERT_ASSET');
-    let insertAssetButton = this.UtilService.createInsertAssetButton(
-      null,
-      this.nodeId,
-      null,
-      'rubric',
-      insertAssetString
-    );
-    this.summernoteRubricOptions = {
-      toolbar: [
-        ['style', ['style']],
-        ['font', ['bold', 'underline', 'clear']],
-        ['fontname', ['fontname']],
-        ['fontsize', ['fontsize']],
-        ['color', ['color']],
-        ['para', ['ul', 'ol', 'paragraph']],
-        ['table', ['table']],
-        ['insert', ['link', 'video']],
-        ['view', ['fullscreen', 'codeview', 'help']],
-        ['customButton', ['insertAssetButton']]
-      ],
-      height: 300,
-      disableDragAndDrop: true,
-      buttons: {
-        insertAssetButton: insertAssetButton
-      },
-      dialogsInBody: true
-    };
-    this.summernoteRubricHTML = this.ProjectService.replaceAssetPaths(this.node.rubric);
-
-    this.$scope.$on('assetSelected', (event, { assetItem, target }) => {
-      if (target === 'rubric') {
-        this.UtilService.insertFileInSummernoteEditor(
-          `summernoteRubric_${this.nodeId}`,
-          `${this.ConfigService.getProjectAssetsDirectoryPath()}/${assetItem.fileName}`,
-          assetItem.fileName
-        );
-      }
-      this.$mdDialog.hide();
-    });
 
     this.$scope.$on('componentShowSubmitButtonValueChanged', (event, { showSubmitButton }) => {
       if (showSubmitButton) {
@@ -1023,7 +977,6 @@ class NodeAuthoringController {
     this.showGeneralAdvanced = false;
     this.showEditTransitions = false;
     this.showConstraints = false;
-    this.showRubric = false;
     this.showCreateBranch = false;
     this.showAdvanced = false;
     this.showStepButtons = false;
@@ -1058,9 +1011,8 @@ class NodeAuthoringController {
     this.showConstraints = true;
   }
 
-  showEditRubricView() {
-    this.hideAllViews();
-    this.showRubric = true;
+  editRubric() {
+    this.$state.go('root.at.project.node.edit-rubric');
   }
 
   showCreateBranchView() {
@@ -1710,24 +1662,6 @@ class NodeAuthoringController {
     this.node.transitionLogic.transitions.splice(branchPathIndex, 1);
   }
 
-  summernoteRubricHTMLChanged() {
-    let html = this.summernoteRubricHTML;
-
-    /*
-     * remove the absolute asset paths
-     * e.g.
-     * <img src='https://wise.berkeley.edu/curriculum/3/assets/sun.png'/>
-     * will be changed to
-     * <img src='sun.png'/>
-     */
-    html = this.ConfigService.removeAbsoluteAssetPaths(html);
-
-    // replace <a> and <button> elements with <wiselink> elements when applicable
-    html = this.UtilService.insertWISELinks(html);
-    this.node.rubric = html;
-    this.authoringViewNodeChanged();
-  }
-
   showComponentAuthoring() {
     this.showComponentAuthoringViews = true;
   }
@@ -2036,7 +1970,7 @@ class NodeAuthoringController {
   }
 
   backButtonClicked() {
-    if (this.showRubric || this.showAdvanced) {
+    if (this.showAdvanced) {
       this.UtilService.hideJSONValidMessage();
       this.showDefaultComponentsView();
       this.$state.go('root.at.project.node', { projectId: this.projectId, nodeId: this.nodeId });

--- a/src/main/webapp/wise5/teacher/teacher-angular-js-module.ts
+++ b/src/main/webapp/wise5/teacher/teacher-angular-js-module.ts
@@ -42,6 +42,7 @@ import '../components/embedded/embeddedAuthoringComponentModule';
 import '../components/graph/graphAuthoringComponentModule';
 import '../components/html/htmlAuthoringComponentModule';
 import '../authoringTool/addComponent/addComponentModule';
+import '../authoringTool/node/editRubric/editRubricModule';
 import '../authoringTool/importComponent/importComponentModule';
 import '../authoringTool/importStep/importStepModule';
 import '../components/label/labelAuthoringComponentModule';
@@ -61,6 +62,7 @@ export function createTeacherAngularJSModule() {
       'common',
       'angular-inview',
       'addComponentModule',
+      'editRubricModule',
       'summaryAuthoringComponentModule',
       'animationAuthoringComponentModule',
       'audioOscillatorAuthoringComponentModule',


### PR DESCRIPTION
Editing a node's rubric now has its own route and is in its own module. This should make the code easier to read, especially nodeAuthoringController and node.html.

Test that you can edit a node's rubric. Test that you can add assets to the rubric and it will show up in the preview.

Closes #2610