### PR TITLE
Extracted preview component from component.js

### DIFF
--- a/src/main/webapp/wise5/authoringTool/components/preview-component/previewComponent.ts
+++ b/src/main/webapp/wise5/authoringTool/components/preview-component/previewComponent.ts
@@ -1,0 +1,51 @@
+import { NodeService } from "../../../services/nodeService";
+
+class PreviewComponentController {
+
+  componentContent: any;
+  componentId: string;
+  nodeId: string;
+
+  static $inject = ['$scope', '$compile', '$element', 'NodeService'];
+
+  constructor(private $scope: any, private $compile: any, private $element: any,
+      private NodeService: NodeService) {
+  }
+
+  $onInit() {
+    this.$scope.mode = 'authoringComponentPreview';
+    this.$scope.componentContent = this.componentContent;
+    this.$scope.componentTemplatePath =
+        this.NodeService.getComponentTemplatePath(this.componentContent.type);
+    this.$scope.nodeId = this.nodeId;
+    this.$scope.type = this.componentContent.type;
+    this.compileComponent();
+    this.$scope.$watch(
+       () => { return this.componentContent; },
+       () => {
+         this.$scope.componentContent = this.componentContent;
+         this.compileComponent();
+       });
+  }
+
+  compileComponent() {
+    const componentHTML =
+        `<div class="component__wrapper">
+          <div ng-include="::componentTemplatePath" class="component__content component__content--{{::type}}"></div>
+        </div>`;
+    this.$element.html(componentHTML);
+    this.$compile(this.$element.contents())(this.$scope);
+  }
+}
+
+const PreviewComponent = {
+  bindings: {
+    componentContent: '<',
+    componentId: '@',
+    nodeId: '@'
+  },
+  scope: true,
+  controller: PreviewComponentController
+};
+
+export default PreviewComponent;

--- a/src/main/webapp/wise5/authoringTool/components/shared/shared.ts
+++ b/src/main/webapp/wise5/authoringTool/components/shared/shared.ts
@@ -7,14 +7,16 @@ import Toolbar from './toolbar/toolbar';
 import TopBar from './topBar/topBar';
 import * as angular from 'angular';
 import EditComponent from '../edit-component/editComponent';
+import PreviewComponent from '../preview-component/previewComponent';
 
 const SharedComponents = angular
   .module('sharedComponents', [])
-  .component('editComponent', EditComponent)
   .component('atMainMenu', MainMenu)
   .component('atSideMenu', SideMenu)
   .component('atStepTools', StepTools)
   .component('atToolbar', Toolbar)
-  .component('atTopBar', TopBar);
+  .component('atTopBar', TopBar)
+  .component('editComponent', EditComponent)
+  .component('previewComponent', PreviewComponent);
 
 export default SharedComponents;

--- a/src/main/webapp/wise5/components/animation/authoring.html
+++ b/src/main/webapp/wise5/components/animation/authoring.html
@@ -623,7 +623,6 @@
     <div>
       <h5>{{ ::'studentPreview' | translate }}</h5>
     </div>
-    <component component-content='animationController.componentContent'
-        mode='authoringComponentPreview'></component>
+    <preview-component component-content='animationController.componentContent'/>
   </div>
 </div>

--- a/src/main/webapp/wise5/components/audioOscillator/authoring.html
+++ b/src/main/webapp/wise5/components/audioOscillator/authoring.html
@@ -304,7 +304,6 @@
     <div>
       <h5>{{ 'studentPreview' | translate }}</h5>
     </div>
-    <component component-content='audioOscillatorController.componentContent'
-        mode='authoringComponentPreview'></component>
+    <preview-component component-content='audioOscillatorController.componentContent'/>
   </div>
 </div>

--- a/src/main/webapp/wise5/components/discussion/authoring.html
+++ b/src/main/webapp/wise5/components/discussion/authoring.html
@@ -221,7 +221,6 @@
     <div>
       <h5>{{ ::'studentPreview' | translate }}</h5>
     </div>
-    <component component-content='discussionController.componentContent'
-        mode='authoringComponentPreview'></component>
+    <preview-component component-content='discussionController.componentContent'/>
   </div>
 </div>

--- a/src/main/webapp/wise5/components/draw/authoring.html
+++ b/src/main/webapp/wise5/components/draw/authoring.html
@@ -477,9 +477,7 @@
     <div ng-style='{"padding-top": "20px", "padding-left": "20px"}'>
       <h5>{{ ::'studentPreview' | translate }}</h5>
     </div>
