### PR TITLE
Update OER thumbnail urls

### DIFF
--- a/src/main/webapp/wise5/components/outsideURL/resources.json
+++ b/src/main/webapp/wise5/components/outsideURL/resources.json
@@ -52,7 +52,7 @@
     {
       "url": "https://phet.colorado.edu/sims/html/projectile-motion/latest/projectile-motion_en.html",
       "info": "https://phet.colorado.edu/en/simulation/projectile-motion",
-      "thumbnail": "https://phet-downloads.colorado.edu/sims/html/projectile-motion/latest/projectile-motion-600.png",
+      "thumbnail": "https://phet.colorado.edu/sims/html/projectile-motion/latest/projectile-motion-600.png",
       "metadata": {
         "title": "Projectile Motion",
         "subjects": ["Physical Sciences", "Engineering, Technology, and Applications of Science"],
@@ -62,7 +62,7 @@
     {
       "url": "https://phet.colorado.edu/sims/html/balancing-act/latest/balancing-act_en.html",
       "info": "https://phet.colorado.edu/en/simulation/balancing-act",
-      "thumbnail": "https://phet-downloads.colorado.edu/sims/html/balancing-act/latest/balancing-act-600.png",
+      "thumbnail": "https://phet.colorado.edu/sims/html/balancing-act/latest/balancing-act-600.png",
       "metadata": {
         "title": "Balancing Act",
         "subjects": ["Physical Sciences", "Engineering, Technology, and Applications of Science"],
@@ -72,7 +72,7 @@
     {
       "url": "https://phet.colorado.edu/sims/html/wave-on-a-string/latest/wave-on-a-string_en.html",
       "info": "https://phet.colorado.edu/en/simulation/wave-on-a-string",
-      "thumbnail": "https://phet-downloads.colorado.edu/sims/html/wave-on-a-string/latest/wave-on-a-string-600.png",
+      "thumbnail": "https://phet.colorado.edu/sims/html/wave-on-a-string/latest/wave-on-a-string-600.png",
       "metadata": {
         "title": "Wave on a String",
         "subjects": ["Physical Sciences"],
@@ -82,7 +82,7 @@
     {
       "url": "https://phet.colorado.edu/sims/html/energy-skate-park-basics/latest/energy-skate-park-basics_en.html",
       "info": "https://phet.colorado.edu/en/simulation/energy-skate-park-basics",
-      "thumbnail": "https://phet-downloads.colorado.edu/sims/html/energy-skate-park-basics/latest/energy-skate-park-basics-600.png",
+      "thumbnail": "https://phet.colorado.edu/sims/html/energy-skate-park-basics/latest/energy-skate-park-basics-600.png",
       "metadata": {
         "title": "Energy Skate Park: Basics",
         "subjects": ["Physical Sciences", "Engineering, Technology, and Applications of Science"],
@@ -92,7 +92,7 @@
     {
       "url": "https://phet.colorado.edu/sims/html/forces-and-motion-basics/latest/forces-and-motion-basics_en.html",
       "info": "https://phet.colorado.edu/en/simulation/forces-and-motion-basics",
-      "thumbnail": "https://phet-downloads.colorado.edu/sims/html/forces-and-motion-basics/latest/forces-and-motion-basics-600.png",
+      "thumbnail": "https://phet.colorado.edu/sims/html/forces-and-motion-basics/latest/forces-and-motion-basics-600.png",
       "metadata": {
         "title": "Forces and Motion: Basics",
         "subjects": ["Physical Sciences"],
@@ -102,7 +102,7 @@
     {
       "url": "https://phet.colorado.edu/sims/html/acid-base-solutions/latest/acid-base-solutions_en.html",
       "info": "https://phet.colorado.edu/en/simulation/acid-base-solutions",
-      "thumbnail": "https://phet-downloads.colorado.edu/sims/html/acid-base-solutions/latest/acid-base-solutions-600.png",
+      "thumbnail": "https://phet.colorado.edu/sims/html/acid-base-solutions/latest/acid-base-solutions-600.png",
       "metadata": {
         "title": "Acid Base Solutions",
         "subjects": ["Physical Sciences"],


### PR DESCRIPTION
1. Log in as a teacher
1. Open the Authoring Tool
1. Open a step
1. Add an Outside Resource component
1. Make sure the thumbnails show up for all the resources. The thumbnails for the phet models previously did not show up but now they should.

Closes #2521