### PR TITLE
Extracted EditComponent from component.js

### DIFF
--- a/src/main/webapp/wise5/authoringTool/components/edit-component/editComponent.ts
+++ b/src/main/webapp/wise5/authoringTool/components/edit-component/editComponent.ts
@@ -1,0 +1,43 @@
+import { ConfigService } from "../../../services/configService";
+import { NodeService } from "../../../services/nodeService";
+import { TeacherProjectService } from "../../../services/teacherProjectService";
+
+class EditComponentController {
+
+  componentId: string;
+  nodeId: string;
+
+  static $inject = ['$scope', 'ConfigService', 'NodeService', 'ProjectService'];
+
+  constructor(private $scope: any, private ConfigService: ConfigService,
+      private NodeService: NodeService, private ProjectService: TeacherProjectService) {
+  }
+
+  $onInit() {
+    this.$scope.mode = 'authoring';
+    const authoringComponentContent = this.ProjectService.getComponentByNodeIdAndComponentId(this.nodeId, this.componentId);
+    const componentContent = this.ConfigService.replaceStudentNames(
+        this.ProjectService.injectAssetPaths(authoringComponentContent));
+    this.$scope.authoringComponentContent = authoringComponentContent;
+    this.$scope.nodeAuthoringController = this.$scope.$parent.nodeAuthoringController;
+    this.$scope.componentTemplatePath = this.NodeService.getComponentAuthoringTemplatePath(componentContent.type);
+    this.$scope.componentContent = componentContent;
+    this.$scope.nodeId = this.nodeId;
+    this.$scope.type = componentContent.type;
+  }
+}
+
+const EditComponent = {
+  bindings: {
+    componentId: '@',
+    nodeId: '@'
+  },
+  scope: true,
+  controller: EditComponentController,
+  template:
+      `<div class="component__wrapper">
+        <div ng-include="::componentTemplatePath" class="component__content component__content--{{::type}}"></div>
+      </div>`
+};
+
+export default EditComponent;

--- a/src/main/webapp/wise5/authoringTool/components/shared/shared.ts
+++ b/src/main/webapp/wise5/authoringTool/components/shared/shared.ts
@@ -6,9 +6,11 @@ import StepTools from './stepTools/stepTools';
 import Toolbar from './toolbar/toolbar';
 import TopBar from './topBar/topBar';
 import * as angular from 'angular';
+import EditComponent from '../edit-component/editComponent';
 
 const SharedComponents = angular
   .module('sharedComponents', [])
+  .component('editComponent', EditComponent)
   .component('atMainMenu', MainMenu)
   .component('atSideMenu', SideMenu)
   .component('atStepTools', StepTools)

--- a/src/main/webapp/wise5/authoringTool/node/node.html
+++ b/src/main/webapp/wise5/authoringTool/node/node.html
@@ -177,7 +177,7 @@
       <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::"insertAfter" | translate }}</md-tooltip>
     </md-button>
   </div>
-  <component ng-if='nodeAuthoringController.showComponentAuthoringViews' node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}' mode='authoring'></component>
+  <edit-component ng-if='nodeAuthoringController.showComponentAuthoringViews' node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}'></edit-component>
   <md-divider ng-if='nodeAuthoringController.showComponentAuthoringViews && !$last'></md-divider>
 </div>
 </div>

--- a/src/main/webapp/wise5/directives/component/component.js
+++ b/src/main/webapp/wise5/directives/component/component.js
@@ -1,7 +1,7 @@
 
 class ComponentController {
-    constructor($injector, $scope, $compile, $element, ConfigService, NodeService, NotebookService, ProjectService, StudentDataService, UtilService) {
-        this.$injector = $injector;
+
+    constructor($scope, $compile, $element, ConfigService, NodeService, NotebookService, ProjectService, StudentDataService) {
         this.$scope = $scope;
         this.$element = $element;
         this.$compile = $compile;
@@ -10,7 +10,6 @@ class ComponentController {
         this.NotebookService = NotebookService;
         this.ProjectService = ProjectService;
         this.StudentDataService = StudentDataService;
-        this.UtilService = UtilService;
     }
 
     $onInit() {
@@ -62,14 +61,7 @@ class ComponentController {
             componentContent = this.ProjectService.injectClickToSnipImage(componentContent);
         }
 
-        if (this.$scope.mode === 'authoring') {
-            this.$scope.authoringComponentContent = authoringComponentContent;
-            this.$scope.nodeAuthoringController = this.$scope.$parent.nodeAuthoringController;
-            this.$scope.componentTemplatePath = this.NodeService.getComponentAuthoringTemplatePath(componentContent.type);
-        } else {
-            this.$scope.componentTemplatePath = this.NodeService.getComponentTemplatePath(componentContent.type);
-        }
-
+        this.$scope.componentTemplatePath = this.NodeService.getComponentTemplatePath(componentContent.type);
         this.$scope.componentContent = componentContent;
         this.$scope.componentState = this.componentState;
         this.$scope.nodeId = this.nodeId;
@@ -99,8 +91,7 @@ class ComponentController {
       this.$compile(this.$element.contents())(this.$scope);
     }
 }
-
-ComponentController.$inject = ['$injector', '$scope', '$compile', '$element', 'ConfigService', 'NodeService', 'NotebookService', 'ProjectService', 'StudentDataService', 'UtilService'];
+ComponentController.$inject = ['$scope', '$compile', '$element', 'ConfigService', 'NodeService', 'NotebookService', 'ProjectService', 'StudentDataService'];
 
 const Component = {
     bindings: {


### PR DESCRIPTION
Also cleaned up code. editComponent no longer needs to call $compile.

Test that editing components in the AT works as before, and also test student/grading views to make sure that they still work.

Closes #2736