### PR TITLE
Converted OutsideURL, OpenResponse, and HTML component authoring to AngularJS component

### DIFF
--- a/src/main/webapp/wise5/authoringTool/components/editComponentController.ts
+++ b/src/main/webapp/wise5/authoringTool/components/editComponentController.ts
@@ -1,0 +1,354 @@
+import * as angular from 'angular';
+import { ConfigService } from "../../services/configService";
+import { UtilService } from "../../services/utilService";
+import { TeacherProjectService } from "../../services/teacherProjectService";
+import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
+import { NodeService } from '../../services/nodeService';
+import { NotificationService } from '../../services/notificationService';
+import { Subscription } from 'rxjs';
+
+export abstract class EditComponentController {
+
+  $translate: any;
+  allowedConnectedComponentTypes: any[];
+  authoringComponentContent: any;
+  authoringComponentContentJSONString: string;
+  authoringValidComponentContentJSONString: string;
+  componentContent: any;
+  componentId: string;
+  idToOrder: any;
+  isDirty: boolean;
+  isJSONStringChanged: boolean = false;
+  isPromptVisible: boolean = true;
+  isSaveButtonVisible: boolean;
+  isSubmitButtonVisible: boolean;
+  isSubmitDirty: boolean;
+  latestAnnotations: any;
+  nodeId: string;
+  showAdvancedAuthoring: boolean = false;
+  showJSONAuthoring: boolean = false;
+  submitCounter: number;
+  summernoteRubricId: string;
+  summernoteRubricHTML: string;
+  summernoteRubricOptions: any;
+  starterStateResponseSubscription: Subscription;
+
+  constructor(
+      protected $scope: any,
+      protected $filter: any,
+      protected ConfigService: ConfigService,
+      protected NodeService: NodeService,
+      protected NotificationService: NotificationService,
+      protected ProjectAssetService: ProjectAssetService,
+      protected ProjectService: TeacherProjectService,
+      protected UtilService: UtilService) {
+  }
+
+  $onInit() {
+    this.authoringComponentContent = this.ProjectService.getComponentByNodeIdAndComponentId(this.nodeId, this.componentId);
+    this.componentContent = this.ConfigService.replaceStudentNames(
+        this.ProjectService.injectAssetPaths(this.authoringComponentContent));
+    this.componentId = this.componentContent.id;
+    this.idToOrder = this.ProjectService.idToOrder;
+    this.$translate = this.$filter('translate');
+    this.isSaveButtonVisible = this.componentContent.showSaveButton;
+    this.isSubmitButtonVisible = this.componentContent.showSubmitButton;
+    this.summernoteRubricId = 'summernoteRubric_' + this.nodeId + '_' + this.componentId;
+    this.summernoteRubricHTML = this.componentContent.rubric;
+    const insertAssetString = this.$translate('INSERT_ASSET');
+    const InsertAssetButton = this.UtilService.createInsertAssetButton(null, this.nodeId,
+        this.componentId, 'rubric', insertAssetString,
+        (params: any) => { this.openAssetChooser(params); });
+    this.summernoteRubricOptions = {
+      toolbar: [
+        ['style', ['style']],
+        ['font', ['bold', 'underline', 'clear']],
+        ['fontname', ['fontname']],
+        ['fontsize', ['fontsize']],
+        ['color', ['color']],
+        ['para', ['ul', 'ol', 'paragraph']],
+        ['table', ['table']],
+        ['insert', ['link', 'video']],
+        ['view', ['fullscreen', 'codeview', 'help']],
+        ['customButton', ['insertAssetButton']]
+      ],
+      height: 300,
+      disableDragAndDrop: true,
+      buttons: {
+        insertAssetButton: InsertAssetButton
+      },
+      dialogsInBody: true
+    };
+
+    this.updateAdvancedAuthoringView();
+    this.$scope.$watch(
+        () => {
+          return this.authoringComponentContent
+        },
+        (newValue, oldValue) => {
+          this.handleAuthoringComponentContentChanged(newValue, oldValue);
+        },
+        true
+    );
+    this.$scope.$watch(() => {
+      return this.$scope.$parent.nodeAuthoringController
+        .showAdvancedComponentAuthoring[this.componentId];
+    }, () => {
+      this.showAdvancedAuthoring = this.$scope.$parent.nodeAuthoringController
+          .showAdvancedComponentAuthoring[this.componentId];
+      this.NotificationService.hideJSONValidMessage();
+    }, true);
+    this.starterStateResponseSubscription =
+        this.NodeService.starterStateResponse$.subscribe((args: any) => {
+      if (this.isForThisComponent(args)) {
+        this.saveStarterState(args.starterState);
+      }
+    });
+  }
+
+  $onDestroy() {
+    this.starterStateResponseSubscription.unsubscribe();
+  }
+
+  handleAuthoringComponentContentChanged(newValue, oldValue): void {
+    this.componentContent = this.ProjectService.injectAssetPaths(newValue);
+    this.isSaveButtonVisible = this.componentContent.showSaveButton;
+    this.isSubmitButtonVisible = this.componentContent.showSubmitButton;
+    this.latestAnnotations = null;
+    this.isDirty = false;
+    this.isSubmitDirty = false;
+    this.submitCounter = 0;
+  }
+
+  showJSONButtonClicked(): void {
+    if (this.showJSONAuthoring) {
+      if (this.isJSONValid()) {
+        this.saveJSONAuthoringViewChanges();
+        this.toggleJSONAuthoringView();
+        this.NotificationService.hideJSONValidMessage();
+      } else {
+        let isRollback = confirm(this.$translate('jsonInvalidErrorMessage'));
+        if (isRollback) {
+          this.toggleJSONAuthoringView();
+          this.NotificationService.hideJSONValidMessage();
+          this.isJSONStringChanged = false;
+          this.rollbackToRecentValidJSON();
+          this.saveJSONAuthoringViewChanges();
+        }
+      }
+    } else {
+      this.toggleJSONAuthoringView();
+      this.rememberRecentValidJSON();
+    }
+  }
+
+  isJSONValid(): boolean {
+    try {
+      angular.fromJson(this.authoringComponentContentJSONString);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  saveJSONAuthoringViewChanges(): void {
+    try {
+      const editedComponentContent = angular.fromJson(this.authoringComponentContentJSONString);
+      this.ProjectService.replaceComponent(this.nodeId, this.componentId, editedComponentContent);
+      this.componentContent = editedComponentContent;
+      this.$scope.$parent.nodeAuthoringController.authoringViewNodeChanged();
+      this.isJSONStringChanged = false;
+    } catch(e) {
+      this.$scope.$parent.nodeAuthoringController.showSaveErrorAdvancedAuthoring();
+    }
+  }
+
+  toggleJSONAuthoringView(): void {
+    this.showJSONAuthoring = !this.showJSONAuthoring;
+  }
+
+  authoringJSONChanged(): void {
+    this.isJSONStringChanged = true;
+    if (this.isJSONValid()) {
+      this.NotificationService.showJSONValidMessage();
+      this.rememberRecentValidJSON();
+    } else {
+      this.NotificationService.showJSONInvalidMessage();
+    }
+  }
+
+  rememberRecentValidJSON(): void {
+    this.authoringValidComponentContentJSONString = this.authoringComponentContentJSONString;
+  }
+
+  rollbackToRecentValidJSON(): void {
+    this.authoringComponentContentJSONString = this.authoringValidComponentContentJSONString;
+  }
+
+  authoringViewComponentChanged(): void {
+    this.updateAdvancedAuthoringView();
+    this.$scope.$parent.nodeAuthoringController.authoringViewNodeChanged();
+  }
+
+  updateAdvancedAuthoringView(): void {
+    this.authoringComponentContentJSONString = angular.toJson(this.authoringComponentContent, 4);
+  }
+
+  summernoteRubricHTMLChanged(): void {
+    let html = this.ConfigService.removeAbsoluteAssetPaths(this.summernoteRubricHTML);
+    html = this.UtilService.insertWISELinks(html);
+    this.authoringComponentContent.rubric = html;
+    this.authoringViewComponentChanged();
+  }
+
+  openAssetChooser(params: any): void {
+    this.ProjectAssetService.openAssetChooser(params).then(
+      (data: any) => { this.assetSelected(data) }
+    );
+  }
+
+  assetSelected({ nodeId, componentId, assetItem, target }): void {
+    if (target === 'rubric') {
+      const fileName = assetItem.fileName;
+      const fullFilePath = `${this.ConfigService.getProjectAssetsDirectoryPath()}/${fileName}`;
+      this.UtilService.insertFileInSummernoteEditor(
+        `summernoteRubric_${this.nodeId}_${this.componentId}`,
+        fullFilePath,
+        fileName
+      );
+    }
+  }
+
+  setShowSubmitButtonValue(show) {
+    if (show == null || show == false) {
+      this.authoringComponentContent.showSaveButton = false;
+      this.authoringComponentContent.showSubmitButton = false;
+    } else {
+      this.authoringComponentContent.showSaveButton = true;
+      this.authoringComponentContent.showSubmitButton = true;
+    }
+    this.NodeService.broadcastComponentShowSubmitButtonValueChanged({
+      nodeId: this.nodeId,
+      componentId: this.componentId,
+      showSubmitButton: show
+    });
+  }
+
+  addTag() {
+    if (this.authoringComponentContent.tags == null) {
+      this.authoringComponentContent.tags = [];
+    }
+    this.authoringComponentContent.tags.push('');
+    this.authoringViewComponentChanged();
+  }
+
+  connectedComponentTypeChanged(connectedComponent) {
+    this.authoringViewComponentChanged();
+  }
+
+  connectedComponentNodeIdChanged(connectedComponent) {
+    connectedComponent.componentId = null;
+    connectedComponent.type = null;
+    this.automaticallySetConnectedComponentComponentIdIfPossible(connectedComponent);
+    this.authoringViewComponentChanged();
+  }
+
+  connectedComponentComponentIdChanged(connectedComponent) {
+    this.automaticallySetConnectedComponentTypeIfPossible(connectedComponent);
+    this.authoringViewComponentChanged();
+  }
+
+  isConnectedComponentTypeAllowed(componentType) {
+    for (const allowedConnectedComponentType of this.allowedConnectedComponentTypes) {
+      if (allowedConnectedComponentType.type === componentType) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  addConnectedComponent() {
+    this.addConnectedComponentAndSetComponentIdIfPossible();
+    this.authoringViewComponentChanged();
+  }
+
+  addConnectedComponentAndSetComponentIdIfPossible() {
+    const connectedComponent = this.createConnectedComponent();
+    if (this.authoringComponentContent.connectedComponents == null) {
+      this.authoringComponentContent.connectedComponents = [];
+    }
+    this.authoringComponentContent.connectedComponents.push(connectedComponent);
+    this.automaticallySetConnectedComponentComponentIdIfPossible(connectedComponent);
+  }
+
+  automaticallySetConnectedComponentComponentIdIfPossible(connectedComponent) {
+    let numberOfAllowedComponents = 0;
+    let allowedComponent = null;
+    for (const component of this.ProjectService.getComponentsByNodeId(connectedComponent.nodeId)) {
+      if (this.isConnectedComponentTypeAllowed(component.type) &&
+          component.id != this.componentId) {
+        numberOfAllowedComponents += 1;
+        allowedComponent = component;
+      }
+    }
+    if (numberOfAllowedComponents === 1) {
+      connectedComponent.componentId = allowedComponent.id;
+      connectedComponent.type = 'importWork';
+    }
+    this.automaticallySetConnectedComponentTypeIfPossible(connectedComponent);
+  }
+
+  automaticallySetConnectedComponentTypeIfPossible(connectedComponent) {
+    if (connectedComponent.componentId != null) {
+      connectedComponent.type = 'importWork';
+    }
+    this.automaticallySetConnectedComponentFieldsIfPossible(connectedComponent);
+  }
+
+  automaticallySetConnectedComponentFieldsIfPossible(connectedComponent) {
+  }
+
+  createConnectedComponent() {
+    return {
+      nodeId: this.nodeId,
+      componentId: null,
+      type: null
+    };
+  }
+
+  deleteConnectedComponent(index) {
+    if (confirm(this.$translate('areYouSureYouWantToDeleteThisConnectedComponent'))) {
+      if (this.authoringComponentContent.connectedComponents != null) {
+        this.authoringComponentContent.connectedComponents.splice(index, 1);
+      }
+      this.authoringViewComponentChanged();
+    }
+  }
+
+  getNodePositionAndTitleByNodeId(nodeId) {
+    return this.ProjectService.getNodePositionAndTitleByNodeId(nodeId);
+  }
+
+  isApplicationNode(nodeId) {
+    return this.ProjectService.isApplicationNode(nodeId);
+  }
+
+  getComponentsByNodeId(nodeId) {
+    return this.ProjectService.getComponentsByNodeId(nodeId);
+  }
+
+  getConnectedComponentType(
+      {nodeId, componentId}: { nodeId: string, componentId: string }) {
+    const component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    if (component != null) {
+      return component.type;
+    }
+    return null;
+  }
+
+  isForThisComponent(object) {
+    return this.nodeId == object.nodeId && this.componentId == object.componentId;
+  }
+
+  saveStarterState(starterState: any) {}
+}

--- a/src/main/webapp/wise5/authoringTool/node/node.html
+++ b/src/main/webapp/wise5/authoringTool/node/node.html
@@ -177,7 +177,13 @@
       <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::"insertAfter" | translate }}</md-tooltip>
     </md-button>
   </div>
-  <edit-component ng-if='nodeAuthoringController.showComponentAuthoringViews' node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}'></edit-component>
-  <md-divider ng-if='nodeAuthoringController.showComponentAuthoringViews && !$last'></md-divider>
+  <div ng-if="nodeAuthoringController.showComponentAuthoringViews">
+    <ng-content ng-switch="::component.type">
+      <outside-url-authoring ng-switch-when="OutsideURL" node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}'/>
+      <open-response-authoring ng-switch-when="OpenResponse" node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}'/>
+      <edit-component ng-switch-default node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}'></edit-component>
+    </ng-content>
+    <md-divider ng-if='!$last'></md-divider>
+  </div>
 </div>
 </div>

