### PR TITLE
Changed workgroupId and teacherWorkgroupId inputs to be numbers

### DIFF
--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.html
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.html
@@ -91,7 +91,7 @@
                     ng-if="$ctrl.isWorkgroupShown(workgroup)"
                     expand="$ctrl.workVisibilityById[workgroup.$key]" max-score="$ctrl.maxScore"
                     show-score="$ctrl.nodeHasWork" node-id="$ctrl.nodeId"
-                    component-id="$ctrl.componentId" workgroup-id="workgroup.$key"
+                    component-id="$ctrl.componentId" workgroup-id="::workgroup.workgroupId"
                     workgroup-data="workgroup" hidden-components="$ctrl.hiddenComponents"
                     on-update-expand="$ctrl.onUpdateExpand(workgroupId, value)"
                     in-view="$ctrl.workgroupInView(workgroup.$key, $inview)"></workgroup-item>

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/workgroupComponentRevisions/workgroupComponentRevisions.ts
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/workgroupComponentRevisions/workgroupComponentRevisions.ts
@@ -159,7 +159,7 @@ const WorkgroupComponentRevisions = {
                         </h3>
                         <div>
                             <component component-state="{{ item.componentState }}"
-                                       workgroup-id="{{ $ctrl.workgroupId }}"
+                                       workgroup-id="::$ctrl.workgroupId"
                                        mode="gradingRevision">
                         </div>
                     </div>

--- a/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/workgroupNodeGrading/workgroupNodeGrading.ts
+++ b/src/main/webapp/wise5/classroomMonitor/classroomMonitorComponents/shared/workgroupNodeGrading/workgroupNodeGrading.ts
@@ -140,8 +140,8 @@ const WorkgroupNodeGrading = {
                                node-id='{{::$ctrl.nodeId}}'
                                component-id='{{::component.id}}'
                                component-state='{{$ctrl.getLatestComponentStateByWorkgroupIdAndComponentId($ctrl.workgroupId, component.id)}}'
-                               workgroup-id='{{::$ctrl.workgroupId}}'
-                               teacher-workgroup-id='{{::$ctrl.teacherWorkgroupId}}'
+                               workgroup-id='::$ctrl.workgroupId'
+                               teacher-workgroup-id='::$ctrl.teacherWorkgroupId'
                                mode='grading'></component>
                 </div>
             </div>

--- a/src/main/webapp/wise5/directives/component/component.ts
+++ b/src/main/webapp/wise5/directives/component/component.ts
@@ -11,8 +11,8 @@ class ComponentController {
   componentState: any;
   mode: string;
   nodeId: string;
-  teacherWorkgroupId: string;
-  workgroupId: string;
+  teacherWorkgroupId: number;
+  workgroupId: number;
 
   static $inject = ['$scope', 'ConfigService', 'NodeService', 'NotebookService', 'ProjectService',
       'StudentDataService'];
@@ -55,8 +55,8 @@ class ComponentController {
     this.$scope.componentContent = componentContent;
     this.$scope.componentState = this.componentState;
     this.$scope.nodeId = this.nodeId;
-    this.$scope.workgroupId = parseInt(this.workgroupId);
-    this.$scope.teacherWorkgroupId = parseInt(this.teacherWorkgroupId);
+    this.$scope.workgroupId = this.workgroupId;
+    this.$scope.teacherWorkgroupId = this.teacherWorkgroupId;
     this.$scope.type = componentContent.type;
     this.$scope.nodeController = this.$scope.$parent.nodeController;
   }
@@ -68,8 +68,8 @@ const Component = {
     componentState: '@',
     mode: '@',
     nodeId: '@',
-    teacherWorkgroupId: '@',
-    workgroupId: '@'
+    teacherWorkgroupId: '<',
+    workgroupId: '<'
   },
   scope: true,
   controller: ComponentController,

--- a/src/main/webapp/wise5/themes/default/node/node.html
+++ b/src/main/webapp/wise5/themes/default/node/node.html
@@ -26,8 +26,8 @@
             <component node-id='{{::nodeController.nodeId}}'
                        component-id='{{::component.id}}'
                        component-state='{{::nodeController.getComponentStateByComponentId(component.id)}}'
-                       workgroup-id='{{::nodeController.workgroupId}}'
-                       teacher-workgroup-id='{{::nodeController.teacherWorkgroupId}}'
+                       workgroup-id='::nodeController.workgroupId'
+                       teacher-workgroup-id='::nodeController.teacherWorkgroupId'
                        mode='student'></component>
         </div>
         <div class="node-content__actions" layout="row" layout-align="start center" flex="100">


### PR DESCRIPTION
These inputs to the component directive will always be a number. 

This fixes the inconsistency in the way we handled toWorkgroupId and fromWorkgroupId. Sometimes it was a string, and sometimes it was a number. This caused the annotation lookup (this.annotations[toWorkgroupId_string]) to return null, even when it does in fact exist in the array. We created a hotfix in #2767. This PR fixes it for good.

Test that grading, viewing revisions, and working on the component as a student work as before.

Closes #2771