### PR TITLE
Replace notebook events with observables

### DIFF
--- a/src/main/webapp/wise5/components/conceptMap/conceptMapController.ts
+++ b/src/main/webapp/wise5/components/conceptMap/conceptMapController.ts
@@ -1876,7 +1876,7 @@ class ConceptMapController extends ComponentController {
 
           // get the image object
           const imageObject = thisUtilService.getImageObjectFromBase64String(base64Image);
-          this.NotebookService.addNote($event, imageObject);
+          this.NotebookService.addNote(imageObject);
         };
 
         // set the src of the image so that the image gets loaded

--- a/src/main/webapp/wise5/components/draw/drawController.ts
+++ b/src/main/webapp/wise5/components/draw/drawController.ts
@@ -591,7 +591,7 @@ class DrawController extends ComponentController {
       const canvasBase64Image = canvas.toDataURL('image/png');
       const imageObject = this.UtilService.getImageObjectFromBase64String(canvasBase64Image);
       const noteText = null;
-      this.NotebookService.addNote($event, imageObject, noteText, [studentWorkId]);
+      this.NotebookService.addNote(imageObject, noteText, [studentWorkId]);
     }
   }
 

--- a/src/main/webapp/wise5/components/embedded/embeddedController.ts
+++ b/src/main/webapp/wise5/components/embedded/embeddedController.ts
@@ -424,7 +424,7 @@ class EmbeddedController extends ComponentController {
         html2canvas(modelElement).then(canvas => {
           const base64Image = canvas.toDataURL('image/png');
           const imageObject = this.UtilService.getImageObjectFromBase64String(base64Image);
-          this.NotebookService.addNote($event, imageObject);
+          this.NotebookService.addNote(imageObject);
         });
       }
     }

--- a/src/main/webapp/wise5/components/graph/graphController.ts
+++ b/src/main/webapp/wise5/components/graph/graphController.ts
@@ -2700,7 +2700,7 @@ class GraphController extends ComponentController {
       renderCallback: () => {
         const base64Image = hiddenCanvas.toDataURL('image/png');
         const imageObject = this.UtilService.getImageObjectFromBase64String(base64Image);
-        this.NotebookService.addNote($event, imageObject);
+        this.NotebookService.addNote(imageObject);
       }
     });
   }

--- a/src/main/webapp/wise5/components/label/labelController.ts
+++ b/src/main/webapp/wise5/components/label/labelController.ts
@@ -1516,7 +1516,7 @@ class LabelController extends ComponentController {
       const imageObject = this.UtilService.getImageObjectFromBase64String(img_b64);
 
       // create a notebook item with the image populated into it
-      this.NotebookService.addNote($event, imageObject);
+      this.NotebookService.addNote(imageObject);
     }
   }
 