--- a/src/main/webapp/wise5/authoringTool/node/node.html
+++ b/src/main/webapp/wise5/authoringTool/node/node.html
@@ -179,8 +179,9 @@
   </div>
   <div ng-if="nodeAuthoringController.showComponentAuthoringViews">
     <ng-content ng-switch="::component.type">
-      <outside-url-authoring ng-switch-when="OutsideURL" node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}'/>
+      <html-authoring ng-switch-when="HTML" node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}'/>
       <open-response-authoring ng-switch-when="OpenResponse" node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}'/>
+      <outside-url-authoring ng-switch-when="OutsideURL" node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}'/>
       <edit-component ng-switch-default node-id='{{nodeAuthoringController.nodeId}}' component-id='{{component.id}}'></edit-component>
     </ng-content>
     <md-divider ng-if='!$last'></md-divider>

--- a/src/main/webapp/wise5/components/html/authoring.html
+++ b/src/main/webapp/wise5/components/html/authoring.html
@@ -1,4 +1,4 @@
-<div ng-controller='HTMLAuthoringController as htmlController'>
+<div>
   <div class='advancedAuthoringDiv'
        ng-if='htmlController.showAdvancedAuthoring'>
     <div>

--- a/src/main/webapp/wise5/components/html/htmlAuthoringComponentModule.ts
+++ b/src/main/webapp/wise5/components/html/htmlAuthoringComponentModule.ts
@@ -3,13 +3,11 @@
 import * as angular from 'angular';
 import { downgradeInjectable } from '@angular/upgrade/static';
 import { HTMLService } from './htmlService';
