### PR TITLE
Fixed issue where assigning scores and comments to components was cau…

### DIFF
--- a/src/main/webapp/wise5/directives/component/component.ts
+++ b/src/main/webapp/wise5/directives/component/component.ts
@@ -11,8 +11,8 @@ class ComponentController {
   componentState: any;
   mode: string;
   nodeId: string;
-  teacherWorkgroupId: number;
-  workgroupId: number;
+  teacherWorkgroupId: string;
+  workgroupId: string;
 
   static $inject = ['$scope', 'ConfigService', 'NodeService', 'NotebookService', 'ProjectService',
       'StudentDataService'];
@@ -55,8 +55,8 @@ class ComponentController {
     this.$scope.componentContent = componentContent;
     this.$scope.componentState = this.componentState;
     this.$scope.nodeId = this.nodeId;
-    this.$scope.workgroupId = this.workgroupId;
-    this.$scope.teacherWorkgroupId = this.teacherWorkgroupId;
+    this.$scope.workgroupId = parseInt(this.workgroupId);
+    this.$scope.teacherWorkgroupId = parseInt(this.teacherWorkgroupId);
     this.$scope.type = componentContent.type;
     this.$scope.nodeController = this.$scope.$parent.nodeController;
   }


### PR DESCRIPTION
This fixes the issues where assigning scores and comments to components caused it to show "Not Assigned" and prevented the teacher from further grading.

The issue had to do with inconsistency in the way we handle toWorkgroupId and fromWorkgroupId. Sometimes it is a string, and sometimes it is a number. This caused the annotation lookup (this.annotations[toWorkgroupId_string]) to return null, even when it does in fact exist in the array.

This is a temporary hot fix. The long term fix should be to always pass in integers from parent component to the child component. I'll create a separate issue for that.

Closes #2766