### PR TITLE
Fixed issue where step advanced view was not loading

### DIFF
--- a/src/main/webapp/wise5/authoringTool/node/advanced/branch/node-advanced-branch-authoring.component.ts
+++ b/src/main/webapp/wise5/authoringTool/node/advanced/branch/node-advanced-branch-authoring.component.ts
@@ -18,6 +18,9 @@ class NodeAdvancedBranchAuthoringController {
   nodeId: string;
   $translate: any;
 
+  static $inject = ['$filter', 'ConfigService', 'TagService', 'ProjectService',
+      'TeacherDataService', 'UtilService'];
+
   constructor(private $filter: any, private ConfigService: ConfigService,
       private TagService: TagService, private ProjectService: TeacherProjectService,
       private TeacherDataService: TeacherDataService, private UtilService: UtilService) {

--- a/src/main/webapp/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts
+++ b/src/main/webapp/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts
@@ -12,6 +12,8 @@ class NodeAdvancedConstraintAuthoringController {
   removalCriteria: any;
   $translate: any;
 
+  static $inject = ['$filter', '$timeout', 'ProjectService', 'TeacherDataService', 'UtilService'];
+
   constructor(private $filter: any,
       private $timeout: any,
       private ProjectService: TeacherProjectService,

--- a/src/main/webapp/wise5/authoringTool/node/advanced/general/node-advanced-general-authoring.component.ts
+++ b/src/main/webapp/wise5/authoringTool/node/advanced/general/node-advanced-general-authoring.component.ts
@@ -5,6 +5,8 @@ class NodeAdvancedGeneralAuthoringController {
 
   node: any;
 
+  static $inject = ['ProjectService', 'TeacherDataService'];
+
   constructor(private ProjectService: TeacherProjectService,
       private TeacherDataService: TeacherDataService) {
   }

--- a/src/main/webapp/wise5/authoringTool/node/advanced/json/node-advanced-json-authoring.component.ts
+++ b/src/main/webapp/wise5/authoringTool/node/advanced/json/node-advanced-json-authoring.component.ts
@@ -9,6 +9,8 @@ class NodeAdvancedJsonAuthoringController {
   node: any;
   nodeId: string;
 
+  static $inject = ['NotificationService', 'ProjectService', 'TeacherDataService'];
+
   constructor(private NotificationService: NotificationService,
       private ProjectService: TeacherProjectService,
       private TeacherDataService: TeacherDataService) {

--- a/src/main/webapp/wise5/authoringTool/node/advanced/node-advanced-authoring.component.ts
+++ b/src/main/webapp/wise5/authoringTool/node/advanced/node-advanced-authoring.component.ts
@@ -7,8 +7,7 @@ class NodeAdvancedAuthoringController {
   node: any;
   nodeId: string;
 
-  static $injector = ['$filter', '$state', 'ConfigService', 'ProjectService', 'TagService',
-      'UtilService'];
+  static $inject = ['$state', 'ConfigService', 'ProjectService', 'TeacherDataService'];
 
   constructor(private $state: any, private ConfigService: ConfigService,
       private ProjectService: TeacherProjectService,

--- a/src/main/webapp/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts
+++ b/src/main/webapp/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts
@@ -11,6 +11,8 @@ class NodeAdvancedPathAuthoringController {
   transitionCriterias: any;
   $translate: any;
 
+  static $inject = ['$filter', 'ProjectService', 'TeacherDataService'];
+
   constructor(private $filter: any,
       private ProjectService: TeacherProjectService,
       private TeacherDataService: TeacherDataService) {


### PR DESCRIPTION
The issue was the optimization phase of the production build was shortening the variables names, and the $injector could not find the right dependencies. I fixed this by adding $inject to the classes.

Test that node advanced authoring loads.

#2723