-import HTMLController from './htmlController';
-import HTMLAuthoringController from './htmlAuthoringController';
+import HTMLAuthoring from './htmlAuthoringController';
 
 const htmlComponentModule = angular.module('htmlAuthoringComponentModule', [])
   .service('HTMLService', downgradeInjectable(HTMLService))
-  .controller('HTMLController', HTMLController)
-  .controller('HTMLAuthoringController', HTMLAuthoringController)
+  .component('htmlAuthoring', HTMLAuthoring)
   .config([
     '$translatePartialLoaderProvider',
     $translatePartialLoaderProvider => {

--- a/src/main/webapp/wise5/components/html/htmlAuthoringController.ts
+++ b/src/main/webapp/wise5/components/html/htmlAuthoringController.ts
@@ -1,11 +1,11 @@
 'use strict';
 
+import { Directive } from '@angular/core';
 import * as angular from 'angular';
-import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
-import { ComponentAuthoringController } from '../componentAuthoringController';
+import { EditComponentController } from '../../authoringTool/components/editComponentController';
 
-class HTMLAuthoringController extends ComponentAuthoringController {
-  ProjectAssetService: ProjectAssetService;
+@Directive()
+class HTMLAuthoringController extends EditComponentController {
   summernotePromptHTML: string;
   summernotePromptOptions: any;
   summernotePromptId: string;
@@ -43,6 +43,10 @@ class HTMLAuthoringController extends ComponentAuthoringController {
       ProjectService,
       UtilService
     );
+  }
+
+  $onInit() {
+    super.$onInit();
     this.summernotePromptHTML = '';
     this.summernotePromptOptions = {
       toolbar: [
@@ -83,7 +87,7 @@ class HTMLAuthoringController extends ComponentAuthoringController {
 
     this.summernotePromptId = 'summernotePrompt_' + this.nodeId + '_' + this.componentId;
     this.summernotePromptHTML = this.UtilService.replaceWISELinks(this.componentContent.html);
-    $scope.$watch(
+    this.$scope.$watch(
       function() {
         return this.authoringComponentContent;
       }.bind(this),
@@ -183,4 +187,15 @@ class HTMLAuthoringController extends ComponentAuthoringController {
   }
 }
 
-export default HTMLAuthoringController;
+const HTMLAuthoring = {
+  bindings: {
+    nodeId: '@',
+    componentId: '@'
+  },
+  controller: HTMLAuthoringController,
+  controllerAs: 'htmlController',
+  templateUrl: 'wise5/components/html/authoring.html'
+}
+
+export default HTMLAuthoring;
+

--- a/src/main/webapp/wise5/components/openResponse/authoring.html
+++ b/src/main/webapp/wise5/components/openResponse/authoring.html
@@ -1,4 +1,4 @@
-<div class='openResponse' ng-controller='OpenResponseAuthoringController as openResponseController' flex>
+<div class='openResponse' flex>
   <style>
     {{openResponseController.nodeContent.style}}
   </style>

--- a/src/main/webapp/wise5/components/openResponse/openResponseAuthoring.ts
+++ b/src/main/webapp/wise5/components/openResponse/openResponseAuthoring.ts
@@ -1,11 +1,11 @@
 'use strict';
 
-import { ProjectAssetService } from '../../../site/src/app/services/projectAssetService';
+import { Directive } from '@angular/core';
+import { EditComponentController } from '../../authoringTool/components/editComponentController';
 import { CRaterService } from '../../services/cRaterService';
-import { ComponentAuthoringController } from '../componentAuthoringController';
 
-class OpenResponseAuthoringController extends ComponentAuthoringController {
-  ProjectAssetService: ProjectAssetService;
+@Directive()
+class OpenResponseAuthoringController extends EditComponentController {
   allowedConnectedComponentTypes: any[];
   useCustomCompletionCriteria: boolean = false;
   cRaterItemIdIsValid: boolean = null;
@@ -44,7 +44,10 @@ class OpenResponseAuthoringController extends ComponentAuthoringController {
       ProjectService,
       UtilService
     );
-    this.ProjectAssetService = ProjectAssetService;
+  }
+
+  $onInit() {
+    super.$onInit();
     this.allowedConnectedComponentTypes = [
       {
         type: 'OpenResponse'
@@ -55,7 +58,7 @@ class OpenResponseAuthoringController extends ComponentAuthoringController {
       this.useCustomCompletionCriteria = true;
     }
 
-    $scope.$watch(
+    this.$scope.$watch(
       function() {
         return this.authoringComponentContent;
       }.bind(this),
@@ -439,4 +442,14 @@ class OpenResponseAuthoringController extends ComponentAuthoringController {
   }
 }
 
-export default OpenResponseAuthoringController;
+const OpenResponseAuthoring = {
+  bindings: {
+    nodeId: '@',
+    componentId: '@'
+  },
+  controller: OpenResponseAuthoringController,
+  controllerAs: 'openResponseController',
+  templateUrl: 'wise5/components/openResponse/authoring.html'
+}
+
+export default OpenResponseAuthoring;

--- a/src/main/webapp/wise5/components/openResponse/openResponseAuthoringComponentModule.ts
+++ b/src/main/webapp/wise5/components/openResponse/openResponseAuthoringComponentModule.ts
@@ -3,14 +3,12 @@
 import * as angular from 'angular';
 import { downgradeInjectable } from '@angular/upgrade/static';
 import { OpenResponseService } from './openResponseService';
-import OpenResponseController from './openResponseController';
-import OpenResponseAuthoringController from './openResponseAuthoringController';
+import OpenResponseAuthoring from './openResponseAuthoring';
 
 const openResponseAuthoringComponentModule = angular
   .module('openResponseAuthoringComponentModule', ['pascalprecht.translate'])
   .service('OpenResponseService', downgradeInjectable(OpenResponseService))
-  .controller('OpenResponseController', OpenResponseController)
-  .controller('OpenResponseAuthoringController', OpenResponseAuthoringController)
+  .component('openResponseAuthoring', OpenResponseAuthoring)
   .config([
     '$translatePartialLoaderProvider',
     $translatePartialLoaderProvider => {

--- a/src/main/webapp/wise5/components/outsideURL/authoring.html
+++ b/src/main/webapp/wise5/components/outsideURL/authoring.html
@@ -1,4 +1,4 @@
-<div ng-controller="OutsideURLAuthoringController as outsideURLController">
+<div>
   <div>
     <div class="advancedAuthoringDiv" ng-if="outsideURLController.showAdvancedAuthoring">
       <div>

--- a/src/main/webapp/wise5/components/outsideURL/outsideURLAuthoring.ts
+++ b/src/main/webapp/wise5/components/outsideURL/outsideURLAuthoring.ts
@@ -1,9 +1,11 @@
 'use strict';
 
-import { ComponentAuthoringController } from '../componentAuthoringController';
+import { Directive } from '@angular/core';
+import { EditComponentController } from '../../authoringTool/components/editComponentController';
 import { OutsideURLService } from './outsideURLService';
 
-class OutsideURLAuthoringController extends ComponentAuthoringController {
+@Directive()
+class OutsideURLAuthoringController extends EditComponentController {
   height: string;
   info: string;
   isShowOERs: boolean;
@@ -50,6 +52,10 @@ class OutsideURLAuthoringController extends ComponentAuthoringController {
       ProjectService,
       UtilService
     );
+  }
+
+  $onInit() {
+    super.$onInit();
     this.$translate = this.$filter('translate');
     this.isShowOERs = this.componentContent.url === '';
     this.subjects = [
@@ -73,7 +79,7 @@ class OutsideURLAuthoringController extends ComponentAuthoringController {
     this.searchText = '';
     this.selectedSubjects = [];
 
-    $scope.$watch(
+    this.$scope.$watch(
       () => {
         return this.authoringComponentContent;
       },
@@ -88,6 +94,7 @@ class OutsideURLAuthoringController extends ComponentAuthoringController {
       },
       true
     );
+
     this.OutsideURLService.getOpenEducationalResources().then((openEducationalResources: any) => {
       this.openEducationalResources = openEducationalResources.sort((a, b) =>
         a.metadata.title > b.metadata.title ? 1 : -1
@@ -152,4 +159,14 @@ class OutsideURLAuthoringController extends ComponentAuthoringController {
   }
 }
 
-export default OutsideURLAuthoringController;
+const OutsideURLAuthoring = {
+  bindings: {
+    nodeId: '@',
+    componentId: '@'
+  },
+  controller: OutsideURLAuthoringController,
+  controllerAs: 'outsideURLController',
+  templateUrl: 'wise5/components/outsideURL/authoring.html'
+}
+
+export default OutsideURLAuthoring;

--- a/src/main/webapp/wise5/components/outsideURL/outsideURLAuthoringComponentModule.ts
+++ b/src/main/webapp/wise5/components/outsideURL/outsideURLAuthoringComponentModule.ts
@@ -3,14 +3,12 @@
 import * as angular from 'angular';
 import { downgradeInjectable } from '@angular/upgrade/static';
 import { OutsideURLService } from './outsideURLService';
-import OutsideURLController from './outsideURLController';
-import OutsideURLAuthoringController from './outsideURLAuthoringController';
+import OutsideURLAuthoring from './outsideURLAuthoring';
 
 const outsideURLAuthoringComponentModule = angular
   .module('outsideURLAuthoringComponentModule', [])
   .service('OutsideURLService', downgradeInjectable(OutsideURLService))
-  .controller('OutsideURLController', OutsideURLController)
-  .controller('OutsideURLAuthoringController', OutsideURLAuthoringController)
+  .component('outsideUrlAuthoring', OutsideURLAuthoring)
   .config([
     '$translatePartialLoaderProvider',
     $translatePartialLoaderProvider => {


### PR DESCRIPTION
Test that authoring those components works as before. 

EditComponentController and ComponentAuthoringController are very similar, and will exist together until all the components have been converted to AngularJS component. At that time, we can remove the latter.

Closes #2752 
Closes #2753 
Closes #2754 