-    <component component-content='drawController.componentContent'
-        node-id='{{drawController.nodeId}}'
-        mode='authoringComponentPreview'></component>
+    <preview-component component-content='drawController.componentContent'
+        node-id='{{drawController.nodeId}}'/>
   </div>
 </div>
-  

--- a/src/main/webapp/wise5/components/embedded/authoring.html
+++ b/src/main/webapp/wise5/components/embedded/authoring.html
@@ -243,8 +243,7 @@
     </div>
     <div ng-style='{"border": "5px solid black", "padding": "20px"}'>
       <div><h5>{{ ::'studentPreview' | translate }}</h5></div>
-      <component component-content='embeddedController.componentContent'
-          mode='authoringComponentPreview'></component>
+      <preview-component component-content='embeddedController.componentContent'/>
     </div>
   </div>
 </div>

--- a/src/main/webapp/wise5/components/graph/authoring.html
+++ b/src/main/webapp/wise5/components/graph/authoring.html
@@ -897,8 +897,7 @@
       <div ng-style='{"padding-top": "20px", "padding-left": "20px"}'>
         <h5>{{ ::'studentPreview' | translate }}</h5>
       </div>
-      <component component-content='graphController.componentContent'
-          mode='authoringComponentPreview'></component>
+      <preview-component component-content='graphController.componentContent'/>
     </div>
   </div>
 </div>

--- a/src/main/webapp/wise5/components/match/authoring.html
+++ b/src/main/webapp/wise5/components/match/authoring.html
@@ -438,8 +438,7 @@
       <h5>{{ ::'studentPreview' | translate }}</h5>
     </div>
     <div>
-      <component component-content='matchController.componentContent'
-          mode='authoringComponentPreview'></component>
+      <preview-component component-content='matchController.componentContent'/>
     </div>
   </div>
 </div>

--- a/src/main/webapp/wise5/components/multipleChoice/authoring.html
+++ b/src/main/webapp/wise5/components/multipleChoice/authoring.html
@@ -308,7 +308,6 @@
     <div>
       <h5>{{ 'studentPreview' | translate }}</h5>
     </div>
-    <component component-content='multipleChoiceController.componentContent'
-        mode='authoringComponentPreview'></component>
+    <preview-component component-content='multipleChoiceController.componentContent'/>
   </div>
 </div>

--- a/src/main/webapp/wise5/components/openResponse/authoring.html
+++ b/src/main/webapp/wise5/components/openResponse/authoring.html
@@ -471,7 +471,6 @@
     <div>
       <h5>{{ ::'studentPreview' | translate }}</h5>
     </div>
-    <component component-content='openResponseController.componentContent'
-        mode='authoringComponentPreview'></component>
+    <preview-component component-content='openResponseController.componentContent'/>
   </div>
 </div>

--- a/src/main/webapp/wise5/components/outsideURL/authoring.html
+++ b/src/main/webapp/wise5/components/outsideURL/authoring.html
@@ -164,6 +164,5 @@
       <md-icon>refresh</md-icon>
     </md-button>
   </div>
-  <component component-content='outsideURLController.componentContent'
-      mode='authoringComponentPreview'></component>
+  <preview-component component-content='outsideURLController.componentContent'/>
 </div>

--- a/src/main/webapp/wise5/components/summary/authoring.html
+++ b/src/main/webapp/wise5/components/summary/authoring.html
@@ -314,8 +314,7 @@
     <div>
       <compile id='prompt' data='summaryController.getPrompt()'></compile>
       <div>
-        <component component-content='summaryController.componentContent'
-            mode='authoringComponentPreview'></component>
+        <preview-component component-content='summaryController.componentContent'/>
       </div>
   </div>
 </div>

--- a/src/main/webapp/wise5/components/table/authoring.html
+++ b/src/main/webapp/wise5/components/table/authoring.html
@@ -493,7 +493,6 @@
       <div ng-style='{"padding-top": "20px", "padding-left": "20px"}'>
         <h5>{{ ::'studentPreview' | translate }}</h5>
       </div>
-      <component component-content='tableController.componentContent'
-          mode='authoringComponentPreview'></component>
+      <preview-component component-content='tableController.componentContent'/>
     </div>
   </div>

