### PR TITLE
Fixed issue where inactive tab + active tab was still logging users out

### DIFF
--- a/src/main/webapp/wise5/services/sessionService.ts
+++ b/src/main/webapp/wise5/services/sessionService.ts
@@ -100,7 +100,11 @@ export class SessionService {
 
   checkForLogout() {
     if (this.isInactiveLongEnoughToForceLogout()) {
-      this.forceLogOut();
+      this.checkIfSessionIsActive().subscribe(isSessionActive => {
+        if (!isSessionActive) {
+          this.forceLogOut();
+        }
+      });
     } else if (this.isInactiveLongEnoughToWarn() && !this.isShowingWarning()) {
       this.showWarning();
     }
@@ -155,10 +159,13 @@ export class SessionService {
     this.renewSession();
   }
 
+  checkIfSessionIsActive() {
+    return this.http.get(this.ConfigService.getConfigParam('renewSessionURL'));
+  }
+
   renewSession() {
-    const renewSessionURL = this.ConfigService.getConfigParam('renewSessionURL');
-    this.http.get(renewSessionURL).toPromise().then(result => {
-      if (result === 'false') {
+    this.checkIfSessionIsActive().subscribe(isSessionActive => {
+      if (!isSessionActive) {
         this.logOut();
       }
     });


### PR DESCRIPTION
Open two tabs, and open a unit in the AT in each tab. You should reduce your session timeout value in application.properties.

Test that
- being inactive in one and active in another does not prevent either tab from logging out
- logging out of one tab will log you out of another

Also fixed issue where users were not being logged out when the session was inactive. It was testing for string 'false', when the server was returning boolean false.

Closes #2750