### PR TITLE
Re-enable custom unit styles

### DIFF
--- a/src/main/webapp/wise5/themes/default/vle.html
+++ b/src/main/webapp/wise5/themes/default/vle.html
@@ -3,12 +3,12 @@
 <link rel="stylesheet" href="/wise5/lib/hopscotch/dist/css/hopscotch.min.css" />
 <link rel="stylesheet" href="/wise5/themes/default/style/angular-material.css" />
 <link rel="stylesheet" href="/wise5/themes/default/style/vle.css" />
+<style ng-bind-html="::vleController.projectStyle"></style>
 <disable-delete-keypress>
     <listen-for-delete-keypress>
         <div class="app-styles" role="main" layout="column" layout-fill
              ng-controller="ThemeController as themeCtrl" ng-mousemove="themeCtrl.mouseMoved()"
-             ng-class="::{'notebook-enabled': vleController.notebookEnabled}"
-             ng-style="::vleController.projectStyle">
+             ng-class="::{'notebook-enabled': vleController.notebookEnabled}">
             <ng-include src="::vleController.themePath + '/templates/topbar.html'"></ng-include>
             <step-tools show-position="themeCtrl.numberProject"
                         ng-if="themeCtrl.layoutState === 'node'"></step-tools>

--- a/src/main/webapp/wise5/themes/default/vle.html
+++ b/src/main/webapp/wise5/themes/default/vle.html
@@ -7,7 +7,8 @@
     <listen-for-delete-keypress>
         <div class="app-styles" role="main" layout="column" layout-fill
              ng-controller="ThemeController as themeCtrl" ng-mousemove="themeCtrl.mouseMoved()"
-             ng-class="::{'notebook-enabled': vleController.notebookEnabled}">
+             ng-class="::{'notebook-enabled': vleController.notebookEnabled}"
+             ng-style="::vleController.projectStyle">
             <ng-include src="::vleController.themePath + '/templates/topbar.html'"></ng-include>
             <step-tools show-position="themeCtrl.numberProject"
                         ng-if="themeCtrl.layoutState === 'node'"></step-tools>


### PR DESCRIPTION
Re-enabled support for custom unit styles.

To test:
- Add a "style" key and value to a unit's `project.json` file with custom CSS. For example:
```
"style": "p {color: red;}"
```
- Preview the unit and check that your custom styles are applied.

Closes #2727.