--- a/src/main/webapp/wise5/directives/component/component.js
+++ b/src/main/webapp/wise5/directives/component/component.js
@@ -1,77 +1,96 @@
 class ComponentController {
+  constructor(
+    $scope,
+    ConfigService,
+    NodeService,
+    NotebookService,
+    ProjectService,
+    StudentDataService
+  ) {
+    this.$scope = $scope;
+    this.ConfigService = ConfigService;
+    this.NodeService = NodeService;
+    this.NotebookService = NotebookService;
+    this.ProjectService = ProjectService;
+    this.StudentDataService = StudentDataService;
+  }
 
-    constructor($scope, ConfigService, NodeService, NotebookService, ProjectService, StudentDataService) {
-        this.$scope = $scope;
-        this.ConfigService = ConfigService;
-        this.NodeService = NodeService;
-        this.NotebookService = NotebookService;
-        this.ProjectService = ProjectService;
-        this.StudentDataService = StudentDataService;
+  $onInit() {
+    if (this.mode) {
+      this.$scope.mode = this.mode;
+    } else {
+      this.$scope.mode = 'student';
     }
 
-    $onInit() {
-        if (this.mode) {
-            this.$scope.mode = this.mode;
-        } else {
-            this.$scope.mode = 'student';
-        }
-
-        if (this.workgroupId != null) {
-            try {
-                this.workgroupId = parseInt(this.workgroupId);
-            } catch(e) {
-
-            }
-        }
-
-        if (this.teacherWorkgroupId) {
-            try {
-                this.teacherWorkgroupId = parseInt(this.teacherWorkgroupId);
-            } catch(e) {
-
-            }
-        }
-
-        if (this.componentState == null || this.componentState === '') {
-            this.componentState = this.StudentDataService.getLatestComponentStateByNodeIdAndComponentId(this.nodeId, this.componentId);
-        } else {
-            this.componentState = angular.fromJson(this.componentState);
-            this.nodeId = this.componentState.nodeId;
-            this.componentId = this.componentState.componentId;
-        }
-
-        let componentContent = this.ProjectService.getComponentByNodeIdAndComponentId(this.nodeId, this.componentId);
-        componentContent = this.ProjectService.injectAssetPaths(componentContent);
-        componentContent = this.ConfigService.replaceStudentNames(componentContent);
-        if (this.NotebookService.isNotebookEnabled() && this.NotebookService.isStudentNoteClippingEnabled()) {
-            componentContent = this.ProjectService.injectClickToSnipImage(componentContent);
-        }
-
-        this.$scope.componentTemplatePath = this.NodeService.getComponentTemplatePath(componentContent.type);
-        this.$scope.componentContent = componentContent;
-        this.$scope.componentState = this.componentState;
-        this.$scope.nodeId = this.nodeId;
-        this.$scope.workgroupId = this.workgroupId;
-        this.$scope.teacherWorkgroupId = this.teacherWorkgroupId;
-        this.$scope.type = componentContent.type;
-        this.$scope.nodeController = this.$scope.$parent.nodeController;
+    if (this.workgroupId != null) {
+      try {
+        this.workgroupId = parseInt(this.workgroupId);
+      } catch (e) {}
     }
+
+    if (this.teacherWorkgroupId) {
+      try {
+        this.teacherWorkgroupId = parseInt(this.teacherWorkgroupId);
+      } catch (e) {}
+    }
+
+    if (this.componentState == null || this.componentState === '') {
+      this.componentState = this.StudentDataService.getLatestComponentStateByNodeIdAndComponentId(
+        this.nodeId,
+        this.componentId
+      );
+    } else {
+      this.componentState = angular.fromJson(this.componentState);
+      this.nodeId = this.componentState.nodeId;
+      this.componentId = this.componentState.componentId;
+    }
+
+    let componentContent = this.ProjectService.getComponentByNodeIdAndComponentId(
+      this.nodeId,
+      this.componentId
+    );
+    componentContent = this.ProjectService.injectAssetPaths(componentContent);
+    componentContent = this.ConfigService.replaceStudentNames(componentContent);
+    if (
+      this.NotebookService.isNotebookEnabled() &&
+      this.NotebookService.isStudentNoteClippingEnabled()
+    ) {
+      componentContent = this.ProjectService.injectClickToSnipImage(componentContent);
+    }
+
+    this.$scope.componentTemplatePath = this.NodeService.getComponentTemplatePath(
+      componentContent.type
+    );
+    this.$scope.componentContent = componentContent;
+    this.$scope.componentState = this.componentState;
+    this.$scope.nodeId = this.nodeId;
+    this.$scope.workgroupId = this.workgroupId;
+    this.$scope.teacherWorkgroupId = this.teacherWorkgroupId;
+    this.$scope.type = componentContent.type;
+    this.$scope.nodeController = this.$scope.$parent.nodeController;
+  }
 }
-ComponentController.$inject = ['$scope', 'ConfigService', 'NodeService', 'NotebookService', 'ProjectService', 'StudentDataService'];
+ComponentController.$inject = [
+  '$scope',
+  'ConfigService',
+  'NodeService',
+  'NotebookService',
+  'ProjectService',
+  'StudentDataService'
+];
 
 const Component = {
-    bindings: {
-        componentId: '@',
-        componentState: '@',
-        mode: '@',
-        nodeId: '@',
-        teacherWorkgroupId: '@',
-        workgroupId: '@'
-    },
-    scope: true,
-    controller: ComponentController,
-    template:
-        `<div class="component__wrapper">
+  bindings: {
+    componentId: '@',
+    componentState: '@',
+    mode: '@',
+    nodeId: '@',
+    teacherWorkgroupId: '@',
+    workgroupId: '@'
+  },
+  scope: true,
+  controller: ComponentController,
+  template: `<div class="component__wrapper">
           <div ng-include="::componentTemplatePath" class="component__content component__content--{{::type}}"></div>
         </div>`
 };

--- a/src/main/webapp/wise5/directives/component/component.js
+++ b/src/main/webapp/wise5/directives/component/component.js
@@ -1,10 +1,7 @@
-
 class ComponentController {
 
-    constructor($scope, $compile, $element, ConfigService, NodeService, NotebookService, ProjectService, StudentDataService) {
+    constructor($scope, ConfigService, NodeService, NotebookService, ProjectService, StudentDataService) {
         this.$scope = $scope;
-        this.$element = $element;
-        this.$compile = $compile;
         this.ConfigService = ConfigService;
         this.NodeService = NodeService;
         this.NotebookService = NotebookService;
@@ -43,21 +40,10 @@ class ComponentController {
             this.componentId = this.componentState.componentId;
         }
 
-        let authoringComponentContent;
-        let componentContent;
-        if (this.componentContent) {
-          authoringComponentContent = this.componentContent;
-          componentContent = this.componentContent;
-        } else {
-          authoringComponentContent = this.ProjectService.getComponentByNodeIdAndComponentId(this.nodeId, this.componentId);
-          componentContent = this.ProjectService.injectAssetPaths(authoringComponentContent);
-        }
-
-        // replace any student names in the component content
+        let componentContent = this.ProjectService.getComponentByNodeIdAndComponentId(this.nodeId, this.componentId);
+        componentContent = this.ProjectService.injectAssetPaths(componentContent);
         componentContent = this.ConfigService.replaceStudentNames(componentContent);
-
         if (this.NotebookService.isNotebookEnabled() && this.NotebookService.isStudentNoteClippingEnabled()) {
-            // inject the click attribute that will snip the image when the image is clicked
             componentContent = this.ProjectService.injectClickToSnipImage(componentContent);
         }
 
@@ -69,33 +55,12 @@ class ComponentController {
         this.$scope.teacherWorkgroupId = this.teacherWorkgroupId;
         this.$scope.type = componentContent.type;
         this.$scope.nodeController = this.$scope.$parent.nodeController;
-
-        if (this.mode === 'authoringComponentPreview') {
-          this.$scope.$watch(
-            () => { return this.componentContent; },
-            () => {
-              this.$scope.componentContent = this.componentContent;
-              this.compileComponent();
-          });
-        } else {
-          this.compileComponent();
-        }
-    }
-
-    compileComponent() {
-      const componentHTML =
-          `<div class="component__wrapper">
-            <div ng-include="::componentTemplatePath" class="component__content component__content--{{::type}}"></div>
-          </div>`;
-      this.$element.html(componentHTML);
-      this.$compile(this.$element.contents())(this.$scope);
     }
 }
-ComponentController.$inject = ['$scope', '$compile', '$element', 'ConfigService', 'NodeService', 'NotebookService', 'ProjectService', 'StudentDataService'];
+ComponentController.$inject = ['$scope', 'ConfigService', 'NodeService', 'NotebookService', 'ProjectService', 'StudentDataService'];
 
 const Component = {
     bindings: {
-        componentContent: '<',
         componentId: '@',
         componentState: '@',
         mode: '@',
@@ -104,7 +69,11 @@ const Component = {
         workgroupId: '@'
     },
     scope: true,
-    controller: ComponentController
+    controller: ComponentController,
+    template:
+        `<div class="component__wrapper">
+          <div ng-include="::componentTemplatePath" class="component__content component__content--{{::type}}"></div>
+        </div>`
 };
 
 export default Component;


### PR DESCRIPTION
Code to handle previewing a component in the authoring tool has been extracted from component.js into its own component. Also cleaned up code in component.js. Note that component.js no longer uses $compile().

Test that previewing component works in the AT. Also test that component works as before in student and grading views.

Closes #2741