### PR TITLE
Replace siblingComponentStudentDataChanged event with an observable

### DIFF
--- a/src/main/webapp/wise5/components/embedded/embeddedController.ts
+++ b/src/main/webapp/wise5/components/embedded/embeddedController.ts
@@ -22,6 +22,7 @@ class EmbeddedController extends ComponentController {
   height: string;
   messageEventListener: any;
   studentData: any;
+  siblingComponentStudentDataChangedSubscription: any;
 
   static $inject = [
     '$filter',
@@ -128,10 +129,11 @@ class EmbeddedController extends ComponentController {
     this.initializeScopeGetComponentState(this.$scope, 'embeddedController');
 
     /*
-     * Listen for the siblingComponentStudentDataChanged event which occurs
-     * when the student data has changed for another component in this step.
+     * Watch for siblingComponentStudentDataChanged which occurs when the student data has changed
+     * for another component in this step.
      */
-    this.$scope.$on('siblingComponentStudentDataChanged', (event, args) => {
+    this.siblingComponentStudentDataChangedSubscription = 
+        this.NodeService.siblingComponentStudentDataChanged$.subscribe((args: any) => {
       if (this.isEventTargetThisComponent(args)) {
         const message = {
           messageType: 'siblingComponentStudentDataChanged',
@@ -143,6 +145,18 @@ class EmbeddedController extends ComponentController {
 
     this.initializeMessageEventListener();
     this.broadcastDoneRenderingComponent();
+
+    this.$scope.$on('$destroy', () => {
+      this.ngOnDestroy();
+    });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribeAll();
+  }
+
+  unsubscribeAll() {
+    this.siblingComponentStudentDataChangedSubscription.unsubscribe();
   }
 
   setWidthAndHeight(width, height) {

--- a/src/main/webapp/wise5/services/nodeService.ts
+++ b/src/main/webapp/wise5/services/nodeService.ts
@@ -7,6 +7,7 @@ import { ProjectService } from './projectService';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { ChooseBranchPathDialogComponent } from '../../site/src/app/preview/modules/choose-branch-path-dialog/choose-branch-path-dialog.component';
 import { DataService } from '../../site/src/app/services/data.service';
+import { Observable, Subject } from 'rxjs';
 
 @Injectable()
 export class NodeService {
@@ -14,6 +15,9 @@ export class NodeService {
   $translate: any;
   transitionResults = {};
   chooseTransitionPromises = {};
+  private siblingComponentStudentDataChangedSource: Subject<any> = new Subject<any>();
+  public siblingComponentStudentDataChanged$: Observable<any> =
+      this.siblingComponentStudentDataChangedSource.asObservable();
 
   constructor(
     private upgrade: UpgradeModule,
@@ -785,5 +789,9 @@ export class NodeService {
       clickOutsideToClose: true,
       escapeToClose: true
     });
+  }
+
+  broadcastSiblingComponentStudentDataChanged(args: any) {
+    this.siblingComponentStudentDataChangedSource.next(args);
   }
 }

--- a/src/main/webapp/wise5/vle/node/nodeController.ts
+++ b/src/main/webapp/wise5/vle/node/nodeController.ts
@@ -227,7 +227,7 @@ class NodeController {
         }
       }
       this.notifyConnectedParts(componentId, componentState);
-      this.$scope.$broadcast('siblingComponentStudentDataChanged', componentStudentData);
+      this.NodeService.broadcastSiblingComponentStudentDataChanged(componentStudentData);
     });
 
     this.$scope.$on('$destroy', () => {


### PR DESCRIPTION
Make sure the the siblingComponentStudentDataChanged functionality still works. You can test it with the [Thermodynamics Challenge](https://wise.berkeley.edu/preview/unit/32121/node81) unit.

Closes #2637