### PR TITLE
Remove nodeAuthoringController and $scope from editComponentController

### DIFF
--- a/src/main/webapp/wise5/authoringTool/node/node.html
+++ b/src/main/webapp/wise5/authoringTool/node/node.html
@@ -151,8 +151,8 @@
     class='component md-padding'
     style='padding: 0; margin-top: 0; margin-left: 16px;'
     ng-if='nodeAuthoringController.showComponents'>
-  <div id='{{component.id}}' layout='row' style='height: 40px; margin-top: 0; margin-bottom: 0;'>
-    <div style='margin-top: 15px; width: 200px;'>
+  <div id='{{component.id}}' layout='row'>
+    <div style='margin-top: 15px; width: 300px;'>
       <md-checkbox ng-model='nodeAuthoringController.componentsToChecked[component.id]'
           ng-disabled='nodeAuthoringController.insertComponentMode'
           class='md-primary'>
@@ -160,7 +160,7 @@
       </md-checkbox>
     </div>
     <div ng-if='!nodeAuthoringController.insertComponentMode && nodeAuthoringController.showComponentAuthoringViews'>
-      <md-input-container style='margin-top: 0; margin-right: 20px; width: 150px;'>
+      <md-input-container style='margin-top: 0; margin-right: 20px; width: 150px; height: 40px;'>
         <md-button class='topButton md-raised md-primary'
             ng-click='nodeAuthoringController.toggleComponentAdvancedAuthoring(component.id)'>
           <md-icon>build</md-icon>

--- a/src/main/webapp/wise5/authoringTool/node/nodeAuthoringController.ts
+++ b/src/main/webapp/wise5/authoringTool/node/nodeAuthoringController.ts
@@ -42,6 +42,7 @@ class NodeAuthoringController {
   showStepButtons: boolean = true;
   undoStack: any[] = [];
   componentShowSubmitButtonValueChangedSubscription: Subscription;
+  nodeChangedSubscription: Subscription;
 
   static $inject = [
     '$anchorScroll',
@@ -128,12 +129,19 @@ class NodeAuthoringController {
     });
   }
 
