### PR TITLE
DrawAuthoringController now extends ComponentAuthoringController

### DIFF
--- a/src/main/webapp/wise5/components/componentAuthoringController.ts
+++ b/src/main/webapp/wise5/components/componentAuthoringController.ts
@@ -5,6 +5,7 @@ import { TeacherProjectService } from "../services/teacherProjectService";
 import { ProjectAssetService } from '../../site/src/app/services/projectAssetService';
 import { NodeService } from '../services/nodeService';
 import { NotificationService } from '../services/notificationService';
+import { Subscription } from 'rxjs';
 
 export abstract class ComponentAuthoringController {
 
@@ -30,6 +31,7 @@ export abstract class ComponentAuthoringController {
   summernoteRubricId: string;
   summernoteRubricHTML: string;
   summernoteRubricOptions: any;
+  starterStateResponseSubscription: Subscription;
 
   constructor(
       protected $scope: any,
@@ -95,6 +97,16 @@ export abstract class ComponentAuthoringController {
           .showAdvancedComponentAuthoring[this.componentId];
       this.NotificationService.hideJSONValidMessage();
     }, true);
+    this.starterStateResponseSubscription =
+        this.NodeService.starterStateResponse$.subscribe((args: any) => {
+      if (this.isForThisComponent(args)) {
+        this.saveStarterState(args.starterState);
+      }
+    });
+  }
+
+  $onDestroy() {
+    this.starterStateResponseSubscription.unsubscribe();
   }
 
   handleAuthoringComponentContentChanged(newValue, oldValue): void {
@@ -319,4 +331,10 @@ export abstract class ComponentAuthoringController {
   getComponentsByNodeId(nodeId) {
     return this.ProjectService.getComponentsByNodeId(nodeId);
   }
+
+  isForThisComponent(object) {
+    return this.nodeId == object.nodeId && this.componentId == object.componentId;
+  }
+
+  saveStarterState(starterState: any) {}
 }

--- a/src/main/webapp/wise5/components/componentController.ts
+++ b/src/main/webapp/wise5/components/componentController.ts
@@ -73,6 +73,7 @@ class ComponentController {
   audioRecordedSubscription: Subscription;
   notebookItemChosenSubscription: Subscription;
   studentWorkSavedToServerSubscription: Subscription;
+  starterStateRequestSubscription: Subscription;
 
   constructor(
       $filter,
@@ -190,6 +191,15 @@ class ComponentController {
     this.registerComponentWithParentNode();
   }
 
+  $onInit() {
+    this.starterStateRequestSubscription =
+        this.NodeService.starterStateRequest$.subscribe((args: any) => {
+      if (this.isForThisComponent(args)) {
+        this.generateStarterState();
+      }
+    });
+  }
+
   isStudentMode() {
     return this.mode === 'student';
   }
@@ -208,6 +218,10 @@ class ComponentController {
 
   isOnlyShowWorkMode() {
     return this.mode === 'onlyShowWork';
+  }
+
+  isAuthoringComponentPreviewMode() {
+    return this.mode === 'authoringComponentPreview';
   }
 
   isSaveOrSubmitButtonVisible() {
@@ -249,6 +263,7 @@ class ComponentController {
     if (this.notebookItemChosenSubscription != null) {
       this.notebookItemChosenSubscription.unsubscribe();
     }
+    this.starterStateRequestSubscription.unsubscribe();
   }
 
   initializeScopeGetComponentState(scope, childControllerName) {
@@ -1388,6 +1403,7 @@ class ComponentController {
     return deferred.promise;
   }
 
+  generateStarterState() {}
 }
 
 export default ComponentController;

--- a/src/main/webapp/wise5/components/draw/authoring.html
+++ b/src/main/webapp/wise5/components/draw/authoring.html
@@ -473,8 +473,8 @@
       </md-button>
     </div>
   </div>
-  <div ng-style='{"border": "5px solid black", "padding": "20px"}'>
-    <div>
+  <div ng-style='{"border": "5px solid black"}'>
+    <div ng-style='{"padding-top": "20px", "padding-left": "20px"}'>
       <h5>{{ ::'studentPreview' | translate }}</h5>
     </div>
     <component component-content='drawController.componentContent'
@@ -482,3 +482,4 @@
         mode='authoringComponentPreview'></component>
   </div>
 </div>
+  

--- a/src/main/webapp/wise5/components/draw/authoring.html
+++ b/src/main/webapp/wise5/components/draw/authoring.html
@@ -90,7 +90,7 @@
             {{ ::'CONNECTED_COMPONENTS' | translate }}
           </label>
           <md-button class='topButton md-raised md-primary'
-                     ng-click='drawController.authoringAddConnectedComponent()'>
+                     ng-click='drawController.addConnectedComponent()'>
             <md-icon>add</md-icon>
             <md-tooltip md-direction='top'
                         class='projectButtonTooltip'>
@@ -105,7 +105,7 @@
             <md-input-container style='margin-right: 20; width: 300;'>
               <label>{{ ::'step' | translate }}</label>
               <md-select ng-model='connectedComponent.nodeId'
-                         ng-change='drawController.authoringConnectedComponentNodeIdChanged(connectedComponent)'
+                         ng-change='drawController.connectedComponentNodeIdChanged(connectedComponent)'
                          style='width: 300'>
                 <md-option ng-repeat='item in drawController.idToOrder | toArray | orderBy : "order"'
                            value='{{item.$key}}'
@@ -117,7 +117,7 @@
             <md-input-container style='margin-right: 20; width: 300;'>
               <label>{{ ::'component' | translate }}</label>
               <md-select ng-model='connectedComponent.componentId'
-                         ng-change='drawController.authoringConnectedComponentComponentIdChanged(connectedComponent)'
+                         ng-change='drawController.connectedComponentComponentIdChanged(connectedComponent)'
                          style='width: 300'>
                 <md-option ng-repeat='(componentIndex, component) in drawController.getComponentsByNodeId(connectedComponent.nodeId)'
                            value='{{component.id}}'
@@ -132,7 +132,7 @@
             <md-input-container style='margin-right: 20; width: 200;'>
               <label>{{ ::'type' | translate }}</label>
               <md-select ng-model='connectedComponent.type'
-                         ng-change='drawController.authoringConnectedComponentTypeChanged(connectedComponent)'
+                         ng-change='drawController.connectedComponentTypeChanged(connectedComponent)'
                          style='width: 200'>
                 <md-option value='importWork'>
                   {{ ::'importWork' | translate }}
@@ -145,7 +145,7 @@
             <span flex></span>
             <md-input-container style='margin-left: 20;'>
               <md-button class='topButton md-raised md-primary'
-                         ng-click='drawController.authoringDeleteConnectedComponent($index)'>
+                         ng-click='drawController.deleteConnectedComponent($index)'>
                 <md-icon>delete</md-icon>
                 <md-tooltip md-direction='top'
                             class='projectButtonTooltip'>
@@ -153,11 +153,11 @@
                 </md-tooltip>
               </md-button>
             </md-input-container>
-            <div ng-if='drawController.authoringGetConnectedComponentType(connectedComponent) == "ConceptMap" || drawController.authoringGetConnectedComponentType(connectedComponent) == "Embedded" || drawController.authoringGetConnectedComponentType(connectedComponent) == "Graph" || drawController.authoringGetConnectedComponentType(connectedComponent) == "Label" || drawController.authoringGetConnectedComponentType(connectedComponent) == "Table"' flex>
+            <div ng-if='drawController.getConnectedComponentType(connectedComponent) == "ConceptMap" || drawController.getConnectedComponentType(connectedComponent) == "Embedded" || drawController.getConnectedComponentType(connectedComponent) == "Graph" || drawController.getConnectedComponentType(connectedComponent) == "Label" || drawController.getConnectedComponentType(connectedComponent) == "Table"' flex>
               <md-input-container style='margin-right: 20;'>
                 <md-checkbox class='md-primary'
                              ng-model='connectedComponent.importWorkAsBackground'
-                             ng-change='drawController.authoringImportWorkAsBackgroundClicked(connectedComponent)'
+                             ng-change='drawController.importWorkAsBackgroundClicked(connectedComponent)'
                              ng-disabled='true'>
                   {{ ::'importWorkAsBackground' | translate }}
                 </md-checkbox>
@@ -256,7 +256,7 @@
           <label>{{ ::'BACKGROUND_IMAGE' | translate }} ({{ ::'OPTIONAL' | translate }})</label>
           <input size='100'
                  ng-model='drawController.authoringComponentContent.background'
-                 ng-change='drawController.authoringViewBackgroundChanged()'/>
+                 ng-change='drawController.backgroundChanged()'/>
         </md-input-container>
         <md-button class='topButton md-raised md-primary'
                    ng-click='drawController.chooseBackgroundImage()'>
@@ -273,19 +273,19 @@
           <input type='number'
                  style='width: 200'
                  ng-model='drawController.authoringComponentContent.width'
-                 ng-change='drawController.authoringViewWidthChanged()'/>
+                 ng-change='drawController.viewWidthChanged()'/>
         </md-input-container>
         <md-input-container>
           <label>{{ ::'draw.canvasHeight' | translate }} ({{ ::'OPTIONAL' | translate }})</label>
           <input type='number'
                  style='width: 200'
                  ng-model='drawController.authoringComponentContent.height'
-                 ng-change='drawController.authoringViewHeightChanged()'/>
+                 ng-change='drawController.viewHeightChanged()'/>
         </md-input-container>
       </div>
       <br/>
       <md-button class='topButton md-raised md-primary'
-                 ng-click='drawController.authoringEnableAllToolsButtonClicked()'>
+                 ng-click='drawController.enableAllToolsButtonClicked()'>
         <md-icon>check</md-icon>
         <md-tooltip md-direction='top'
                     class='projectButtonTooltip'>
@@ -293,7 +293,7 @@
         </md-tooltip>
       </md-button>
       <md-button class='topButton md-raised md-primary'
-                 ng-click='drawController.authoringDisableAllToolsButtonClicked()'>
+                 ng-click='drawController.disableAllToolsButtonClicked()'>
         <md-icon>check_box_outline_blank</md-icon>
         <md-tooltip md-direction='top'
                     class='projectButtonTooltip'>
@@ -305,94 +305,94 @@
         <div class='toolsDiv'>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.select'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.selectTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.line'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.lineTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.shape'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.shapeTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.freeHand'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.freeHandTool' | translate }}
           </md-checkbox>
         </div>
         <div class='toolsDiv'>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.text'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.textTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.stamp'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.stampTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.clone'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.cloneTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.strokeColor'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.strokeColorTool' | translate }}
           </md-checkbox>
         </div>
         <div class='toolsDiv'>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.fillColor'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.fillColorTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.strokeWidth'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.strokeWidthTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.sendBack'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.sendBackTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.sendForward'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.sendForwardTool' | translate }}
           </md-checkbox>
         </div>
         <div class='toolsDiv'>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.undo'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.undoTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.redo'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.redoTool' | translate }}
           </md-checkbox>
           <br/>
           <md-checkbox class='md-primary'
                        ng-model='drawController.authoringComponentContent.tools.delete'
-                       ng-change='drawController.authoringViewToolClicked()'>
+                       ng-change='drawController.toolClicked()'>
             {{ ::'draw.deleteTool' | translate }}
           </md-checkbox>
         </div>
@@ -421,7 +421,7 @@
             </md-tooltip>
           </md-button>
           <md-button class='topButton md-raised md-primary'
-                     ng-click='drawController.authoringMoveStampUp($index)'>
+                     ng-click='drawController.moveStampUp($index)'>
             <md-icon>arrow_upward</md-icon>
             <md-tooltip md-direction='top'
                         class='projectButtonTooltip'>
@@ -429,7 +429,7 @@
             </md-tooltip>
           </md-button>
           <md-button class='topButton md-raised md-primary'
-                     ng-click='drawController.authoringMoveStampDown($index)'>
+                     ng-click='drawController.moveStampDown($index)'>
             <md-icon>arrow_downward</md-icon>
             <md-tooltip md-direction='top'
                         class='projectButtonTooltip'>
@@ -437,7 +437,7 @@
             </md-tooltip>
           </md-button>
           <md-button class='topButton md-raised md-primary'
-                     ng-click='drawController.authoringDeleteStampClicked($index)'>
+                     ng-click='drawController.deleteStampClicked($index)'>
             <md-icon>delete</md-icon>
             <md-tooltip md-direction='top'
                         class='projectButtonTooltip'>
@@ -447,7 +447,7 @@
         </div>
         <br/>
         <md-button class='topButton md-raised md-primary'
-                   ng-click='drawController.authoringAddStampButtonClicked()'>
+                   ng-click='drawController.addStampButtonClicked()'>
           <md-icon>library_add</md-icon>
           <md-tooltip md-direction='top'
                       class='projectButtonTooltip'>
@@ -456,7 +456,7 @@
         </md-button>
       </div>
       <md-button class='topButton md-raised md-primary'
-                 ng-click='drawController.authoringSaveStarterDrawData()'>
+                 ng-click='drawController.saveStarterDrawData()'>
         <md-icon>create</md-icon>
         <md-tooltip md-direction='top'
                     class='projectButtonTooltip'>
@@ -464,7 +464,7 @@
         </md-tooltip>
       </md-button>
       <md-button class='topButton md-raised md-primary'
-                 ng-click='drawController.authoringDeleteStarterDrawData()'>
+                 ng-click='drawController.deleteStarterDrawData()'>
         <md-icon>delete_sweep</md-icon>
         <md-tooltip md-direction='top'
                     class='projectButtonTooltip'>
@@ -477,72 +477,8 @@
     <div>
       <h5>{{ ::'studentPreview' | translate }}</h5>
     </div>
-    <div>
-      <div>
-        <div class='component__prompt'>
-          <div class='component__prompt__content'>
-            <compile data='drawController.getPrompt()'></compile>
-          </div>
-        </div>
-        <div class='component__actions'
-             layout='row'>
-          <md-button class='md-accent'
-                     ng-if='drawController.isStudentAttachmentEnabled'
-                     ng-click='nodeController.showStudentAssets($event, component.id, drawController.isDisabled)'>
-            <md-icon>image</md-icon>
-            {{ ::'draw.insertFile' | translate }}
-          </md-button>
-        </div>
-        <md-button class='md-accent'
-                   ng-click='drawController.resetButtonClicked()'
-                   ng-if='drawController.isResetButtonVisible'>
-          <md-icon>restore</md-icon>
-          {{ ::'RESET' | translate }}
-        </md-button>
-        <md-button class='md-accent md-primary'
-                   ng-click='drawController.snipButtonClicked($event)'
-                   ng-if='drawController.isAddToNotebookEnabled()'>
-          <md-icon>note_add</md-icon>
-          {{ ::'ADD_TO_NOTEBOOK' | translate:{label:drawController.notebookConfig.label} }}
-        </md-button>
-        <md-button class='md-accent md-primary'
-                   ng-click='drawController.copyPublicNotebookItemButtonClicked($event)'
-                   ng-if='drawController.showCopyPublicNotebookItemButton()'>
-          <md-icon>file_download</md-icon>
-          {{ ::'importClassmateWork' | translate:{label:drawController.notebookConfig.label} }}
-        </md-button>
-        <div data-drop='true'
-             jqyoui-droppable='{onDrop: "drawController.dropCallback(item, $index)"}'>
-          <div id='{{drawController.drawingToolId}}'></div>
-        </div>
-        <div ng-if='drawController.isSaveButtonVisible || drawController.isSubmitButtonVisible'
-             class='component__actions'
-             layout='row'
-             layout-align='start center'>
-          <md-button class='md-raised md-primary'
-                     ng-click='drawController.saveButtonClicked()'
-                     ng-disabled='drawController.isDisabled || !drawController.isDirty'
-                     ng-if='drawController.isSaveButtonVisible'>
-            {{ ::'SAVE' | translate }}
-          </md-button>
-          <md-button class='md-raised md-primary'
-                     ng-click='drawController.submitButtonClicked()'
-                     ng-disabled='drawController.isDisabled || !drawController.isSubmitDirty || drawController.isSubmitButtonDisabled'
-                     ng-if='drawController.isSubmitButtonVisible'>
-            {{ ::'SUBMIT' | translate }}
-          </md-button>
-          <span ng-if='drawController.saveMessage.text'
-                class='component__actions__info md-caption'>
-              {{drawController.saveMessage.text}}
-              <span class='component__actions__more'>
-                <md-tooltip md-direction='top'>
-                  {{ drawController.saveMessage.time | amDateFormat:'ddd, MMM D YYYY, h:mm a' }}
-                </md-tooltip>
-                <span am-time-ago='drawController.saveMessage.time'></span>
-              </span>
-          </span>
-        </div>
-      </div>
-    </div>
+    <component component-content='drawController.componentContent'
+        node-id='{{drawController.nodeId}}'
+        mode='authoringComponentPreview'></component>
   </div>
 </div>

--- a/src/main/webapp/wise5/components/draw/drawAuthoringController.ts
+++ b/src/main/webapp/wise5/components/draw/drawAuthoringController.ts
@@ -1,100 +1,34 @@
 'use strict';
 
 import * as angular from 'angular';
-import { Subscription } from 'rxjs';
-import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
-import DrawController from './drawController';
+import { ComponentAuthoringController } from '../componentAuthoringController';
 
-class DrawAuthoringController extends DrawController {
-  ProjectAssetService: ProjectAssetService;
-  $timeout: any;
-  allowedConnectedComponentTypes: any[];
-  isResetButtonVisible: boolean;
-  drawingToolId: string;
-  drawingTool: any;
+class DrawAuthoringController extends ComponentAuthoringController {
+  allowedConnectedComponentTypes: any[] = [{ type: 'ConceptMap' }, { type: 'Draw' },
+      { type: 'Embedded' }, { type: 'Graph' }, { type: 'Label' }, { type: 'Table' }];
   width: number;
   height: number;
-  starterStateRequestedSubscription: Subscription;
-  starterStateResponseSubscription: Subscription;
-
-  static $inject = [
-    '$filter',
-    '$injector',
-    '$mdDialog',
-    '$q',
-    '$rootScope',
-    '$scope',
-    '$timeout',
-    'AnnotationService',
-    'AudioRecorderService',
-    'ConfigService',
-    'DrawService',
-    'NodeService',
-    'NotebookService',
-    'NotificationService',
-    'ProjectAssetService',
-    'ProjectService',
-    'StudentAssetService',
-    'StudentDataService',
-    'UtilService'
-  ];
 
   constructor(
     $filter,
-    $injector,
-    $mdDialog,
-    $q,
-    $rootScope,
     $scope,
-    $timeout,
-    AnnotationService,
-    AudioRecorderService,
     ConfigService,
-    DrawService,
     NodeService,
-    NotebookService,
     NotificationService,
     ProjectAssetService,
     ProjectService,
-    StudentAssetService,
-    StudentDataService,
     UtilService
   ) {
     super(
-      $filter,
-      $injector,
-      $mdDialog,
-      $q,
-      $rootScope,
       $scope,
-      $timeout,
-      AnnotationService,
-      AudioRecorderService,
+      $filter,
       ConfigService,
-      DrawService,
       NodeService,
-      NotebookService,
       NotificationService,
+      ProjectAssetService,
       ProjectService,
-      StudentAssetService,
-      StudentDataService,
       UtilService
     );
-
-    this.ProjectAssetService = ProjectAssetService;
-
-    this.allowedConnectedComponentTypes = [
-      { type: 'ConceptMap' },
-      { type: 'Draw' },
-      { type: 'Embedded' },
-      { type: 'Graph' },
-      { type: 'Label' },
-      { type: 'Table' }
-    ];
-
-    this.isResetButtonVisible = true;
-    this.drawingToolId = 'drawingtool_' + this.nodeId + '_' + this.componentId;
-
     $scope.$watch(
       function() {
         return this.authoringComponentContent;
@@ -102,7 +36,6 @@ class DrawAuthoringController extends DrawController {
       function(newValue, oldValue) {
         this.componentContent = this.ProjectService.injectAssetPaths(newValue);
         this.submitCounter = 0;
-        this.initializeDrawingTool();
         this.isSaveButtonVisible = this.componentContent.showSaveButton;
         this.isSubmitButtonVisible = this.componentContent.showSubmitButton;
       }.bind(this),
@@ -110,28 +43,7 @@ class DrawAuthoringController extends DrawController {
     );
   }
 
-  $onInit() {
-    this.starterStateRequestedSubscription =
-        this.NodeService.starterStateRequested$.subscribe((args: any) => {
-      if (this.isForThisComponent(args)) {
-        this.generateStarterState();
-      }
-    });
-    this.starterStateResponseSubscription =
-        this.NodeService.starterStateResponse$.subscribe((args: any) => {
-      if (this.isForThisComponent(args)) {
-        this.saveStarterState(args.starterState);
-      }
-    });
-  }
-
-  unsubscribeAll() {
-    this.starterStateRequestedSubscription.unsubscribe();
-    this.starterStateResponseSubscription.unsubscribe();
-    super.unsubscribeAll();
-  }
-
-  authoringAddStampButtonClicked() {
+  addStampButtonClicked() {
     this.initializeAuthoringComponentContentStampsIfNecessary();
     this.authoringComponentContent.stamps.Stamps.push('');
     this.authoringViewComponentChanged();
@@ -148,11 +60,7 @@ class DrawAuthoringController extends DrawController {
     }
   }
 
-  /**
-   * Move a stamp up in the authoring view
-   * @param index the index of the stamp to move
-   */
-  authoringMoveStampUp(index) {
+  moveStampUp(index) {
     if (index != 0) {
       const stamp = this.authoringComponentContent.stamps.Stamps[index];
       this.authoringComponentContent.stamps.Stamps.splice(index, 1);
@@ -161,11 +69,7 @@ class DrawAuthoringController extends DrawController {
     }
   }
 
-  /**
-   * Move the stamp down in the authoring view
-   * @param index the index of the stamp to move
-   */
-  authoringMoveStampDown(index) {
+  moveStampDown(index) {
     if (index != this.authoringComponentContent.stamps.Stamps.length - 1) {
       const stamp = this.authoringComponentContent.stamps.Stamps[index];
       this.authoringComponentContent.stamps.Stamps.splice(index, 1);
@@ -174,11 +78,7 @@ class DrawAuthoringController extends DrawController {
     }
   }
 
-  /**
-   * Delete a stamp from the authoring view
-   * @param index the index of the stamp
-   */
-  authoringDeleteStampClicked(index) {
+  deleteStampClicked(index) {
     if (
       confirm(
         this.$translate('draw.areYouSureYouWantToDeleteThisStamp') +
@@ -191,7 +91,7 @@ class DrawAuthoringController extends DrawController {
     }
   }
 
-  authoringEnableAllToolsButtonClicked() {
+  enableAllToolsButtonClicked() {
     if (this.authoringComponentContent.tools == null) {
       this.authoringComponentContent.tools = {};
     }
@@ -213,7 +113,7 @@ class DrawAuthoringController extends DrawController {
     this.authoringViewComponentChanged();
   }
 
-  authoringDisableAllToolsButtonClicked() {
+  disableAllToolsButtonClicked() {
     if (this.authoringComponentContent.tools == null) {
       this.authoringComponentContent.tools = {};
     }
@@ -235,15 +135,10 @@ class DrawAuthoringController extends DrawController {
     this.authoringViewComponentChanged();
   }
 
-  authoringSaveStarterDrawData() {
+  saveStarterDrawData() {
     if (confirm(this.$translate('draw.areYouSureYouWantToSaveTheStarterDrawing'))) {
       this.NodeService.requestStarterState({nodeId: this.nodeId, componentId: this.componentId});
     }
-  }
-
-  generateStarterState() {
-    this.NodeService.respondStarterState({nodeId: this.nodeId, componentId: this.componentId,
-        starterState: this.getDrawData()});
   }
 
   saveStarterState(starterState) {
@@ -251,19 +146,17 @@ class DrawAuthoringController extends DrawController {
     this.authoringViewComponentChanged();
   }
 
-  authoringDeleteStarterDrawData() {
+  deleteStarterDrawData() {
     if (confirm(this.$translate('draw.areYouSureYouWantToDeleteTheStarterDrawing'))) {
       this.authoringComponentContent.starterDrawData = null;
-      this.drawingTool.clear();
       this.authoringViewComponentChanged();
     }
   }
 
-  authoringViewWidthChanged() {
+  viewWidthChanged() {
     this.width = this.authoringComponentContent.width;
     this.updateStarterDrawDataWidth();
     this.authoringViewComponentChanged();
-    this.authoringInitializeDrawingToolAfterTimeout();
   }
 
   updateStarterDrawDataWidth() {
@@ -278,11 +171,10 @@ class DrawAuthoringController extends DrawController {
     }
   }
 
-  authoringViewHeightChanged() {
+  viewHeightChanged() {
     this.height = this.authoringComponentContent.height;
     this.updateStarterDrawDataHeight();
     this.authoringViewComponentChanged();
-    this.authoringInitializeDrawingToolAfterTimeout();
   }
 
   updateStarterDrawDataHeight() {
@@ -297,9 +189,8 @@ class DrawAuthoringController extends DrawController {
     }
   }
 
-  authoringViewToolClicked() {
+  toolClicked() {
     this.authoringViewComponentChanged();
-    this.authoringInitializeDrawingToolAfterTimeout();
   }
 
   chooseBackgroundImage() {
@@ -329,28 +220,20 @@ class DrawAuthoringController extends DrawController {
     );
   }
 
-  assetSelected(args: any) {
-    const fileName = args.assetItem.fileName;
-    if (args.target === 'rubric') {
-      const summernoteId = this.getSummernoteId(args);
-      this.restoreSummernoteCursorPosition(summernoteId);
-      const fullAssetPath = this.getFullAssetPath(fileName);
-      if (this.UtilService.isImage(fileName)) {
-        this.insertImageIntoSummernote(summernoteId, fullAssetPath, fileName);
-      } else if (this.UtilService.isVideo(fileName)) {
-        this.insertVideoIntoSummernote(summernoteId, fullAssetPath);
-      }
-    } else if (args.target === 'background') {
+  assetSelected({ nodeId, componentId, assetItem, target, targetObject }) {
+    super.assetSelected({ nodeId, componentId, assetItem, target });
+    const fileName = assetItem.fileName;
+    if (target === 'background') {
       this.authoringComponentContent.background = fileName;
-      this.authoringViewBackgroundChanged();
-    } else if (args.target === 'stamp') {
-      const stampIndex = args.targetObject;
+      this.backgroundChanged();
+    } else if (target === 'stamp') {
+      const stampIndex = targetObject;
       this.setStampImage(stampIndex, fileName);
-      this.authoringViewBackgroundChanged();
+      this.backgroundChanged();
     }
   }
 
-  authoringViewBackgroundChanged() {
+  backgroundChanged() {
     this.updateStarterDrawDataBackground();
     this.authoringViewComponentChanged();
   }
@@ -374,27 +257,11 @@ class DrawAuthoringController extends DrawController {
     }
   }
 
-  /**
-   * Set the stamp image
-   * @param index the index of the stamp
-   * @param fileName the file name of the image
-   */
   setStampImage(index, fileName) {
     this.authoringComponentContent.stamps.Stamps[index] = fileName;
   }
 
-  handleConnectedComponentsPostProcess() {
-    if (this.componentContent != null && this.componentContent.background != null) {
-      this.drawingTool.setBackgroundImage(this.componentContent.background);
-    }
-  }
-
-  /**
-   * Automatically set the component id for the connected component if there
-   * is only one viable option.
-   * @param connectedComponent the connected component object we are authoring
-   */
-  authoringAutomaticallySetConnectedComponentComponentIdIfPossible(connectedComponent) {
+  automaticallySetConnectedComponentComponentIdIfPossible(connectedComponent) {
     let numberOfAllowedComponents = 0;
     let allowedComponent = null;
     for (const component of this.getComponentsByNodeId(connectedComponent.nodeId)) {
@@ -409,18 +276,19 @@ class DrawAuthoringController extends DrawController {
     if (numberOfAllowedComponents === 1) {
       connectedComponent.componentId = allowedComponent.id;
       connectedComponent.type = 'importWork';
-      this.authoringSetImportWorkAsBackgroundIfApplicable(connectedComponent);
+      this.setImportWorkAsBackgroundIfApplicable(connectedComponent);
     }
   }
 
-  authoringConnectedComponentComponentIdChanged(connectedComponent) {
+  connectedComponentComponentIdChanged(connectedComponent) {
     connectedComponent.type = 'importWork';
-    this.authoringSetImportWorkAsBackgroundIfApplicable(connectedComponent);
+    this.setImportWorkAsBackgroundIfApplicable(connectedComponent);
     this.authoringViewComponentChanged();
   }
 
-  authoringSetImportWorkAsBackgroundIfApplicable(connectedComponent) {
-    const componentType = this.authoringGetConnectedComponentType(connectedComponent);
+  setImportWorkAsBackgroundIfApplicable(connectedComponent) {
+    const componentType = this.ProjectService.getComponentType(connectedComponent.nodeId,
+        connectedComponent.componentId);
     if (['ConceptMap', 'Embedded', 'Graph', 'Label', 'Table'].includes(componentType)) {
       connectedComponent.importWorkAsBackground = true;
     } else {
@@ -428,15 +296,11 @@ class DrawAuthoringController extends DrawController {
     }
   }
 
-  authoringImportWorkAsBackgroundClicked(connectedComponent) {
+  importWorkAsBackgroundClicked(connectedComponent) {
     if (!connectedComponent.importWorkAsBackground) {
       delete connectedComponent.importWorkAsBackground;
     }
     this.authoringViewComponentChanged();
-  }
-
-  authoringInitializeDrawingToolAfterTimeout() {
-    this.$timeout(angular.bind(this, this.initializeDrawingTool));
   }
 }
 

--- a/src/main/webapp/wise5/components/draw/drawController.ts
+++ b/src/main/webapp/wise5/components/draw/drawController.ts
@@ -106,7 +106,7 @@ class DrawController extends ComponentController {
 
     this.componentType = this.componentContent.type;
 
-    if (this.isStudentMode()) {
+    if (this.isStudentMode() || this.isAuthoringComponentPreviewMode()) {
       this.isSaveButtonVisible = this.componentContent.showSaveButton;
       this.isSubmitButtonVisible = this.componentContent.showSubmitButton;
       this.isResetButtonVisible = true;
@@ -245,7 +245,7 @@ class DrawController extends ComponentController {
           this.drawingTool.setBackgroundImage(this.componentContent.background);
         }
       }
-    } else if (this.isAuthoringMode()) {
+    } else if (this.isAuthoringComponentPreviewMode()) {
       if (this.componentContent.starterDrawData != null) {
         this.drawingTool.load(this.componentContent.starterDrawData);
       }
@@ -684,6 +684,11 @@ class DrawController extends ComponentController {
     this.generateImageFromComponentState(componentState).then(image => {
       this.drawingTool.setBackgroundImage(image.url);
     });
+  }
+
+  generateStarterState() {
+    this.NodeService.respondStarterState({nodeId: this.nodeId, componentId: this.componentId,
+        starterState: this.getDrawData()});
   }
 }
 

--- a/src/main/webapp/wise5/services/nodeService.ts
+++ b/src/main/webapp/wise5/services/nodeService.ts
@@ -25,6 +25,10 @@ export class NodeService {
   private siblingComponentStudentDataChangedSource: Subject<any> = new Subject<any>();
   public siblingComponentStudentDataChanged$: Observable<any> =
       this.siblingComponentStudentDataChangedSource.asObservable();
+  private starterStateRequestedSource: Subject<any> = new Subject<any>();
+  public starterStateRequested$: Observable<any> = this.starterStateRequestedSource.asObservable();
+  private starterStateResponseSource: Subject<any> = new Subject<any>();
+  public starterStateResponse$: Observable<any> = this.starterStateResponseSource.asObservable();
 
   constructor(
     private upgrade: UpgradeModule,
@@ -812,5 +816,13 @@ export class NodeService {
 
   broadcastSiblingComponentStudentDataChanged(args: any) {
     this.siblingComponentStudentDataChangedSource.next(args);
+  }
+
+  requestStarterState(args: any) {
+    this.starterStateRequestedSource.next(args);
+  }
+
+  respondStarterState(args: any) {
+    this.starterStateResponseSource.next(args);
   }
 }

--- a/src/main/webapp/wise5/services/nodeService.ts
+++ b/src/main/webapp/wise5/services/nodeService.ts
@@ -25,8 +25,8 @@ export class NodeService {
   private siblingComponentStudentDataChangedSource: Subject<any> = new Subject<any>();
   public siblingComponentStudentDataChanged$: Observable<any> =
       this.siblingComponentStudentDataChangedSource.asObservable();
-  private starterStateRequestedSource: Subject<any> = new Subject<any>();
-  public starterStateRequested$: Observable<any> = this.starterStateRequestedSource.asObservable();
+  private starterStateRequestSource: Subject<any> = new Subject<any>();
+  public starterStateRequest$: Observable<any> = this.starterStateRequestSource.asObservable();
   private starterStateResponseSource: Subject<any> = new Subject<any>();
   public starterStateResponse$: Observable<any> = this.starterStateResponseSource.asObservable();
 
@@ -819,7 +819,7 @@ export class NodeService {
   }
 
   requestStarterState(args: any) {
-    this.starterStateRequestedSource.next(args);
+    this.starterStateRequestSource.next(args);
   }
 
   respondStarterState(args: any) {

--- a/src/main/webapp/wise5/services/projectService.ts
+++ b/src/main/webapp/wise5/services/projectService.ts
@@ -625,7 +625,7 @@ export class ProjectService {
          */
         return matchedString.replace(
           'img',
-          `img ng-click=\\"this.$ctrl.ProjectService.broadcastSnipImage(` + 
+          `img ng-click=\\"this.$ctrl.ProjectService.broadcastSnipImage(` +
           `{ target: $event.target, componentId: '${componentId}' })\\"`
         );
       });
@@ -4384,6 +4384,11 @@ export class ProjectService {
       this.componentServices[componentServiceName] = componentService;
     }
     return componentService;
+  }
+
+  getComponentType(nodeId: string, componentId: string): string {
+    const component = this.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    return component.type;
   }
 
   /**

--- a/src/main/webapp/wise5/test-unit/components/draw/drawAuthoringController.spec.js
+++ b/src/main/webapp/wise5/test-unit/components/draw/drawAuthoringController.spec.js
@@ -88,7 +88,7 @@ function shouldMoveAStampUp() {
       'oxygen.png'
     );
     spyOn(drawAuthoringController, 'authoringViewComponentChanged').and.callFake(() => {});
-    drawAuthoringController.authoringMoveStampUp(1);
+    drawAuthoringController.moveStampUp(1);
     expect(drawAuthoringController.authoringComponentContent.stamps.Stamps[0]).toEqual(
       'oxygen.png'
     );
@@ -107,7 +107,7 @@ function shouldMoveAStampDown() {
       'oxygen.png'
     );
     spyOn(drawAuthoringController, 'authoringViewComponentChanged').and.callFake(() => {});
-    drawAuthoringController.authoringMoveStampDown(0);
+    drawAuthoringController.moveStampDown(0);
     expect(drawAuthoringController.authoringComponentContent.stamps.Stamps[0]).toEqual(
       'oxygen.png'
     );


### PR DESCRIPTION
Test that draw component authoring works as before. Starter drawing are now sent as events using Observables, which was required to break the dependency between the authoring and viewing controllers.

Specifically:
- saving starter drawing
- connected components with various component types

Closes #2720