### PR TITLE
Replace openAssetChooser and assetSelected events

### DIFF
--- a/src/main/webapp/site/src/app/services/projectAssetService.ts
+++ b/src/main/webapp/site/src/app/services/projectAssetService.ts
@@ -215,4 +215,15 @@ export class ProjectAssetService {
   isProjectAssetsAvailable() {
     return this.getProjectAssets().getValue() != null;
   }
+
+  openAssetChooser(params: any) {
+    return this.upgrade.$injector.get('$mdDialog').show({
+      templateUrl: 'wise5/authoringTool/asset/asset.html',
+      controller: 'ProjectAssetController',
+      controllerAs: 'projectAssetController',
+      $stateParams: params,
+      clickOutsideToClose: true,
+      escapeToClose: true
+    });
+  }
 }

--- a/src/main/webapp/wise5/authoringTool/advanced/advancedAuthoringController.ts
+++ b/src/main/webapp/wise5/authoringTool/advanced/advancedAuthoringController.ts
@@ -2,6 +2,7 @@ import { ConfigService } from '../../services/configService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { UtilService } from '../../services/utilService';
 import * as angular from 'angular';
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
 
 class AdvancedAuthoringController {
   $translate: any;
@@ -17,6 +18,7 @@ class AdvancedAuthoringController {
     '$state',
     '$stateParams',
     'ConfigService',
+    'ProjectAssetService',
     'ProjectService',
     'UtilService'
   ];
@@ -28,6 +30,7 @@ class AdvancedAuthoringController {
     private $state,
     $stateParams: any,
     private ConfigService: ConfigService,
+    private ProjectAssetService: ProjectAssetService,
     private ProjectService: TeacherProjectService,
     private UtilService: UtilService
   ) {
@@ -36,6 +39,7 @@ class AdvancedAuthoringController {
     this.$state = $state;
     this.$translate = $filter('translate');
     this.ConfigService = ConfigService;
+    this.ProjectAssetService = ProjectAssetService;
     this.ProjectService = ProjectService;
     this.UtilService = UtilService;
     this.projectId = $stateParams.projectId;
@@ -43,12 +47,6 @@ class AdvancedAuthoringController {
 
   $onInit() {
     this.setProjectScriptFilename();
-    this.$scope.$on('assetSelected', (event, { assetItem, target }) => {
-      if (target === 'scriptFilename') {
-        this.projectScriptFilename = assetItem.fileName;
-        this.projectScriptFilenameChanged();
-      }
-    });
   }
 
   showJSONClicked() {
@@ -96,12 +94,21 @@ class AdvancedAuthoringController {
   }
 
   chooseProjectScriptFile() {
-    const openAssetChooserParams = {
+    const params = {
       isPopup: true,
       projectId: this.projectId,
       target: 'scriptFilename'
     };
-    this.$rootScope.$broadcast('openAssetChooser', openAssetChooserParams);
+    this.ProjectAssetService.openAssetChooser(params).then(
+      (data: any) => { this.assetSelected(data) }
+    );
+  }
+
+  assetSelected({ assetItem, target }) {
+    if (target === 'scriptFilename') {
+      this.projectScriptFilename = assetItem.fileName;
+      this.projectScriptFilenameChanged();
+    }
   }
 
   downloadProject() {

--- a/src/main/webapp/wise5/authoringTool/asset/projectAssetController.ts
+++ b/src/main/webapp/wise5/authoringTool/asset/projectAssetController.ts
@@ -190,7 +190,7 @@ class ProjectAssetController {
       target: this.target,
       targetObject: this.targetObject
     };
-    this.$rootScope.$broadcast('assetSelected', params);
+    this.$mdDialog.hide(params);
   }
 
   /**

--- a/src/main/webapp/wise5/authoringTool/authoringToolController.ts
+++ b/src/main/webapp/wise5/authoringTool/authoringToolController.ts
@@ -252,25 +252,6 @@ class AuthoringToolController {
       this.setGlobalMessage(this.$translate('notAllowedToEditThisProject'), false, null);
     });
 
-    this.$scope.$on('openAssetChooser', (event, params) => {
-      const stateParams = {
-        isPopup: params.isPopup,
-        projectId: params.projectId,
-        nodeId: params.nodeId,
-        componentId: params.componentId,
-        target: params.target,
-        targetObject: params.targetObject
-      };
-      this.$mdDialog.show({
-        templateUrl: 'wise5/authoringTool/asset/asset.html',
-        controller: 'ProjectAssetController',
-        controllerAs: 'projectAssetController',
-        $stateParams: stateParams,
-        clickOutsideToClose: true,
-        escapeToClose: true
-      });
-    });
-
     this.$scope.$on('openWISELinkChooser', (event, params) => {
       const stateParams = {
         projectId: params.projectId,

--- a/src/main/webapp/wise5/authoringTool/info/projectInfoController.ts
+++ b/src/main/webapp/wise5/authoringTool/info/projectInfoController.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
 import { ConfigService } from '../../services/configService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 
@@ -21,6 +22,7 @@ class ProjectInfoController {
     '$scope',
     '$timeout',
     'ConfigService',
+    'ProjectAssetService',
     'ProjectService'
   ];
 
@@ -31,6 +33,7 @@ class ProjectInfoController {
     private $scope: any,
     private $timeout: any,
     private ConfigService: ConfigService,
+    private ProjectAssetService: ProjectAssetService,
     private ProjectService: TeacherProjectService
   ) {
     this.$translate = $filter('translate');
@@ -40,16 +43,6 @@ class ProjectInfoController {
     );
     this.loadProjectIcon();
     this.processMetadata();
-    this.registerListeners();
-  }
-
-  registerListeners() {
-    this.$scope.$on('assetSelected', (event, args) => {
-      if (args.target === 'projectIcon') {
-        this.setCustomProjectIcon(args.assetItem.fileName);
-        this.$mdDialog.hide();
-      }
-    });
   }
 
   processMetadata() {
@@ -155,7 +148,16 @@ class ProjectInfoController {
       isPopup: true,
       target: 'projectIcon'
     };
-    this.$rootScope.$broadcast('openAssetChooser', params);
+    this.ProjectAssetService.openAssetChooser(params).then(
+      (data: any) => { this.assetSelected(data) }
+    );
+  }
+
+  assetSelected(args) {
+    if (args.target === 'projectIcon') {
+      this.setCustomProjectIcon(args.assetItem.fileName);
+      this.$mdDialog.hide();
+    }
   }
 
   setCustomProjectIcon(projectIcon) {

--- a/src/main/webapp/wise5/authoringTool/node/editRubric/edit-rubric.component.ts
+++ b/src/main/webapp/wise5/authoringTool/node/editRubric/edit-rubric.component.ts
@@ -50,10 +50,6 @@ class EditRubricComponentController {
     this.summernoteRubricHTML = this.ProjectService.replaceAssetPaths(this.node.rubric);
   }
 
-  /**
-   * Creates and returns a function so that within the function the 'this' object will be this
-   * authorNotebookController.
-   */
   createOpenAssetChooserFunction() {
     return (params: any) => {
       this.ProjectAssetService.openAssetChooser(params).then(

--- a/src/main/webapp/wise5/authoringTool/node/editRubric/edit-rubric.component.ts
+++ b/src/main/webapp/wise5/authoringTool/node/editRubric/edit-rubric.component.ts
@@ -1,3 +1,4 @@
+import { ProjectAssetService } from "../../../../site/src/app/services/projectAssetService";
 import { ConfigService } from "../../../services/configService";
 import { ProjectService } from "../../../services/projectService";
 import { TeacherDataService } from "../../../services/teacherDataService";
@@ -11,13 +12,13 @@ class EditRubricComponentController {
   summernoteRubricId: string;
   summernoteRubricOptions: any;
 
-  static $inject = ['$filter', '$mdDialog', '$scope', '$state', 'ConfigService', 'ProjectService',
-      'TeacherDataService', 'UtilService'];
+  static $inject = ['$filter', '$mdDialog', '$scope', '$state', 'ConfigService',
+      'ProjectAssetService', 'ProjectService', 'TeacherDataService', 'UtilService'];
 
   constructor(private $filter: any, private $mdDialog: any, private $scope: any,
       private $state: any, private ConfigService: ConfigService,
-      private ProjectService: ProjectService, private TeacherDataService: TeacherDataService,
-      private UtilService: UtilService) {
+      private ProjectAssetService: ProjectAssetService, private ProjectService: ProjectService,
+      private TeacherDataService: TeacherDataService, private UtilService: UtilService) {
   }
 
   $onInit() {
@@ -41,21 +42,34 @@ class EditRubricComponentController {
       disableDragAndDrop: true,
       buttons: {
         insertAssetButton: this.UtilService.createInsertAssetButton(null, this.nodeId, null,
-          'rubric', this.$filter('translate')('INSERT_ASSET'))
+          'rubric', this.$filter('translate')('INSERT_ASSET'),
+          this.createOpenAssetChooserFunction())
       },
       dialogsInBody: true
     };
     this.summernoteRubricHTML = this.ProjectService.replaceAssetPaths(this.node.rubric);
-    this.$scope.$on('assetSelected', (event, { assetItem, target }) => {
-      if (target === 'rubric') {
-        this.UtilService.insertFileInSummernoteEditor(
-          `summernoteRubric_${this.nodeId}`,
-          `${this.ConfigService.getProjectAssetsDirectoryPath()}/${assetItem.fileName}`,
-          assetItem.fileName
-        );
-      }
-      this.$mdDialog.hide();
-    });
+  }
+
+  /**
+   * Creates and returns a function so that within the function the 'this' object will be this
+   * authorNotebookController.
+   */
+  createOpenAssetChooserFunction() {
+    return (params: any) => {
+      this.ProjectAssetService.openAssetChooser(params).then(
+        (data: any) => { this.assetSelected(data) }
+      );
+    }
+  }
+
+  assetSelected({ assetItem, target }) {
+    if (target === 'rubric') {
+      this.UtilService.insertFileInSummernoteEditor(
+        `summernoteRubric_${this.nodeId}`,
+        `${this.ConfigService.getProjectAssetsDirectoryPath()}/${assetItem.fileName}`,
+        assetItem.fileName
+      );
+    }
   }
 
   summernoteRubricHTMLChanged() {

--- a/src/main/webapp/wise5/authoringTool/notebook/authorNotebookController.ts
+++ b/src/main/webapp/wise5/authoringTool/notebook/authorNotebookController.ts
@@ -109,10 +109,6 @@ class AuthorNotebookController {
     this.setReportIdToAuthoringNote(note.reportId, authoringReportNote);
   }
 
-  /**
-   * Creates and returns a function so that within the function the 'this' object will be this
-   * authorNotebookController.
-   */
   createOpenAssetChooserFunction() {
     return (params: any) => {
       this.ProjectAssetService.openAssetChooser(params).then(

--- a/src/main/webapp/wise5/authoringTool/notebook/notebookAuthoring.html
+++ b/src/main/webapp/wise5/authoringTool/notebook/notebookAuthoring.html
@@ -162,7 +162,7 @@
       <label>
         {{ ::'starterText' | translate }}
       </label>
-      <summernote id="{{::reportNote.summernoteId}}"
+      <summernote id="summernoteNotebook_{{reportNote.reportId}}"
                   ng-model="authorNotebookController.reportIdToAuthoringNote[reportNote.reportId].summernoteHTML"
                   ng-change="authorNotebookController.reportStarterTextChanged(reportNote.reportId)"
                   config="authorNotebookController.reportIdToAuthoringNote[reportNote.reportId].summernoteOptions"
@@ -250,7 +250,7 @@
       <label>
         {{ ::'starterText' | translate }}
       </label>
-      <summernote id="{{::reportNote.summernoteId}}"
+      <summernote id="summernoteNotebook_{{reportNote.reportId}}"
                   ng-model="authorNotebookController.reportIdToAuthoringNote[reportNote.reportId].summernoteHTML"
                   ng-change="authorNotebookController.reportStarterTextChanged(reportNote.reportId)"
                   config="authorNotebookController.reportIdToAuthoringNote[reportNote.reportId].summernoteOptions"

--- a/src/main/webapp/wise5/authoringTool/rubric/rubricAuthoringController.ts
+++ b/src/main/webapp/wise5/authoringTool/rubric/rubricAuthoringController.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '../../services/configService';
 import { UtilService } from '../../services/utilService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
 
 class RubricAuthoringController {
   translate: any;
@@ -16,6 +17,7 @@ class RubricAuthoringController {
     '$state',
     '$stateParams',
     'ConfigService',
+    'ProjectAssetService',
     'ProjectService',
     'UtilService'
   ];
@@ -27,6 +29,7 @@ class RubricAuthoringController {
     private $state: any,
     $stateParams: any,
     private ConfigService: ConfigService,
+    private ProjectAssetService: ProjectAssetService,
     private ProjectService: TeacherProjectService,
     private UtilService: UtilService
   ) {
@@ -54,7 +57,8 @@ class RubricAuthoringController {
           this.nodeId,
           null,
           'rubric',
-          this.translate('INSERT_ASSET')
+          this.translate('INSERT_ASSET'),
+          this.createOpenAssetChooserFunction()
         )
       },
       dialogsInBody: true
@@ -64,19 +68,29 @@ class RubricAuthoringController {
     );
   }
 
-  $onInit() {
-    this.$scope.$on('assetSelected', (event, { assetItem, target }) => {
-      if (target === 'rubric') {
-        const fileName = assetItem.fileName;
-        const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
-        this.UtilService.insertFileInSummernoteEditor(
-          this.summernoteRubricId,
-          fullFilePath,
-          fileName
-        );
-        this.$mdDialog.hide();
-      }
-    });
+  /**
+   * Creates and returns a function so that within the function the 'this' object will be this
+   * rubricAuthoringController.
+   */
+  createOpenAssetChooserFunction() {
+    return (params: any) => {
+      this.ProjectAssetService.openAssetChooser(params).then(
+        (data: any) => { this.assetSelected(data) }
+      );
+    }
+  }
+
+  assetSelected({ assetItem, target }) {
+    if (target === 'rubric') {
+      const fileName = assetItem.fileName;
+      const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
+      this.UtilService.insertFileInSummernoteEditor(
+        this.summernoteRubricId,
+        fullFilePath,
+        fileName
+      );
+      this.$mdDialog.hide();
+    }
   }
 
   summernoteRubricHTMLChanged() {

--- a/src/main/webapp/wise5/authoringTool/rubric/rubricAuthoringController.ts
+++ b/src/main/webapp/wise5/authoringTool/rubric/rubricAuthoringController.ts
@@ -68,10 +68,6 @@ class RubricAuthoringController {
     );
   }
 
-  /**
-   * Creates and returns a function so that within the function the 'this' object will be this
-   * rubricAuthoringController.
-   */
   createOpenAssetChooserFunction() {
     return (params: any) => {
       this.ProjectAssetService.openAssetChooser(params).then(

--- a/src/main/webapp/wise5/components/audioOscillator/audioOscillatorAuthoringController.ts
+++ b/src/main/webapp/wise5/components/audioOscillator/audioOscillatorAuthoringController.ts
@@ -1,8 +1,10 @@
 'use strict';
 
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
 import AudioOscillatorController from './audioOscillatorController';
 
 class AudioOscillatorAuthoringController extends AudioOscillatorController {
+  ProjectAssetService: ProjectAssetService;
   allowedConnectedComponentTypes: any[];
   authoringSineChecked: boolean;
   authoringSquareChecked: boolean;
@@ -21,6 +23,7 @@ class AudioOscillatorAuthoringController extends AudioOscillatorController {
     'ConfigService',
     'NodeService',
     'NotebookService',
+    'ProjectAssetService',
     'ProjectService',
     'StudentAssetService',
     'StudentDataService',
@@ -39,6 +42,7 @@ class AudioOscillatorAuthoringController extends AudioOscillatorController {
     ConfigService,
     NodeService,
     NotebookService,
+    ProjectAssetService,
     ProjectService,
     StudentAssetService,
     StudentDataService,
@@ -61,6 +65,7 @@ class AudioOscillatorAuthoringController extends AudioOscillatorController {
       StudentDataService,
       UtilService
     );
+    this.ProjectAssetService = ProjectAssetService;
     this.allowedConnectedComponentTypes = [{ type: 'AudioOscillator' }];
     this.populateCheckedOscillatorTypes();
   }
@@ -107,6 +112,13 @@ class AudioOscillatorAuthoringController extends AudioOscillatorController {
     }
     this.authoringViewComponentChanged();
   }
+
+  openAssetChooser(params: any) {
+    this.ProjectAssetService.openAssetChooser(params).then(
+      (data: any) => { this.assetSelected(data) }
+    );
+  }
+
 }
 
 export default AudioOscillatorAuthoringController;

--- a/src/main/webapp/wise5/components/componentController.ts
+++ b/src/main/webapp/wise5/components/componentController.ts
@@ -260,7 +260,8 @@ class ComponentController {
     this.summernoteRubricHTML = this.componentContent.rubric;
 
     const insertAssetString = this.$translate('INSERT_ASSET');
-    const InsertAssetButton = this.UtilService.createInsertAssetButton(null, this.nodeId, this.componentId, 'rubric', insertAssetString);
+    const InsertAssetButton = this.UtilService.createInsertAssetButton(null, this.nodeId,
+        this.componentId, 'rubric', insertAssetString, this.createOpenAssetChooserFunction());
     this.summernoteRubricOptions = {
       toolbar: [
         ['style', ['style']],
@@ -286,6 +287,24 @@ class ComponentController {
     this.updateAdvancedAuthoringView();
   }
 
+  /**
+   * Creates and returns a function so that within the function the 'this' object will be this
+   * rubricAuthoringController.
+   */
+  createOpenAssetChooserFunction() {
+    return (params: any) => {
+      this.openAssetChooser(params);
+    }
+  }
+
+  /**
+   * This function should be implemented by child components.
+   * @param params and object containing key value pairs
+   */
+  openAssetChooser(params: any) {
+
+  }
+
   registerAuthoringListeners() {
     this.$scope.$watch(
         () => {
@@ -305,10 +324,6 @@ class ComponentController {
             .showAdvancedAdvancedAuthoring[this.componentId];
         this.UtilService.hideJSONValidMessage();
       }, true);
-
-    this.$scope.$on('assetSelected', (event, args) => {
-      this.assetSelected(event, args);
-    });
   }
 
   handleAuthoringComponentContentChanged(newValue, oldValue) {
@@ -351,21 +366,18 @@ class ComponentController {
     ($('#' + summernoteId) as any).summernote('insertNode', videoElement);
   }
 
-  assetSelected(event, args) {
-    if (this.isEventTargetThisComponent(args)) {
-      if (args.target === 'rubric') {
-        const fileName = args.assetItem.fileName;
-        const summernoteId = this.getSummernoteId(args);
-        this.restoreSummernoteCursorPosition(summernoteId);
-        const fullAssetPath = this.getFullAssetPath(fileName);
-        if (this.UtilService.isImage(fileName)) {
-          this.insertImageIntoSummernote(summernoteId, fullAssetPath, fileName);
-        } else if (this.UtilService.isVideo(fileName)) {
-          this.insertVideoIntoSummernote(summernoteId, fullAssetPath);
-        }
+  assetSelected(args: any) {
+    if (args.target === 'rubric') {
+      const fileName = args.assetItem.fileName;
+      const summernoteId = this.getSummernoteId(args);
+      this.restoreSummernoteCursorPosition(summernoteId);
+      const fullAssetPath = this.getFullAssetPath(fileName);
+      if (this.UtilService.isImage(fileName)) {
+        this.insertImageIntoSummernote(summernoteId, fullAssetPath, fileName);
+      } else if (this.UtilService.isVideo(fileName)) {
+        this.insertVideoIntoSummernote(summernoteId, fullAssetPath);
       }
     }
-    this.$mdDialog.hide();
   }
 
   registerComponentWithParentNode() {
@@ -1173,7 +1185,6 @@ class ComponentController {
       this.ProjectService.replaceComponent(this.nodeId, this.componentId, editedComponentContent);
       this.componentContent = editedComponentContent;
       this.$scope.$parent.nodeAuthoringController.authoringViewNodeChanged();
-      this.$rootScope.$broadcast('scrollToComponent', { componentId: this.componentId });
       this.isJSONStringChanged = false;
     } catch(e) {
       this.$scope.$parent.nodeAuthoringController.showSaveErrorAdvancedAuthoring();
@@ -1301,6 +1312,7 @@ class ComponentController {
       }
     });
   }
+
 }
 
 export default ComponentController;

--- a/src/main/webapp/wise5/components/componentController.ts
+++ b/src/main/webapp/wise5/components/componentController.ts
@@ -287,10 +287,6 @@ class ComponentController {
     this.updateAdvancedAuthoringView();
   }
 
-  /**
-   * Creates and returns a function so that within the function the 'this' object will be this
-   * rubricAuthoringController.
-   */
   createOpenAssetChooserFunction() {
     return (params: any) => {
       this.openAssetChooser(params);

--- a/src/main/webapp/wise5/components/discussion/discussionAuthoringController.ts
+++ b/src/main/webapp/wise5/components/discussion/discussionAuthoringController.ts
@@ -1,8 +1,10 @@
 'use strict';
 
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
 import DiscussionController from './discussionController';
 
 class DiscussionAuthoringController extends DiscussionController {
+  ProjectAssetService: ProjectAssetService;
   allowedConnectedComponentTypes: any[];
 
   static $inject = [
@@ -17,6 +19,7 @@ class DiscussionAuthoringController extends DiscussionController {
     'NodeService',
     'NotebookService',
     'NotificationService',
+    'ProjectAssetService',
     'ProjectService',
     'StudentAssetService',
     'StudentDataService',
@@ -36,6 +39,7 @@ class DiscussionAuthoringController extends DiscussionController {
     NodeService,
     NotebookService,
     NotificationService,
+    ProjectAssetService,
     ProjectService,
     StudentAssetService,
     StudentDataService,
@@ -60,6 +64,7 @@ class DiscussionAuthoringController extends DiscussionController {
       UtilService,
       $mdMedia
     );
+    this.ProjectAssetService = ProjectAssetService;
     this.allowedConnectedComponentTypes = [{ type: 'Discussion' }];
   }
 
@@ -80,6 +85,13 @@ class DiscussionAuthoringController extends DiscussionController {
       connectedComponent.type = firstConnectedComponent.type;
     }
   }
+
+  openAssetChooser(params: any) {
+    this.ProjectAssetService.openAssetChooser(params).then(
+      (data: any) => { this.assetSelected(data) }
+    );
+  }
+
 }
 
 export default DiscussionAuthoringController;

--- a/src/main/webapp/wise5/components/graph/graphAuthoringController.ts
+++ b/src/main/webapp/wise5/components/graph/graphAuthoringController.ts
@@ -2,8 +2,10 @@
 
 import GraphController from "./graphController";
 import html2canvas from 'html2canvas';
+import { ProjectAssetService } from "../../../site/src/app/services/projectAssetService";
 
 class GraphAuthoringController extends GraphController {
+  ProjectAssetService: ProjectAssetService;
 
   availableGraphTypes: any[];
   availableRoundingOptions: any[];
@@ -27,6 +29,7 @@ class GraphAuthoringController extends GraphController {
     'GraphService',
     'NodeService',
     'NotebookService',
+    'ProjectAssetService',
     'ProjectService',
     'StudentAssetService',
     'StudentDataService',
@@ -44,6 +47,7 @@ class GraphAuthoringController extends GraphController {
               GraphService,
               NodeService,
               NotebookService,
+              ProjectAssetService,
               ProjectService,
               StudentAssetService,
               StudentDataService,
@@ -63,6 +67,8 @@ class GraphAuthoringController extends GraphController {
       StudentAssetService,
       StudentDataService,
       UtilService);
+
+    this.ProjectAssetService = ProjectAssetService;
 
     this.availableGraphTypes = [
       {
@@ -220,26 +226,6 @@ class GraphAuthoringController extends GraphController {
     return false;
   }
 
-  assetSelected(event, args) {
-    if (this.isEventTargetThisComponent(args)) {
-      const fileName = args.assetItem.fileName;
-      if (args.target === 'rubric') {
-        const summernoteId = this.getSummernoteId(args);
-        this.restoreSummernoteCursorPosition(summernoteId);
-        const fullAssetPath = this.getFullAssetPath(fileName);
-        if (this.UtilService.isImage(fileName)) {
-          this.insertImageIntoSummernote(summernoteId, fullAssetPath, fileName);
-        } else if (this.UtilService.isVideo(fileName)) {
-          this.insertVideoIntoSummernote(summernoteId, fullAssetPath);
-        }
-      } else if (args.target === 'background') {
-        this.authoringComponentContent.backgroundImage = fileName;
-        this.authoringViewComponentChanged();
-      }
-    }
-    this.$mdDialog.hide();
-  }
-
   authoringAddSeriesClicked() {
     const newSeries: any = this.createNewSeries();
     if (this.authoringComponentContent.graphType === 'line') {
@@ -295,7 +281,30 @@ class GraphAuthoringController extends GraphController {
       componentId: this.componentId,
       target: 'background'
     };
-    this.$rootScope.$broadcast('openAssetChooser', params);
+    this.openAssetChooser(params);
+  }
+
+  openAssetChooser(params: any) {
+    this.ProjectAssetService.openAssetChooser(params).then(
+      (data: any) => { this.assetSelected(data) }
+    );
+  }
+
+  assetSelected(args: any) {
+    const fileName = args.assetItem.fileName;
+    if (args.target === 'rubric') {
+      const summernoteId = this.getSummernoteId(args);
+      this.restoreSummernoteCursorPosition(summernoteId);
+      const fullAssetPath = this.getFullAssetPath(fileName);
+      if (this.UtilService.isImage(fileName)) {
+        this.insertImageIntoSummernote(summernoteId, fullAssetPath, fileName);
+      } else if (this.UtilService.isVideo(fileName)) {
+        this.insertVideoIntoSummernote(summernoteId, fullAssetPath);
+      }
+    } else if (args.target === 'background') {
+      this.authoringComponentContent.backgroundImage = fileName;
+      this.authoringViewComponentChanged();
+    }
   }
 
   authoringAddXAxisCategory() {

--- a/src/main/webapp/wise5/components/html/htmlAuthoringController.ts
+++ b/src/main/webapp/wise5/components/html/htmlAuthoringController.ts
@@ -121,11 +121,7 @@ class HTMLAuthoringController extends HTMLController {
   $onInit() {
     this.registerWISELinkListener();
   }
-  
-  /**
-   * Creates and returns a function so that within the function the 'this' object will be this
-   * authorNotebookController.
-   */
+
   createOpenAssetChooserFunction() {
     return (params: any) => {
       this.ProjectAssetService.openAssetChooser(params).then(

--- a/src/main/webapp/wise5/components/html/htmlAuthoringController.ts
+++ b/src/main/webapp/wise5/components/html/htmlAuthoringController.ts
@@ -1,9 +1,11 @@
 'use strict';
 
 import * as angular from 'angular';
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
 import HTMLController from './htmlController';
 
 class HTMLAuthoringController extends HTMLController {
+  ProjectAssetService: ProjectAssetService;
   summernotePromptHTML: string;
   summernotePromptOptions: any;
   summernotePromptId: string;
@@ -21,6 +23,7 @@ class HTMLAuthoringController extends HTMLController {
     'ConfigService',
     'NodeService',
     'NotebookService',
+    'ProjectAssetService',
     'ProjectService',
     'StudentAssetService',
     'StudentDataService',
@@ -40,6 +43,7 @@ class HTMLAuthoringController extends HTMLController {
     ConfigService,
     NodeService,
     NotebookService,
+    ProjectAssetService,
     ProjectService,
     StudentAssetService,
     StudentDataService,
@@ -63,6 +67,7 @@ class HTMLAuthoringController extends HTMLController {
       StudentDataService,
       UtilService
     );
+    this.ProjectAssetService = ProjectAssetService;
     this.summernotePromptHTML = '';
     this.summernotePromptOptions = {
       toolbar: [
@@ -93,7 +98,8 @@ class HTMLAuthoringController extends HTMLController {
           this.nodeId,
           this.componentId,
           'prompt',
-          this.$translate('INSERT_ASSET')
+          this.$translate('INSERT_ASSET'),
+          this.createOpenAssetChooserFunction()
         )
       },
       dialogsInBody: true
@@ -113,31 +119,37 @@ class HTMLAuthoringController extends HTMLController {
   }
 
   $onInit() {
-    this.registerAssetListener();
     this.registerWISELinkListener();
   }
+  
+  /**
+   * Creates and returns a function so that within the function the 'this' object will be this
+   * authorNotebookController.
+   */
+  createOpenAssetChooserFunction() {
+    return (params: any) => {
+      this.ProjectAssetService.openAssetChooser(params).then(
+        (data: any) => { this.assetSelected(data) }
+      );
+    }
+  }
 
-  registerAssetListener() {
-    this.$scope.$on('assetSelected', (event, { nodeId, componentId, assetItem, target }) => {
-      if (nodeId === this.nodeId && componentId === this.componentId) {
-        const fileName = assetItem.fileName;
-        const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
-        if (target === 'prompt') {
-          this.UtilService.insertFileInSummernoteEditor(
-            `summernotePrompt_${this.nodeId}_${this.componentId}`,
-            fullFilePath,
-            fileName
-          );
-        } else {
-          this.UtilService.insertFileInSummernoteEditor(
-            `summernoteRubric_${this.nodeId}_${this.componentId}`,
-            fullFilePath,
-            fileName
-          );
-        }
-      }
-      this.$mdDialog.hide();
-    });
+  assetSelected({ nodeId, componentId, assetItem, target }) {
+    const fileName = assetItem.fileName;
+    const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
+    if (target === 'prompt') {
+      this.UtilService.insertFileInSummernoteEditor(
+        `summernotePrompt_${this.nodeId}_${this.componentId}`,
+        fullFilePath,
+        fileName
+      );
+    } else {
+      this.UtilService.insertFileInSummernoteEditor(
+        `summernoteRubric_${this.nodeId}_${this.componentId}`,
+        fullFilePath,
+        fileName
+      );
+    }
   }
 
   registerWISELinkListener() {

--- a/src/main/webapp/wise5/components/match/matchAuthoringController.ts
+++ b/src/main/webapp/wise5/components/match/matchAuthoringController.ts
@@ -1,8 +1,10 @@
 'use strict';
 
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
 import MatchController from './matchController';
 
 class MatchAuthoringController extends MatchController {
+  ProjectAssetService: ProjectAssetService;
   $mdDialog: any;
   allowedConnectedComponentTypes: any[];
 
@@ -19,6 +21,7 @@ class MatchAuthoringController extends MatchController {
     'MatchService',
     'NodeService',
     'NotebookService',
+    'ProjectAssetService',
     'ProjectService',
     'StudentAssetService',
     'StudentDataService',
@@ -38,6 +41,7 @@ class MatchAuthoringController extends MatchController {
     MatchService,
     NodeService,
     NotebookService,
+    ProjectAssetService,
     ProjectService,
     StudentAssetService,
     StudentDataService,
@@ -61,6 +65,7 @@ class MatchAuthoringController extends MatchController {
       StudentDataService,
       UtilService
     );
+    this.ProjectAssetService = ProjectAssetService;
     this.allowedConnectedComponentTypes = [
       {
         type: 'Match'
@@ -83,33 +88,6 @@ class MatchAuthoringController extends MatchController {
         this.initializeBuckets();
       }.bind(this),
       true
-    );
-    this.registerAssetListener();
-  }
-
-  registerAssetListener() {
-    this.$scope.$on(
-      'assetSelected',
-      (event, { nodeId, componentId, assetItem, target, targetObject }) => {
-        if (nodeId === this.nodeId && componentId === this.componentId) {
-          const fileName = assetItem.fileName;
-          const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
-          if (target === 'rubric') {
-            this.UtilService.insertFileInSummernoteEditor(
-              `summernoteRubric_${this.nodeId}_${this.componentId}`,
-              fullFilePath,
-              fileName
-            );
-          } else if (target === 'choice') {
-            targetObject.value = '<img src="' + fileName + '"/>';
-            this.authoringViewComponentChanged();
-          } else if (target === 'bucket') {
-            targetObject.value = '<img src="' + fileName + '"/>';
-            this.authoringViewComponentChanged();
-          }
-        }
-        this.$mdDialog.hide();
-      }
     );
   }
 
@@ -398,7 +376,7 @@ class MatchAuthoringController extends MatchController {
       target: 'choice',
       targetObject: choice
     };
-    this.$rootScope.$broadcast('openAssetChooser', params);
+    this.openAssetChooser(params);
   }
 
   /**
@@ -413,8 +391,33 @@ class MatchAuthoringController extends MatchController {
       target: 'bucket',
       targetObject: bucket
     };
-    this.$rootScope.$broadcast('openAssetChooser', params);
+    this.openAssetChooser(params);
   }
+
+  openAssetChooser(params: any) {
+    this.ProjectAssetService.openAssetChooser(params).then(
+      (data: any) => { this.assetSelected(data) }
+    );
+  }
+
+  assetSelected({ nodeId, componentId, assetItem, target, targetObject }) {
+    const fileName = assetItem.fileName;
+    const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
+    if (target === 'rubric') {
+      this.UtilService.insertFileInSummernoteEditor(
+        `summernoteRubric_${this.nodeId}_${this.componentId}`,
+        fullFilePath,
+        fileName
+      );
+    } else if (target === 'choice') {
+      targetObject.value = '<img src="' + fileName + '"/>';
+      this.authoringViewComponentChanged();
+    } else if (target === 'bucket') {
+      targetObject.value = '<img src="' + fileName + '"/>';
+      this.authoringViewComponentChanged();
+    }
+  }
+
 }
 
 export default MatchAuthoringController;

--- a/src/main/webapp/wise5/components/openResponse/openResponseAuthoringController.ts
+++ b/src/main/webapp/wise5/components/openResponse/openResponseAuthoringController.ts
@@ -1,8 +1,10 @@
 'use strict';
 
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
 import OpenResponseController from './openResponseController';
 
 class OpenResponseAuthoringController extends OpenResponseController {
+  ProjectAssetService: ProjectAssetService;
   allowedConnectedComponentTypes: any[];
 
   static $inject = [
@@ -19,6 +21,7 @@ class OpenResponseAuthoringController extends OpenResponseController {
     'NotebookService',
     'NotificationService',
     'OpenResponseService',
+    'ProjectAssetService',
     'ProjectService',
     'StudentAssetService',
     'StudentDataService',
@@ -39,6 +42,7 @@ class OpenResponseAuthoringController extends OpenResponseController {
     NotebookService,
     NotificationService,
     OpenResponseService,
+    ProjectAssetService,
     ProjectService,
     StudentAssetService,
     StudentDataService,
@@ -63,6 +67,7 @@ class OpenResponseAuthoringController extends OpenResponseController {
       StudentDataService,
       UtilService
     );
+    this.ProjectAssetService = ProjectAssetService;
     this.allowedConnectedComponentTypes = [
       {
         type: 'OpenResponse'
@@ -88,24 +93,24 @@ class OpenResponseAuthoringController extends OpenResponseController {
       }.bind(this),
       true
     );
-    this.registerAssetListener();
   }
 
-  registerAssetListener() {
-    this.$scope.$on('assetSelected', (event, { nodeId, componentId, assetItem, target }) => {
-      if (nodeId === this.nodeId && componentId === this.componentId) {
-        const fileName = assetItem.fileName;
-        const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
-        if (target === 'rubric') {
-          this.UtilService.insertFileInSummernoteEditor(
-            `summernoteRubric_${this.nodeId}_${this.componentId}`,
-            fullFilePath,
-            fileName
-          );
-        }
-      }
-      this.$mdDialog.hide();
-    });
+  openAssetChooser(params: any) {
+    this.ProjectAssetService.openAssetChooser(params).then(
+      (data: any) => { this.assetSelected(data) }
+    );
+  }
+
+  assetSelected({ nodeId, componentId, assetItem, target }) {
+    const fileName = assetItem.fileName;
+    const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
+    if (target === 'rubric') {
+      this.UtilService.insertFileInSummernoteEditor(
+        `summernoteRubric_${this.nodeId}_${this.componentId}`,
+        fullFilePath,
+        fileName
+      );
+    }
   }
 
   authoringAddScoringRule() {

--- a/src/main/webapp/wise5/components/outsideURL/outsideURLAuthoringController.ts
+++ b/src/main/webapp/wise5/components/outsideURL/outsideURLAuthoringController.ts
@@ -1,8 +1,10 @@
 'use strict';
 
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
 import OutsideURLController from './outsideURLController';
 
 class OutsideURLAuthoringController extends OutsideURLController {
+  ProjectAssetService: ProjectAssetService;
   isShowOERs: boolean;
   subjects: any[];
   searchText: string;
@@ -21,6 +23,7 @@ class OutsideURLAuthoringController extends OutsideURLController {
     'NodeService',
     'NotebookService',
     'OutsideURLService',
+    'ProjectAssetService',
     'ProjectService',
     'StudentAssetService',
     'StudentDataService',
@@ -39,6 +42,7 @@ class OutsideURLAuthoringController extends OutsideURLController {
     NodeService,
     NotebookService,
     OutsideURLService,
+    ProjectAssetService,
     ProjectService,
     StudentAssetService,
     StudentDataService,
@@ -61,6 +65,7 @@ class OutsideURLAuthoringController extends OutsideURLController {
       StudentDataService,
       UtilService
     );
+    this.ProjectAssetService = ProjectAssetService;
     this.$translate = this.$filter('translate');
     this.isShowOERs = this.componentContent.url === '';
     this.subjects = [
@@ -104,24 +109,24 @@ class OutsideURLAuthoringController extends OutsideURLController {
         a.metadata.title > b.metadata.title ? 1 : -1
       );
     });
-    this.registerAssetListener();
   }
 
-  registerAssetListener() {
-    this.$scope.$on('assetSelected', (event, { nodeId, componentId, assetItem, target }) => {
-      if (nodeId === this.nodeId && componentId === this.componentId) {
-        const fileName = assetItem.fileName;
-        const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
-        if (target === 'rubric') {
-          this.UtilService.insertFileInSummernoteEditor(
-            `summernoteRubric_${this.nodeId}_${this.componentId}`,
-            fullFilePath,
-            fileName
-          );
-        }
-      }
-      this.$mdDialog.hide();
-    });
+  openAssetChooser(params: any) {
+    this.ProjectAssetService.openAssetChooser(params).then(
+      (data: any) => { this.assetSelected(data) }
+    );
+  }
+
+  assetSelected({ nodeId, componentId, assetItem, target }) {
+    const fileName = assetItem.fileName;
+    const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
+    if (target === 'rubric') {
+      this.UtilService.insertFileInSummernoteEditor(
+        `summernoteRubric_${this.nodeId}_${this.componentId}`,
+        fullFilePath,
+        fileName
+      );
+    }
   }
 
   urlInputChanged() {

--- a/src/main/webapp/wise5/components/table/tableAuthoringController.ts
+++ b/src/main/webapp/wise5/components/table/tableAuthoringController.ts
@@ -1,8 +1,12 @@
 'use strict';
 
+import { Project } from '../../../site/src/app/domain/project';
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
 import TableController from './tableController';
 
 class TableAuthoringController extends TableController {
+  ProjectAssetService: ProjectAssetService;
+  
   constructor(
     $anchorScroll,
     $filter,
@@ -15,6 +19,7 @@ class TableAuthoringController extends TableController {
     ConfigService,
     NodeService,
     NotebookService,
+    ProjectAssetService,
     ProjectService,
     StudentAssetService,
     StudentDataService,
@@ -39,6 +44,7 @@ class TableAuthoringController extends TableController {
       TableService,
       UtilService
     );
+    this.ProjectAssetService = ProjectAssetService;
     this.allowedConnectedComponentTypes = [
       {
         type: 'Embedded'
@@ -69,24 +75,24 @@ class TableAuthoringController extends TableController {
       }.bind(this),
       true
     );
-    this.registerAssetListener();
   }
 
-  registerAssetListener() {
-    this.$scope.$on('assetSelected', (event, { nodeId, componentId, assetItem, target }) => {
-      if (nodeId === this.nodeId && componentId === this.componentId) {
-        const fileName = assetItem.fileName;
-        const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
-        if (target === 'rubric') {
-          this.UtilService.insertFileInSummernoteEditor(
-            `summernoteRubric_${this.nodeId}_${this.componentId}`,
-            fullFilePath,
-            fileName
-          );
-        }
-      }
-      this.$mdDialog.hide();
-    });
+  openAssetChooser(params: any) {
+    this.ProjectAssetService.openAssetChooser(params).then(
+      (data: any) => { this.assetSelected(data) }
+    );
+  }
+
+  assetSelected({ nodeId, componentId, assetItem, target }) {
+    const fileName = assetItem.fileName;
+    const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
+    if (target === 'rubric') {
+      this.UtilService.insertFileInSummernoteEditor(
+        `summernoteRubric_${this.nodeId}_${this.componentId}`,
+        fullFilePath,
+        fileName
+      );
+    }
   }
 
   initializeDataExplorerSeriesParams() {
@@ -580,6 +586,7 @@ TableAuthoringController.$inject = [
   'ConfigService',
   'NodeService',
   'NotebookService',
+  'ProjectAssetService',
   'ProjectService',
   'StudentAssetService',
   'StudentDataService',

--- a/src/main/webapp/wise5/services/utilService.ts
+++ b/src/main/webapp/wise5/services/utilService.ts
@@ -303,7 +303,8 @@ export class UtilService {
    * @param tooltip the tooltip text for the custom button
    * @return custom summernote button
    */
-  createInsertAssetButton(projectId, nodeId, componentId, target, tooltip) {
+  createInsertAssetButton(projectId, nodeId, componentId, target, tooltip,
+      openAssetChooserFunction) {
     const thisRootScope = this.upgrade.$injector.get('$rootScope');
     const InsertAssetButton = function(context) {
       const ui = ($ as any).summernote.ui;
@@ -324,7 +325,7 @@ export class UtilService {
             params.componentId = componentId;
           }
           params.target = target;
-          thisRootScope.$broadcast('openAssetChooser', params);
+          openAssetChooserFunction(params);
         }
       });
       return button.render(); // return button as jquery object


### PR DESCRIPTION
Make sure opening the asset chooser and selecting an asset works in all these places in the Authoring Tool
- Authoring Student Notebook Starter Text
- Authoring Teacher Notebook Starter Text
- Authoring Unit Info Unit Icon. Click Edit, then click Upload.
- Authoring advanced Script Filename
- Edit Project Rubric
- Edit Step Rubric
- Edit Component Rubric
- Animation component Objects (Image, Image Moving Left, Image Moving Right)
- Concept Map (Background Image, Nodes)
- Draw (Background Image, Stamps)
- Embedded (Model File Name)
- Graph (Background Image)
- HTML (Insert Asset)
- Label (Background Image)
- Match (Choice Name, Bucket Name)
- Multiple Choice (Choice Text)
- and any other places we use the asset chooser and

Note: I also removed the one line where we broadcast the scrollToComponent event

Closes #2614