### PR TITLE
JS error after wise link/button click

### DIFF
--- a/src/main/webapp/wise5/directives/wiselink/wiselink.js
+++ b/src/main/webapp/wise5/directives/wiselink/wiselink.js
@@ -18,7 +18,9 @@ class WiselinkController {
   }
 
   unsubscribeAll() {
-    this.currentNodeChangedSubscription.unsubscribe();
+    if (this.currentNodeChangedSubscription != null) {
+      this.currentNodeChangedSubscription.unsubscribe();
+    }
   }
 
   $onInit() {


### PR DESCRIPTION
1. Add two WISE links to an HTML component
1. Preview the project and click on one of the links
1. You should not see the console error anymore

This error occurs when there are multiple WISE links on a component. The link that was not clicked would throw the error because it would have a null currentNodeChangedSubscription. I also noticed that the function in the subscribe that calls scrollAndHighlightComponent() doesn't even get called. I'll create another issue for that.

Closes #2628