+  $onInit() {
+    this.nodeChangedSubscription = this.ProjectService.nodeChanged$.subscribe((doParseProject) => {
+      this.authoringViewNodeChanged(doParseProject);
+    })
+  }
+
   ngOnDestroy() {
     this.unsubscribeAll();
   }
 
   unsubscribeAll() {
     this.componentShowSubmitButtonValueChangedSubscription.unsubscribe();
+    this.nodeChangedSubscription.unsubscribe();
   }
 
   previewStepInNewWindow() {
@@ -590,9 +598,11 @@ class NodeAuthoringController {
     return componentObjects;
   }
 
-  toggleComponentAdvancedAuthoring(componentId) {
+  toggleComponentAdvancedAuthoring(componentId: string) {
     this.showAdvancedComponentAuthoring[componentId] =
         !this.showAdvancedComponentAuthoring[componentId];
+    this.ProjectService.showAdvancedComponentView(componentId,
+      this.showAdvancedComponentAuthoring[componentId]);
   }
 }
 

--- a/src/main/webapp/wise5/components/animation/animationAuthoring.ts
+++ b/src/main/webapp/wise5/components/animation/animationAuthoring.ts
@@ -10,7 +10,6 @@ class AnimationAuthoringController extends EditComponentController {
 
   static $inject = [
     '$filter',
-    '$scope',
     'ConfigService',
     'NodeService',
     'NotificationService',
@@ -21,7 +20,6 @@ class AnimationAuthoringController extends EditComponentController {
 
   constructor(
     $filter,
-    $scope,
     ConfigService,
     NodeService,
     NotificationService,
@@ -30,7 +28,6 @@ class AnimationAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/audioOscillator/audioOscillatorAuthoring.ts
+++ b/src/main/webapp/wise5/components/audioOscillator/audioOscillatorAuthoring.ts
@@ -14,7 +14,6 @@ class AudioOscillatorAuthoringController extends EditComponentController {
 
   static $inject = [
     '$filter',
-    '$scope',
     'ConfigService',
     'NodeService',
     'NotificationService',
@@ -25,7 +24,6 @@ class AudioOscillatorAuthoringController extends EditComponentController {
 
   constructor(
     $filter,
-    $scope,
     ConfigService,
     NodeService,
     NotificationService,
@@ -34,7 +32,6 @@ class AudioOscillatorAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/conceptMap/conceptMapAuthoring.ts
+++ b/src/main/webapp/wise5/components/conceptMap/conceptMapAuthoring.ts
@@ -11,7 +11,6 @@ class ConceptMapAuthoringController extends EditComponentController {
   availableLinks: any[];
 
   static $inject = [
-    '$scope',
     '$filter',
     'ConceptMapService',
     'ConfigService',
@@ -23,7 +22,6 @@ class ConceptMapAuthoringController extends EditComponentController {
   ];
 
   constructor(
-    $scope,
     $filter,
     private ConceptMapService,
     ConfigService,
@@ -34,7 +32,6 @@ class ConceptMapAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/discussion/discussionAuthoring.ts
+++ b/src/main/webapp/wise5/components/discussion/discussionAuthoring.ts
@@ -9,7 +9,6 @@ class DiscussionAuthoringController extends EditComponentController {
   allowedConnectedComponentTypes: any[] = [{ type: 'Discussion' }];
 
   static $inject = [
-    '$scope',
     '$filter',
     'ConfigService',
     'NodeService',
@@ -20,7 +19,6 @@ class DiscussionAuthoringController extends EditComponentController {
   ];
 
   constructor(
-    $scope,
     $filter,
     ConfigService,
     NodeService,
@@ -30,7 +28,6 @@ class DiscussionAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/draw/drawAuthoring.ts
+++ b/src/main/webapp/wise5/components/draw/drawAuthoring.ts
@@ -13,7 +13,6 @@ class DrawAuthoringController extends EditComponentController {
 
   static $inject = [
     '$filter',
-    '$scope',
     'ConfigService',
     'NodeService',
     'NotificationService',
@@ -24,7 +23,6 @@ class DrawAuthoringController extends EditComponentController {
 
   constructor(
     $filter,
-    $scope,
     ConfigService,
     NodeService,
     NotificationService,
@@ -33,7 +31,6 @@ class DrawAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/embedded/embeddedAuthoring.ts
+++ b/src/main/webapp/wise5/components/embedded/embeddedAuthoring.ts
@@ -24,7 +24,6 @@ class EmbeddedAuthoringController extends EditComponentController {
 
   static $inject = [
     '$filter',
-    '$scope',
     'ConfigService',
     'NodeService',
     'NotificationService',
@@ -34,14 +33,13 @@ class EmbeddedAuthoringController extends EditComponentController {
   ];
 
   constructor($filter,
-      $scope,
       ConfigService,
       NodeService,
       NotificationService,
       ProjectAssetService,
       ProjectService,
       UtilService) {
-    super($scope,
+    super(
         $filter,
         ConfigService,
         NodeService,

--- a/src/main/webapp/wise5/components/graph/graphAuthoring.ts
+++ b/src/main/webapp/wise5/components/graph/graphAuthoring.ts
@@ -19,7 +19,6 @@ class GraphAuthoringController extends EditComponentController {
 
   static $inject = [
     '$filter',
-    '$scope',
     'ConfigService',
     'GraphService',
     'NodeService',
@@ -30,7 +29,6 @@ class GraphAuthoringController extends EditComponentController {
   ];
 
   constructor($filter,
-              $scope,
               ConfigService,
               private GraphService,
               NodeService,
@@ -38,7 +36,7 @@ class GraphAuthoringController extends EditComponentController {
               ProjectAssetService,
               ProjectService,
               UtilService) {
-    super($scope,
+    super(
       $filter,
       ConfigService,
       NodeService,
@@ -683,7 +681,7 @@ class GraphAuthoringController extends EditComponentController {
       if (singleSeries.yAxis === yAxisIndex) {
         singleSeries.color = color;
       }
-    } 
+    }
   }
 
   addAnyMissingYAxisFieldsToAllYAxes(yAxis) {

--- a/src/main/webapp/wise5/components/html/htmlAuthoring.ts
+++ b/src/main/webapp/wise5/components/html/htmlAuthoring.ts
@@ -11,7 +11,6 @@ class HTMLAuthoringController extends EditComponentController {
   summernotePromptId: string;
 
   static $inject = [
-    '$scope',
     '$filter',
     '$mdDialog',
     'ConfigService',
@@ -23,7 +22,6 @@ class HTMLAuthoringController extends EditComponentController {
   ];
 
   constructor(
-    $scope,
     $filter,
     private $mdDialog: any,
     ConfigService,
@@ -34,7 +32,6 @@ class HTMLAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/label/labelAuthoring.ts
+++ b/src/main/webapp/wise5/components/label/labelAuthoring.ts
@@ -20,7 +20,6 @@ class LabelAuthoringController extends EditComponentController {
   ];
 
   static $inject = [
-    '$scope',
     '$filter',
     '$window',
     'ConfigService',
@@ -32,7 +31,6 @@ class LabelAuthoringController extends EditComponentController {
   ];
 
   constructor(
-    $scope,
     $filter,
     private $window,
     ConfigService,
@@ -43,7 +41,6 @@ class LabelAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/match/matchAuthoring.ts
+++ b/src/main/webapp/wise5/components/match/matchAuthoring.ts
@@ -9,7 +9,6 @@ class MatchAuthoringController extends EditComponentController {
   defaultSourceBucketId: string = '0';
 
   static $inject = [
-    '$scope',
     '$filter',
     'ConfigService',
     'MatchService',
@@ -22,7 +21,6 @@ class MatchAuthoringController extends EditComponentController {
   ];
 
   constructor(
-    $scope,
     $filter,
     ConfigService,
     private MatchService,
@@ -34,7 +32,6 @@ class MatchAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/multipleChoice/multipleChoiceAuthoring.ts
+++ b/src/main/webapp/wise5/components/multipleChoice/multipleChoiceAuthoring.ts
@@ -15,7 +15,6 @@ class MultipleChoiceAuthoringController extends EditComponentController {
 
   static $inject = [
     '$filter',
-    '$scope',
     'ConfigService',
     'NodeService',
     'NotificationService',
@@ -26,7 +25,6 @@ class MultipleChoiceAuthoringController extends EditComponentController {
 
   constructor(
     $filter,
-    $scope,
     ConfigService,
     NodeService,
     NotificationService,
@@ -35,7 +33,6 @@ class MultipleChoiceAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/openResponse/openResponseAuthoring.ts
+++ b/src/main/webapp/wise5/components/openResponse/openResponseAuthoring.ts
@@ -13,7 +13,6 @@ class OpenResponseAuthoringController extends EditComponentController {
 
   static $inject = [
     '$filter',
-    '$scope',
     'ConfigService',
     'CRaterService',
     'NodeService',
@@ -25,7 +24,6 @@ class OpenResponseAuthoringController extends EditComponentController {
 
   constructor(
     $filter,
-    $scope,
     ConfigService,
     protected CRaterService: CRaterService,
     NodeService,
@@ -35,7 +33,6 @@ class OpenResponseAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/outsideURL/outsideURLAuthoring.ts
+++ b/src/main/webapp/wise5/components/outsideURL/outsideURLAuthoring.ts
@@ -20,7 +20,6 @@ class OutsideURLAuthoringController extends EditComponentController {
   static $inject = [
     '$filter',
     '$sce',
-    '$scope',
     'ConfigService',
     'NodeService',
     'NotificationService',
@@ -33,7 +32,6 @@ class OutsideURLAuthoringController extends EditComponentController {
   constructor(
     $filter,
     private $sce: any,
-    $scope,
     ConfigService,
     NodeService,
     NotificationService,
@@ -43,7 +41,6 @@ class OutsideURLAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/summary/summaryAuthoring.ts
+++ b/src/main/webapp/wise5/components/summary/summaryAuthoring.ts
@@ -12,7 +12,6 @@ class SummaryAuthoringController extends EditComponentController {
   static $inject = [
     '$filter',
     '$injector',
-    '$scope',
     'ConfigService',
     'NodeService',
     'NotificationService',
@@ -25,7 +24,6 @@ class SummaryAuthoringController extends EditComponentController {
   constructor(
     protected $filter,
     protected $injector,
-    protected $scope,
     protected ConfigService,
     protected NodeService,
     protected NotificationService,
@@ -35,7 +33,6 @@ class SummaryAuthoringController extends EditComponentController {
     protected UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,

--- a/src/main/webapp/wise5/components/table/tableAuthoring.ts
+++ b/src/main/webapp/wise5/components/table/tableAuthoring.ts
@@ -22,7 +22,6 @@ class TableAuthoringController extends EditComponentController {
   isDataExplorerBarGraphEnabled: boolean;
 
   static $inject = [
-    '$scope',
     '$filter',
     'ConfigService',
     'NodeService',
@@ -33,7 +32,6 @@ class TableAuthoringController extends EditComponentController {
   ];
 
   constructor(
-    $scope,
     $filter,
     ConfigService,
     NodeService,
@@ -43,7 +41,6 @@ class TableAuthoringController extends EditComponentController {
     UtilService
   ) {
     super(
-      $scope,
       $filter,
       ConfigService,
       NodeService,
@@ -540,7 +537,7 @@ class TableAuthoringController extends EditComponentController {
       }
     }
   }
-  
+
   automaticallySetConnectedComponentFieldsIfPossible(connectedComponent) {
     if (connectedComponent.type === 'importWork' && connectedComponent.action == null) {
       connectedComponent.action = 'merge';

--- a/src/main/webapp/wise5/services/teacherProjectService.ts
+++ b/src/main/webapp/wise5/services/teacherProjectService.ts
@@ -7,16 +7,21 @@ import { UtilService } from '../services/utilService';
 import { Injectable } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClient } from '@angular/common/http';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { SessionService } from './sessionService';
 
 @Injectable()
 export class TeacherProjectService extends ProjectService {
 
+  private nodeChangedSource: Subject<boolean> = new Subject<boolean>();
+  public nodeChanged$: Observable<boolean> = this.nodeChangedSource.asObservable();
   private refreshProjectSource: Subject<void> = new Subject<void>();
   public refreshProject$ = this.refreshProjectSource.asObservable();
   private scrollToBottomOfPageSource: Subject<void> = new Subject<void>();
   public scrollToBottomOfPage$ = this.scrollToBottomOfPageSource.asObservable();
+  private showAdvancedComponentViewSource: Subject<any> = new Subject<any>();
+  public showAdvancedComponentView$: Observable<any> =
+      this.showAdvancedComponentViewSource.asObservable();
 
   constructor(
       protected upgrade: UpgradeModule,
@@ -1263,12 +1268,21 @@ export class TeacherProjectService extends ProjectService {
     return null;
   }
 
+  nodeChanged(doParseProject: boolean = false): void {
+    this.nodeChangedSource.next(doParseProject);
+  }
+
   refreshProject() {
     this.refreshProjectSource.next();
   }
 
   scrollToBottomOfPage() {
     this.scrollToBottomOfPageSource.next();
+  }
+
+  showAdvancedComponentView(componentId: string, isShow: boolean) {
+    this.showAdvancedComponentViewSource
+        .next({componentId: componentId, isShow: isShow});
   }
 
   addTeacherRemovalConstraint(node: any, periodId: number) {


### PR DESCRIPTION
Removing these dependencies will allow us to upgrade this component to Angular.

Instead of doing $scope.$watch for changes to authoringComponentContent, the component authoring components should call authoringViewComponentChanged(). This was already being called from most places, so I figured it was safe to remove the $scope.$watch block.

Test that editing components works as before, especially editing advanced component settings.

Closes #2769