### PR TITLE
Fixed server and client timestamp inconsistencies

### DIFF
--- a/src/main/java/org/wise/vle/domain/annotation/wise5/AnnotationSerializer.java
+++ b/src/main/java/org/wise/vle/domain/annotation/wise5/AnnotationSerializer.java
@@ -18,7 +18,7 @@ public class AnnotationSerializer extends JsonSerializer<Annotation> {
       throws IOException {
     gen.writeStartObject();
     gen.writeObjectField("id", annotation.getId());
-    gen.writeObjectField("clientSaveTime", annotation.getClientSaveTime());
+    gen.writeObjectField("clientSaveTime", annotation.getClientSaveTime().getTime());
     gen.writeObjectField("componentId", annotation.getComponentId());
     ObjectMapper objectMapper = new ObjectMapper();
     gen.writeObjectField("data", objectMapper.readTree(annotation.getData()));
@@ -35,7 +35,7 @@ public class AnnotationSerializer extends JsonSerializer<Annotation> {
     }
     gen.writeObjectField("periodId", annotation.getPeriod().getId());
     gen.writeObjectField("runId", annotation.getRun().getId());
-    gen.writeObjectField("serverSaveTime", annotation.getServerSaveTime());
+    gen.writeObjectField("serverSaveTime", annotation.getServerSaveTime().getTime());
     StudentWork studentWork = annotation.getStudentWork();
     if (studentWork != null) {
       gen.writeObjectField("studentWorkId", studentWork.getId());

--- a/src/main/java/org/wise/vle/domain/notification/NotificationSerializer.java
+++ b/src/main/java/org/wise/vle/domain/notification/NotificationSerializer.java
@@ -33,9 +33,11 @@ public class NotificationSerializer extends JsonSerializer<Notification> {
     } else {
       gen.writeObjectField("data", null);
     }
-    gen.writeObjectField("timeGenerated", notification.getTimeGenerated());
-    gen.writeObjectField("serverSaveTime", notification.getServerSaveTime());
-    gen.writeObjectField("timeDismissed", notification.getTimeDismissed());
+    gen.writeObjectField("timeGenerated", notification.getTimeGenerated().getTime());
+    gen.writeObjectField("serverSaveTime", notification.getServerSaveTime().getTime());
+    if (notification.getTimeDismissed() != null) {
+      gen.writeObjectField("timeDismissed", notification.getTimeDismissed().getTime());
+    }
     gen.writeEndObject();
   }
 

--- a/src/main/java/org/wise/vle/domain/work/EventSerializer.java
+++ b/src/main/java/org/wise/vle/domain/work/EventSerializer.java
@@ -21,7 +21,7 @@ public class EventSerializer extends JsonSerializer<Event> {
     gen.writeStartObject();
     gen.writeObjectField("id", event.getId());
     gen.writeObjectField("category", event.getCategory());
-    gen.writeObjectField("clientSaveTime", event.getClientSaveTime());
+    gen.writeObjectField("clientSaveTime", event.getClientSaveTime().getTime());
     gen.writeObjectField("componentId", event.getComponentId());
     gen.writeObjectField("componentType", event.getComponentType());
     gen.writeObjectField("context", event.getContext());
@@ -41,7 +41,7 @@ public class EventSerializer extends JsonSerializer<Event> {
     if (run != null) {
       gen.writeObjectField("runId", run.getId());
     }
-    gen.writeObjectField("serverSaveTime", event.getServerSaveTime());
+    gen.writeObjectField("serverSaveTime", event.getServerSaveTime().getTime());
     Workgroup workgroup = event.getWorkgroup();
     if (workgroup != null) {
       gen.writeObjectField("workgroupId", workgroup.getId());

--- a/src/main/java/org/wise/vle/domain/work/NotebookItemSerializer.java
+++ b/src/main/java/org/wise/vle/domain/work/NotebookItemSerializer.java
@@ -19,10 +19,14 @@ public class NotebookItemSerializer extends JsonSerializer<NotebookItem> {
     gen.writeStringField("type", item.getType());
     gen.writeStringField("localNotebookItemId", item.getLocalNotebookItemId());
     gen.writeStringField("content", item.getContent());
-    gen.writeObjectField("clientSaveTime", item.getClientSaveTime());
-    gen.writeObjectField("serverSaveTime", item.getServerSaveTime());
-    gen.writeObjectField("clientDeleteTime", item.getClientDeleteTime());
-    gen.writeObjectField("serverDeleteTime", item.getServerDeleteTime());
+    gen.writeObjectField("clientSaveTime", item.getClientSaveTime().getTime());
+    gen.writeObjectField("serverSaveTime", item.getServerSaveTime().getTime());
+    if (item.getClientDeleteTime() != null) {
+      gen.writeObjectField("clientDeleteTime", item.getClientDeleteTime().getTime());
+    }
+    if (item.getServerDeleteTime() != null) {
+      gen.writeObjectField("serverDeleteTime", item.getServerDeleteTime().getTime());
+    }
     if (item.getType().equals("note")) {
       addNoteFields(gen, item);
     }

--- a/src/main/java/org/wise/vle/domain/work/StudentWorkSerializer.java
+++ b/src/main/java/org/wise/vle/domain/work/StudentWorkSerializer.java
@@ -14,7 +14,7 @@ public class StudentWorkSerializer extends JsonSerializer<StudentWork> {
       throws IOException {
     gen.writeStartObject();
     gen.writeObjectField("id", studentWork.getId());
-    gen.writeObjectField("clientSaveTime", studentWork.getClientSaveTime());
+    gen.writeObjectField("clientSaveTime", studentWork.getClientSaveTime().getTime());
     gen.writeObjectField("componentId", studentWork.getComponentId());
     gen.writeObjectField("componentType", studentWork.getComponentType());
     gen.writeObjectField("isAutoSave", studentWork.getIsAutoSave());
@@ -22,7 +22,7 @@ public class StudentWorkSerializer extends JsonSerializer<StudentWork> {
     gen.writeObjectField("nodeId", studentWork.getNodeId());
     gen.writeObjectField("periodId", studentWork.getPeriod().getId());
     gen.writeObjectField("runId", studentWork.getRun().getId());
-    gen.writeObjectField("serverSaveTime", studentWork.getServerSaveTime());
+    gen.writeObjectField("serverSaveTime", studentWork.getServerSaveTime().getTime());
     ObjectMapper objectMapper = new ObjectMapper();
     gen.writeObjectField("studentData", objectMapper.readTree(studentWork.getStudentData()));
     gen.writeObjectField("workgroupId", studentWork.getWorkgroup().getId());

--- a/src/test/java/org/wise/portal/domain/work/NotebookItemTest.java
+++ b/src/test/java/org/wise/portal/domain/work/NotebookItemTest.java
@@ -55,7 +55,6 @@ public class NotebookItemTest extends DomainTest {
         ",\"localNotebookItemId\":\"ooacs8tls7\"" +
         ",\"content\":\"{\\\"text\\\":\\\"my note!\\\"}\"" +
         ",\"clientSaveTime\":1582337976000,\"serverSaveTime\":1582338031000" +
-        ",\"clientDeleteTime\":null,\"serverDeleteTime\":null" +
         ",\"periodId\":100,\"nodeId\":\"node78\",\"title\":\"Note from first step\"}", json);
   }
 


### PR DESCRIPTION
Changed server and client save times returned from the server to a long instead of a timestamp for StudentWork, Annotation, and Event.

Test that the "new" work badge appears correctly in the grading tool when student has ungraded work, either retrieved from the GET request (on grading tool load), or from WebSocket (student submits work while teacher is looking at the component in the grading tool).

Closes #2716