--- a/src/main/webapp/wise5/components/match/matchController.ts
+++ b/src/main/webapp/wise5/components/match/matchController.ts
@@ -23,6 +23,7 @@ class MatchController extends ComponentController {
   sourceBucket: any;
   privateNotebookItems: any[];
   autoScroll: any;
+  notebookUpdatedSubscription: any;
 
   static $inject = [
     '$filter',
@@ -106,7 +107,8 @@ class MatchController extends ComponentController {
         this.privateNotebookItems = allPrivateNotebookItems.filter(note => { 
           return note.serverDeleteTime == null
         });
-        this.$rootScope.$on('notebookUpdated', (event, args) => {
+        this.notebookUpdatedSubscription = this.NotebookService.notebookUpdated$
+            .subscribe((args) => {
           if (args.notebookItem.type === 'note') {
             this.addNotebookItemToSourceBucket(args.notebookItem);
           }
@@ -202,6 +204,20 @@ class MatchController extends ComponentController {
       nodeId: this.nodeId,
       componentId: this.componentId
     });
+
+    this.$scope.$on('$destroy', () => {
+      this.ngOnDestroy();
+    });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribeAll();
+  }
+
+  unsubscribeAll() {
+    if (this.notebookUpdatedSubscription != null) {
+      this.notebookUpdatedSubscription.unsubscribe();
+    }
   }
 
   addNotebookItemToSourceBucket(notebookItem) {

--- a/src/main/webapp/wise5/components/openResponse/openResponseController.ts
+++ b/src/main/webapp/wise5/components/openResponse/openResponseController.ts
@@ -873,7 +873,6 @@ class OpenResponseController extends ComponentController {
           const isEditTextEnabled = false;
           const isFileUploadEnabled = false;
           this.NotebookService.addNote(
-            $event,
             imageObject,
             noteText,
             [componentState.id],
@@ -894,7 +893,6 @@ class OpenResponseController extends ComponentController {
       const isEditTextEnabled = false;
       const isFileUploadEnabled = false;
       this.NotebookService.addNote(
-        $event,
         imageObject,
         noteText,
         [studentWork.id],

--- a/src/main/webapp/wise5/components/table/tableController.ts
+++ b/src/main/webapp/wise5/components/table/tableController.ts
@@ -1086,7 +1086,7 @@ class TableController extends ComponentController {
         const imageObject = this.UtilService.getImageObjectFromBase64String(img_b64);
 
         // create a notebook item with the image populated into it
-        this.NotebookService.addNote($event, imageObject);
+        this.NotebookService.addNote(imageObject);
       });
     }
   }

--- a/src/main/webapp/wise5/directives/component/component.js
+++ b/src/main/webapp/wise5/directives/component/component.js
@@ -36,7 +36,7 @@ class ComponentController {
                 if (imageObject != null) {
 
                     // create a notebook item with the image populated into it
-                    this.NotebookService.addNote($eventArgs, imageObject);
+                    this.NotebookService.addNote(imageObject);
                 }
             }
         });

--- a/src/main/webapp/wise5/services/studentDataService.ts
+++ b/src/main/webapp/wise5/services/studentDataService.ts
@@ -84,6 +84,8 @@ export class StudentDataService extends DataService {
 
   $q: any;
   $translate: any;
+  private notebookItemAnnotationReceivedSource: Subject<boolean> = new Subject<boolean>();
+  public notebookItemAnnotationReceived$ = this.notebookItemAnnotationReceivedSource.asObservable();
   private pauseScreenSource: Subject<boolean> = new Subject<boolean>();
   public pauseScreen$ = this.pauseScreenSource.asObservable();
   private componentStudentDataSource: Subject<any> = new Subject<any>();
@@ -777,10 +779,14 @@ export class StudentDataService extends DataService {
   handleAnnotationReceived(annotation) {
     this.studentData.annotations.push(annotation);
     if (annotation.notebookItemId) {
-      this.upgrade.$injector.get('$rootScope').$broadcast('notebookItemAnnotationReceived', { annotation: annotation });
+      this.broadcastNotebookItemAnnotationReceived({ annotation: annotation });
     } else {
       this.upgrade.$injector.get('$rootScope').$broadcast('annotationReceived', { annotation: annotation });
     }
+  }
+
+  broadcastNotebookItemAnnotationReceived(args: any) {
+    this.notebookItemAnnotationReceivedSource.next(args);
   }
 
   saveComponentEvent(component, category, event, data) {

--- a/src/main/webapp/wise5/themes/default/notebook/notebook/notebook.js
+++ b/src/main/webapp/wise5/themes/default/notebook/notebook/notebook.js
@@ -45,32 +45,7 @@ class NotebookController {
     this.insertContent = null;
     this.requester = null;
 
-    this.$scope.$on('notebookUpdated', (event, args) => {
-      this.notebook = angular.copy(args.notebook);
-    });
-
-    this.$scope.$on('openNotebook', (event, args) => {
-      this.open('note', event);
-      this.setInsertMode(args.insertMode, args.requester);
-    });
-
-    this.$scope.$on('closeNotebook', (event, args) => {
-      this.closeNotes(event);
-    });
-
-    this.$scope.$on('editNote', (event, args) => {
-      const note = args.note;
-      const isEditMode = args.isEditMode;
-      const file = null;
-      const noteText = null;
-      const isEditTextEnabled = true;
-      const isFileUploadEnabled = true;
-      const studentWorkIds = null;
-      const ev = args.ev;
-      this.showEditNoteDialog(note, isEditMode, file, noteText, isEditTextEnabled, isFileUploadEnabled, studentWorkIds, ev);
-    });
-
-    this.$scope.$on('addNote', (event, args) => {
+    this.addNoteSubscription = this.NotebookService.addNote$.subscribe((args) => {
       const note = null;
       const isEditMode = true;
       const file = args.file;
@@ -79,18 +54,34 @@ class NotebookController {
       const isFileUploadEnabled = args.isFileUploadEnabled;
       const studentWorkIds = args.studentWorkIds;
       const ev = args.ev;
-      this.showEditNoteDialog(note, isEditMode, file, noteText, isEditTextEnabled, isFileUploadEnabled, studentWorkIds, ev);
+      this.showEditNoteDialog(note, isEditMode, file, noteText, isEditTextEnabled,
+          isFileUploadEnabled, studentWorkIds, ev);
     });
 
-    this.$scope.$on('copyNote', (event, args) => {
-      const itemId = args.itemId;
+    this.closeNotebookSubscription = this.NotebookService.closeNotebook$.subscribe(() => {
+      this.closeNotes();
+    });
+
+    this.editNoteSubscription = this.NotebookService.editNote$.subscribe((args) => {
+      const note = args.note;
+      const isEditMode = args.isEditMode;
+      const file = null;
+      const noteText = null;
+      const isEditTextEnabled = true;
+      const isFileUploadEnabled = true;
+      const studentWorkIds = null;
       const ev = args.ev;
-      this.showCopyNoteConfirmDialog(itemId, ev);
+      this.showEditNoteDialog(note, isEditMode, file, noteText, isEditTextEnabled,
+          isFileUploadEnabled, studentWorkIds, ev);
     });
 
-    this.logOutListener = $scope.$on('logOut', (event, args) => {
-      this.logOutListener();
-      this.$rootScope.$broadcast('componentDoneUnloading');
+    this.notebookUpdatedSubscription = this.NotebookService.notebookUpdated$.subscribe((args) => {
+      this.notebook = angular.copy(args.notebook);
+    });
+
+    this.openNotebookSubscription = this.NotebookService.openNotebook$.subscribe((args) => {
+      this.open('note');
+      this.setInsertMode(args.insertMode, args.requester);
     });
 
     this.notebook = this.NotebookService.getNotebookByWorkgroup(this.workgroupId);
@@ -98,6 +89,22 @@ class NotebookController {
 
     // assume only 1 report for now
     this.reportId = this.config.itemTypes.report.notes[0].reportId;
+
+    this.$scope.$on('$destroy', () => {
+      this.ngOnDestroy();
+    });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribeAll();
+  }
+
+  unsubscribeAll() {
+    this.addNoteSubscription.unsubscribe();
+    this.closeNotebookSubscription.unsubscribe();
+    this.editNoteSubscription.unsubscribe();
+    this.notebookUpdatedSubscription.unsubscribe();
+    this.openNotebookSubscription.unsubscribe();
   }
 
   isStudentNotebook() {
@@ -111,11 +118,11 @@ class NotebookController {
     alert(this.$translate('deleteStudentAssetFromNotebookNotImplementedYet'));
   }
 
-  showEditNoteDialog(note, isEditMode, file, text, isEditTextEnabled, isFileUploadEnabled, studentWorkIds, ev) {
+  showEditNoteDialog(note, isEditMode, file, text, isEditTextEnabled, isFileUploadEnabled,
+      studentWorkIds) {
     const notebookItemTemplate = this.themePath + '/notebook/editNotebookItem.html';
     this.$mdDialog.show({
       parent: angular.element(document.body),
-      targetEvent: ev,
       templateUrl: notebookItemTemplate,
       controller: EditNotebookItemController,
       controllerAs: 'editNotebookItemController',
@@ -155,23 +162,23 @@ class NotebookController {
     return notes;
   }
 
-  open(value, event) {
+  open(value) {
     if (value === 'report') {
       this.reportVisible = !this.reportVisible;
     } else if (value === 'note') {
       if (this.notesVisible) {
-        this.closeNotes(event);
+        this.closeNotes();
       } else {
         this.NotebookService.retrievePublicNotebookItems('public').then(() => {
           this.notesVisible = true;
         });
       }
     } else if (value === 'new') {
-      this.NotebookService.addNote(event);
+      this.NotebookService.addNote();
     }
   }
 
-  closeNotes($event) {
+  closeNotes() {
     this.notesVisible = false;
     this.insertMode = false;
   }
@@ -190,7 +197,9 @@ class NotebookController {
     if (this.requester === 'report') {
       this.insertContent = angular.copy(notebookItem);
     } else {
-      this.$rootScope.$broadcast('notebookItemChosen', { requester: this.requester, notebookItem: notebookItem });
+      this.NotebookService.broadcastNotebookItemChosen(
+        { requester: this.requester, notebookItem: notebookItem }
+      );
     }
   }
 }

--- a/src/main/webapp/wise5/themes/default/notebook/notebookItem/notebookItem.js
+++ b/src/main/webapp/wise5/themes/default/notebook/notebookItem/notebookItem.js
@@ -24,6 +24,17 @@ class NotebookItemController {
     this.StudentDataService = StudentDataService;
     this.UtilService = UtilService;
     this.$translate = this.$filter('translate');
+    this.$scope.$on('$destroy', () => {
+      this.ngOnDestroy();
+    });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribeAll();
+  }
+
+  unsubscribeAll() {
+    this.notebookUpdatedSubscription.unsubscribe();
   }
 
   $onInit() {
@@ -36,7 +47,7 @@ class NotebookItemController {
       this.color = this.label.color;
     }
 
-    this.$rootScope.$on('notebookUpdated', (event, args) => {
+    this.notebookUpdatedSubscription = this.NotebookService.notebookUpdated$.subscribe((args) => {
       const notebook = args.notebook;
       if (notebook.items[this.itemId]) {
         this.item = notebook.items[this.itemId].last();

--- a/src/main/webapp/wise5/themes/default/notebook/notebookReport/notebookReport.js
+++ b/src/main/webapp/wise5/themes/default/notebook/notebookReport/notebookReport.js
@@ -124,12 +124,12 @@ class NotebookReportController {
      * Captures the annotation received event, checks whether the given
      * annotation id matches this report id, updates UI accordingly
      */
-    this.$scope.$on('notebookItemAnnotationReceived', (event, args) => {
-      const annotation = args.annotation;
+    this.notebookItemAnnotationReceivedSubscription = 
+        this.NotebookService.notebookItemAnnotationReceived$.subscribe(({ annotation }) => {
       if (annotation.localNotebookItemId === this.reportId) {
         this.hasNewAnnotation = true;
-        this.latestAnnotations =
-            this.AnnotationService.getLatestNotebookItemAnnotations(this.workgroupId, this.reportId);
+        this.latestAnnotations = this.AnnotationService.getLatestNotebookItemAnnotations(
+            this.workgroupId, this.reportId);
       }
     });
 
@@ -137,7 +137,8 @@ class NotebookReportController {
      * Captures the show report annotations event, opens report (if collapsed)
      * and scrolls to the report annotations display
      */
-    this.$scope.$on('showReportAnnotations', (args) => {
+    this.showReportAnnotationsSubscription =
+        this.NotebookService.showReportAnnotations$.subscribe(() => {
       if (this.collapsed) {
         this.collapse();
       }

--- a/src/main/webapp/wise5/vle/vleController.ts
+++ b/src/main/webapp/wise5/vle/vleController.ts
@@ -497,7 +497,7 @@ class VLEController {
     } else if (notebookItemId != null) {
       // assume notification with notebookItemId is for the report for now,
       // as we don't currently support annotations on notes
-      this.$rootScope.$broadcast('showReportAnnotations', { ev: event });
+      this.NotebookService.broadcastShowReportAnnotations();
     }
   }
 


### PR DESCRIPTION
Make sure notebook functions still work, particularly the ones associated with the events below. I think some of these might not actually be used at the moment such as notebookItemAnnotationReceived and showReportAnnotations so there isn't anything to test for those right now.

addNote
closeNotebook
editNote
notebookItemAnnotationReceived
notebookItemChosen
notebookUpdated
openNotebook
publicNotebookItemsRetrieved
showReportAnnotations

Closes #2635