### PR TITLE
Disabled run and unit sharing from admin pages

### DIFF
--- a/src/main/webapp/portal/admin/index.jsp
+++ b/src/main/webapp/portal/admin/index.jsp
@@ -172,33 +172,31 @@
 
                     </div>
 
-                    <sec:authorize access="hasRole('ROLE_ADMINISTRATOR')">
-                        <div class="sectionHead">
-                            <spring:message code='admin.index.projectManagement' />
-                        </div>
-                        <div class="sectionContent">
-                            <spring:message code='admin.index.manageProjectBy' />
-                            <form style="display:inline" id="lookupProjectForm" action="${contextPath}/admin/project/manageallprojects.html" method="GET" onsubmit="return validateForm('project')">
-                                <select name="projectLookupType" id="projectLookupType">
-                                    <option value="id"><spring:message code='id' /></option>
-                                    <option value="title"><spring:message code='title' /></option>
-                                    <option value="author"><spring:message code='author' /></option>
-                                </select>
-                                <input type="text" name="projectLookupValue" id="projectLookupValue" size="20"></input>
-                                <input type="Submit" value="Go"></input>
-                            </form> |
-                            <a href="${contextPath}/admin/project/manageallprojects.html">
-                                <spring:message code='admin.index.manageAllProjects' /></a>
-                            <h5>
-                                <a href="${contextPath}/admin/project/currentlyAuthoredProjects">
-                                    <spring:message code='admin.index.viewCurrentAuthors' /></a>
-                            </h5>
-                            <h5>
-                                <a href="${contextPath}/admin/project/import">
-                                    <spring:message code='admin.index.importProject' /></a>
-                            </h5>
-                        </div>
-                    </sec:authorize>
+                    <div class="sectionHead">
+                        <spring:message code='admin.index.projectManagement' />
+                    </div>
+                    <div class="sectionContent">
+                        <spring:message code='admin.index.manageProjectBy' />
+                        <form style="display:inline" id="lookupProjectForm" action="${contextPath}/admin/project/manageallprojects.html" method="GET" onsubmit="return validateForm('project')">
+                            <select name="projectLookupType" id="projectLookupType">
+                                <option value="id"><spring:message code='id' /></option>
+                                <option value="title"><spring:message code='title' /></option>
+                                <option value="author"><spring:message code='author' /></option>
+                            </select>
+                            <input type="text" name="projectLookupValue" id="projectLookupValue" size="20"></input>
+                            <input type="Submit" value="Go"></input>
+                        </form> |
+                        <a href="${contextPath}/admin/project/manageallprojects.html">
+                            <spring:message code='admin.index.manageAllProjects' /></a>
+                        <h5>
+                            <a href="${contextPath}/admin/project/currentlyAuthoredProjects">
+                                <spring:message code='admin.index.viewCurrentAuthors' /></a>
+                        </h5>
+                        <h5>
+                            <a href="${contextPath}/admin/project/import">
+                                <spring:message code='admin.index.importProject' /></a>
+                        </h5>
+                    </div>
 
                     <div class="sectionHead">
                         <spring:message code='misc' />

--- a/src/main/webapp/portal/admin/project/manageallprojects.jsp
+++ b/src/main/webapp/portal/admin/project/manageallprojects.jsp
@@ -149,7 +149,6 @@ function updateMaxTotalAssetsSize(projectId, newMaxTotalAssetsSize) {
 		</td>
 		<td>
 		<a href="${contextPath}/author/authorproject.html?projectId=${project.id}">Edit Project</a><br/>
-		<a href="${contextPath}/teacher/projects/customized/shareproject.html?projectId=${project.id}">Manage Shared Teachers</a><br/>
 		<a href="${contextPath}/project/export/${project.id}">Export project as Zip</a>
 		</td>
 	</tr>

--- a/src/main/webapp/portal/admin/run/manageprojectruns.jsp
+++ b/src/main/webapp/portal/admin/run/manageprojectruns.jsp
@@ -422,9 +422,6 @@
                                                 |&nbsp;<a onclick="if(confirm('<spring:message code="teacher.management.projectruntabs.editWarning"/>')){window.top.location='${contextPath}/author/authorproject.html?projectId=${run.project.id}';} return true;"><img class="icon" alt="edit" src="${contextPath}/<spring:theme code="edit"/>" /><span><spring:message code="teacher.management.projectruntabs.edit"/></span></a>
                                             </li>
                                         </ul>
-                                        <ul class="actionList">
-                                            <li><a id="shareRun_${run.id}" class="shareRun" title="<spring:message code="teacher.management.projectruntabs.sharingPermissionsTitle"/> ${run.name} (<spring:message code="run_id"/> ${run.id})"><img class="icon" alt="share" src="${contextPath}/<spring:theme code="agent"/>" /><span><spring:message code="teacher.management.projectruntabs.sharingPermissions"/></span></a></li>
-                                        </ul>
                                     </td>
                                     <td style="display:none;">${run.starttime}</td>
                                     <td style="display:none;"></td>

--- a/src/main/webapp/portal/admin/run/stats.jsp
+++ b/src/main/webapp/portal/admin/run/stats.jsp
@@ -60,7 +60,6 @@ th {
 			    <td>
 			    	<ul>
 			    		<sec:authorize access="hasRole('ROLE_ADMINISTRATOR')">
-			    		  <li><a href="${contextPath}/teacher/run/shareprojectrun.html?runId=${run.id}"><spring:message code="admin.run.manageSharedTeachers" /></a></li>
 			    		  <li><a href="${contextPath}/teacher/management/viewmystudents?runId=${run.id}"><spring:message code="admin.run.manageStudents" /></a></li>
 			    		</sec:authorize>
 			    	</ul>


### PR DESCRIPTION
Also show Project Management section to researchers.

Test the following:
- run/unit sharing options do not appear in the admin pages.
- researchers (not admins) can view and use the Project Management section  in the admin home page.

Closes #2798