### PR TITLE
Clarify difference between sharing runs and units

### DIFF
--- a/src/main/webapp/site/src/app/features/features.component.scss
+++ b/src/main/webapp/site/src/app/features/features.component.scss
@@ -115,7 +115,3 @@
     margin-left: -16%;
   }
 }
-
-.mat-divider {
-  margin: 16px 0;
-}

--- a/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.ts
@@ -1,17 +1,18 @@
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { LibraryProjectDetailsComponent } from "../library-project-details/library-project-details.component";
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material/dialog';
 import { finalize } from 'rxjs/operators';
 import { LibraryProject } from "../libraryProject";
 import { LibraryService } from "../../../services/library.service";
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-copy-project-dialog',
   templateUrl: './copy-project-dialog.component.html',
   styleUrls: ['./copy-project-dialog.component.scss']
 })
-export class CopyProjectDialogComponent implements OnInit {
+export class CopyProjectDialogComponent {
 
   isCopying: boolean = false;
 
@@ -20,13 +21,9 @@ export class CopyProjectDialogComponent implements OnInit {
               @Inject(MAT_DIALOG_DATA) public data: any,
               private libraryService: LibraryService,
               private snackBar: MatSnackBar) {
-
     this.libraryService.newProjectSource$.subscribe(() => {
       this.dialog.closeAll();
     });
-  }
-
-  ngOnInit() {
   }
 
   copy() {

--- a/src/main/webapp/site/src/app/modules/library/library-project-menu/library-project-menu.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/library-project-menu/library-project-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Project } from '../../../domain/project';
 import { TeacherService } from '../../../teacher/teacher.service';
@@ -59,10 +59,7 @@ export class LibraryProjectMenuComponent implements OnInit {
   }
 
   copyProject() {
-    this.dialog.open(CopyProjectDialogComponent, {
-      data: { project: this.project },
-      panelClass: 'mat-dialog--sm'
-    });
+    this.teacherService.copyProject(this.project);
   }
 
   editProject() {

--- a/src/main/webapp/site/src/app/modules/library/library-project-menu/library-project-menu.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/library-project-menu/library-project-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Project } from '../../../domain/project';
 import { TeacherService } from '../../../teacher/teacher.service';
@@ -13,7 +13,7 @@ import { EditRunWarningDialogComponent } from '../../../teacher/edit-run-warning
   templateUrl: './library-project-menu.component.html',
   styleUrls: ['./library-project-menu.component.scss']
 })
-export class LibraryProjectMenuComponent implements OnInit {
+export class LibraryProjectMenuComponent {
   @Input()
   project: Project;
 
@@ -27,10 +27,10 @@ export class LibraryProjectMenuComponent implements OnInit {
   isChild: boolean = false;
 
   constructor(
-    public dialog: MatDialog,
-    public teacherService: TeacherService,
-    public userService: UserService,
-    public configService: ConfigService
+    private dialog: MatDialog,
+    private teacherService: TeacherService,
+    private userService: UserService,
+    private configService: ConfigService
   ) {}
 
   ngOnInit() {
@@ -59,7 +59,7 @@ export class LibraryProjectMenuComponent implements OnInit {
   }
 
   copyProject() {
-    this.teacherService.copyProject(this.project);
+    this.teacherService.copyProject(this.project, this.dialog);
   }
 
   editProject() {

--- a/src/main/webapp/site/src/app/modules/library/library/library.component.scss
+++ b/src/main/webapp/site/src/app/modules/library/library/library.component.scss
@@ -17,6 +17,10 @@
       margin-right: 8px;
     }
   }
+
+  .mat-divider {
+    margin: 0;
+  }
 }
 
 .library__header {

--- a/src/main/webapp/site/src/app/modules/library/personal-library/personal-library.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/personal-library/personal-library.component.ts
@@ -3,6 +3,7 @@ import { LibraryProject } from "../libraryProject";
 import { LibraryService } from "../../../services/library.service";
 import { LibraryComponent } from "../library/library.component";
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-personal-library',
@@ -15,20 +16,27 @@ export class PersonalLibraryComponent extends LibraryComponent {
   filteredProjects: LibraryProject[] = [];
   personalProjects: LibraryProject[] = [];
   sharedProjects: LibraryProject[] = [];
+  personalLibraryProjectsSourceSubscription: Subscription;
+  sharedLibraryProjectsSourceSubscription: Subscription;
+  newProjectSourceSubscription: Subscription;
 
-  constructor(libraryService: LibraryService, public dialog: MatDialog) {
+  constructor(libraryService: LibraryService, private dialog: MatDialog) {
     super(libraryService);
     this.libraryService = libraryService;
+  }
 
-    this.libraryService.personalLibraryProjectsSource$.subscribe((personalProjects: LibraryProject[]) => {
+  ngOnInit() {
+    this.personalLibraryProjectsSourceSubscription = 
+        this.libraryService.personalLibraryProjectsSource$.subscribe((personalProjects: LibraryProject[]) => {
       this.personalProjects = personalProjects;
       this.updateProjects();
     });
-    this.libraryService.sharedLibraryProjectsSource$.subscribe((sharedProjects: LibraryProject[]) => {
+    this.sharedLibraryProjectsSourceSubscription = 
+        this.libraryService.sharedLibraryProjectsSource$.subscribe((sharedProjects: LibraryProject[]) => {
       this.sharedProjects = sharedProjects;
       this.updateProjects();
     });
-    this.libraryService.newProjectSource$.subscribe(project => {
+    this.newProjectSourceSubscription = this.libraryService.newProjectSource$.subscribe(project => {
       if (project) {
         project.isHighlighted = true;
         this.projects.unshift(project);
@@ -37,7 +45,10 @@ export class PersonalLibraryComponent extends LibraryComponent {
     });
   }
 
-  ngOnInit() {
+  ngOnDestroy() {
+    this.personalLibraryProjectsSourceSubscription.unsubscribe();
+    this.sharedLibraryProjectsSourceSubscription.unsubscribe();
+    this.newProjectSourceSubscription.unsubscribe();
   }
 
   combinePersonalAndSharedProjects() {

--- a/src/main/webapp/site/src/app/modules/library/share-project-dialog/share-project-dialog.component.html
+++ b/src/main/webapp/site/src/app/modules/library/share-project-dialog/share-project-dialog.component.html
@@ -3,8 +3,11 @@
   <p class="mat-subheading-1 accent-1">
     {{ project.name }} <span class="mat-caption" i18n>(Unit ID: {{ project.id }})</span>
   </p>
+  <p><strong i18n>Sharing a curriculum unit allows other WISE teachers to use it with their own students and optionally edit the unit's content.</strong></p>
+  <p i18n>Shared units appear in a teacher's "My Units" library.</p>
+  <mat-divider></mat-divider>
   <mat-form-field appearance="fill">
-    <mat-label i18n>Enter teacher username</mat-label>
+    <mat-label i18n>Find a teacher</mat-label>
     <mat-icon matPrefix>search</mat-icon>
     <input id="share-project-dialog-search"
            type="text"

--- a/src/main/webapp/site/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.html
+++ b/src/main/webapp/site/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.html
@@ -66,5 +66,6 @@
 </mat-dialog-content>
 <mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
   <button mat-button mat-dialog-close i18n>Cancel</button>
-  <button mat-flat-button (click)="launchRun()" [disabled]="!isCanLaunch()" i18n>Launch Unit</button>
+  <button mat-flat-button color="primary" (click)="launchRun()" [disabled]="!isCanLaunch()" 
+          i18n>Launch Unit</button>
 </mat-dialog-actions>

--- a/src/main/webapp/site/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.scss
+++ b/src/main/webapp/site/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.scss
@@ -2,10 +2,6 @@
   display: block !important;
 }
 
-.mat-divider {
-  margin: 16px 0 16px;
-}
-
 .mat-form-field {
   display: block;
 }

--- a/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.scss
+++ b/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.scss
@@ -1,7 +1,3 @@
-.mat-divider {
-  margin: 20px 0 16px;
-}
-
 .period-select {
   margin-right: 24px;
 }

--- a/src/main/webapp/site/src/app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.scss
+++ b/src/main/webapp/site/src/app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.scss
@@ -4,10 +4,6 @@
   '~style/abstracts/variables',
   '~style/abstracts/mixins';
 
-.mat-divider {
-  margin: 20px 0 16px;
-}
-
 h2 {
   .mat-icon {
     @include mat-icon-size(mat-font-size($config, display-1));

--- a/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.html
+++ b/src/main/webapp/site/src/app/teacher/run-menu/run-menu.component.html
@@ -18,8 +18,8 @@
       <span i18n>Unit Info</span>
     </a>
     <a mat-menu-item (click)="shareRun()" *ngIf="canShare() && run.project.wiseVersion !== 4">
-      <mat-icon>share</mat-icon>
-      <span i18n>Share</span>
+      <mat-icon>supervised_user_circle</mat-icon>
+      <span i18n>Share Access</span>
     </a>
     <a mat-menu-item (click)="checkClassroomAuthorization()"
        *ngIf="isGoogleUser() && isGoogleClassroomEnabled() && !isRunCompleted() && run.project.wiseVersion !== 4">

--- a/src/main/webapp/site/src/app/teacher/run-settings-dialog/run-settings-dialog.component.scss
+++ b/src/main/webapp/site/src/app/teacher/run-settings-dialog/run-settings-dialog.component.scss
@@ -1,7 +1,3 @@
-.mat-divider {
-  margin: 20px 0 16px;
-}
-
 .info-block {
   margin-bottom: 16px;
   padding: 4px;

--- a/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.html
+++ b/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.html
@@ -1,4 +1,4 @@
-<h2 *ngIf="!isTransfer" mat-dialog-title i18n>Share Classroom Unit</h2>
+<h2 *ngIf="!isTransfer" mat-dialog-title i18n>Share Classroom Access</h2>
 <h2 *ngIf="isTransfer" 
     mat-dialog-title 
     fxLayoutAlign="start center" 
@@ -13,8 +13,13 @@
     <p class="mat-subheading-1 accent-1">
       {{ run.name }} <span class="mat-caption" i18n>(Run ID: {{ run.id }})</span>
     </p>
+    <ng-container *ngIf="!isTransfer">
+      <p><strong i18n>Sharing access allows other WISE teachers to view student work and optionally view student names, grade, manage teams, and edit unit content.</strong></p>
+      <p i18n>If you have customized the content in this unit and want to share so other teachers can use with their students, <a [routerLink]="" (click)="copyProject()">make a copy</a> of the unit.</p>
+      <mat-divider></mat-divider>
+    </ng-container>
     <mat-form-field appearance="fill" *ngIf="!transferRunWarning">
-      <mat-label i18n>Enter teacher username</mat-label>
+      <mat-label i18n>Find a teacher</mat-label>
       <mat-icon matPrefix>search</mat-icon>
       <input id="share-run-dialog-search"
              type="text"

--- a/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.scss
+++ b/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.scss
@@ -1,7 +1,3 @@
 table, .mat-form-field {
   width: 100%;
 }
-
-table {
-  margin-top: 8px;
-}

--- a/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.spec.ts
+++ b/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.spec.ts
@@ -4,7 +4,7 @@ import { Observable } from "rxjs";
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TeacherService } from "../teacher.service";
 import { Run } from "../../domain/run";
-import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
@@ -85,6 +85,10 @@ describe('ShareRunDialogComponent', () => {
         { provide: TeacherService, useClass: MockTeacherService },
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: { run: runObj } },
+        { provide: MatDialog, useValue: {
+          closeAll: () => {
+          }
+        }},
         { provide: UserService, useClass: MockUserService }
       ],
       schemas: [ NO_ERRORS_SCHEMA ]
@@ -95,6 +99,7 @@ describe('ShareRunDialogComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ShareRunDialogComponent);
     component = fixture.componentInstance;
+    component.dialog = TestBed.get(MatDialog);
     fixture.detectChanges();
   });
 

--- a/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.ts
+++ b/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { TeacherService } from "../teacher.service";
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTableDataSource } from "@angular/material/table";
 import { ShareItemDialogComponent } from "../../modules/library/share-item-dialog/share-item-dialog.component";
@@ -28,7 +28,8 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
               public teacherService: TeacherService,
               private userService: UserService,
               private utilService: UtilService,
-              public snackBar: MatSnackBar) {
+              public snackBar: MatSnackBar,
+              public dialog: MatDialog) {
     super(dialogRef, data, teacherService, snackBar);
     this.teacherService.getRun(this.data.run.id).subscribe((run: TeacherRun) => {
       this.run = new TeacherRun(run);
@@ -184,6 +185,6 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
   }
 
   copyProject() {
-    this.teacherService.copyProject(this.project);
+    this.teacherService.copyProject(this.project, this.dialog);
   }
 }

--- a/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.ts
+++ b/src/main/webapp/site/src/app/teacher/share-run-dialog/share-run-dialog.component.ts
@@ -182,4 +182,8 @@ export class ShareRunDialogComponent extends ShareItemDialogComponent {
     this.transferRunWarning = false;
     this.teacherSearchControl.setValue('');
   }
+
+  copyProject() {
+    this.teacherService.copyProject(this.project);
+  }
 }

--- a/src/main/webapp/site/src/app/teacher/teacher.service.spec.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher.service.spec.ts
@@ -1,13 +1,17 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HttpParams } from '@angular/common/http';
+import { MatDialog } from '@angular/material/dialog';
 import { TeacherService } from './teacher.service';
 
 describe('TeacherService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ HttpClientTestingModule ],
-      providers: [ TeacherService ]
+      providers: [ 
+        TeacherService,
+        { provide: MatDialog, useValue: {}}
+      ]
     });
   });
 

--- a/src/main/webapp/site/src/app/teacher/teacher.service.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher.service.ts
@@ -41,10 +41,10 @@ export class TeacherService {
   public newRunSource$ = this.newRunSource.asObservable();
   private updateProfileUrl = '/api/teacher/profile/update';
 
-  constructor(private http: HttpClient, public dialog: MatDialog) { }
+  constructor(private http: HttpClient) { }
 
-  copyProject(project: Project) {
-    this.dialog.open(CopyProjectDialogComponent, {
+  copyProject(project: Project, dialog: MatDialog) {
+    dialog.open(CopyProjectDialogComponent, {
       data: { project: project },
       panelClass: 'mat-dialog--sm'
     });

--- a/src/main/webapp/site/src/app/teacher/teacher.service.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { MatDialog } from '@angular/material/dialog';
 import { Project } from '../domain/project';
 import { Teacher } from '../domain/teacher';
 import { Run } from '../domain/run';
 import { Course } from '../domain/course';
+import { CopyProjectDialogComponent } from '../modules/library/copy-project-dialog/copy-project-dialog.component';
 
 @Injectable()
 export class TeacherService {
@@ -39,8 +41,15 @@ export class TeacherService {
   public newRunSource$ = this.newRunSource.asObservable();
   private updateProfileUrl = '/api/teacher/profile/update';
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, public dialog: MatDialog) { }
 
+  copyProject(project: Project) {
+    this.dialog.open(CopyProjectDialogComponent, {
+      data: { project: project },
+      panelClass: 'mat-dialog--sm'
+    });
+  }
+  
   getRuns(): Observable<Run[]> {
     const headers = new HttpHeaders({ 'Cache-Control': 'no-cache' });
     return this.http.get<Run[]>(this.runsUrl, { headers: headers });

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -211,11 +211,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">22</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="7f32abe3fc638f65c0d3eb269d478ee49ad41ebe">
@@ -1032,6 +1032,89 @@
           <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
+      <trans-unit datatype="html" id="d1acaeb5fa466988ff526619702c4bf21e0a5e15">
+        <source>Copy Unit</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="2883a2c78d97119d2ab3002336e04da6657a7dfd">
+        <source>(Unit ID: <x equiv-text="{{ data.project.id }}" id="INTERPOLATION"/>)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="459457d652be00e6fe313f88d938d4f063c3b3e0">
+        <source>Copying creates a duplicate that will appear in “My Units”. You will be the owner and can edit the content and share the new unit with other WISE users.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="d7b35c384aecd25a516200d6921836374613dfe7">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/edit-run-warning-dialog/edit-run-warning-dialog.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/student/add-project-dialog/add-project-dialog.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/student/team-sign-in-dialog/team-sign-in-dialog.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
+          <context context-type="linenumber">100</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="1979da7460819153e11d2078244645d94291b69c">
+        <source>Copy</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/library-project-menu/library-project-menu.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
       <trans-unit datatype="html" id="76de164da3c441addbf9b14950150aa869b00fdb">
         <source>Share to Google Classroom</source>
         <context-group purpose="location">
@@ -1117,57 +1200,6 @@
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="d7b35c384aecd25a516200d6921836374613dfe7">
-        <source>Cancel</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
-          <context context-type="linenumber">63</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html</context>
-          <context context-type="linenumber">15</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
-          <context context-type="linenumber">11</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/edit-run-warning-dialog/edit-run-warning-dialog.component.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/student/add-project-dialog/add-project-dialog.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/student/team-sign-in-dialog/team-sign-in-dialog.component.html</context>
-          <context context-type="linenumber">68</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">95</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">62</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component.html</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-      </trans-unit>
       <trans-unit datatype="html" id="f6755cff4957d5c3c89bafce5651f1b6fa2b1fd9">
         <source>Add</source>
         <context-group purpose="location">
@@ -1205,11 +1237,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">70</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">97</context>
+          <context context-type="linenumber">102</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
@@ -1564,33 +1596,47 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="ee4d90b52495d483667dffbd2236c15b0c722cbb">
-        <source>Enter teacher username</source>
+      <trans-unit datatype="html" id="e37f493e816aac1bba5e9c25e50efb4ea9e357cf">
+        <source>Sharing a curriculum unit allows other WISE teachers to use it with their own students and optionally edit the unit's content.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="6324a3a991d13ea5359329e8ab667c8969f81e16">
+        <source>Shared units appear in a teacher's "My Units" library.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
           <context context-type="linenumber">7</context>
         </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="d05f250fb7d4cc9b770a9efb7be3d54aef3014cf">
+        <source>Find a teacher</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="39e715b9ebc52d3b9c9a0b629419034bf1610efa">
         <source>Teacher is already on shared list.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">27</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="cff1428d10d59d14e45edec3c735a27b5482db59">
         <source>Name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/contact/contact-form/contact-form.component.html</context>
@@ -1598,90 +1644,58 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="53ea2772322e7d4d21515bb0c6dead283f8e18a5">
         <source>Revoke</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">52</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit datatype="html" id="70f45880fce6ac5d8e468e25e82aefbba8098cfe">
-        <source>Permissions</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
           <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
+      <trans-unit datatype="html" id="70f45880fce6ac5d8e468e25e82aefbba8098cfe">
+        <source>Permissions</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
       <trans-unit datatype="html" id="e4c62e79146aa053669046c6d0d40e889049f8a1">
         <source>Owner. Full permissions.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">50</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">64</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="6bd0461d56d457667267858196994feefee0de48">
         <source>View &amp; Use with Students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">55</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="66b2e8f48c13af491ad76683bc68fb0b07df83c4">
         <source>Edit Unit Content</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">59</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">76</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit datatype="html" id="d1acaeb5fa466988ff526619702c4bf21e0a5e15">
-        <source>Copy Unit</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
-          <context context-type="linenumber">1</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit datatype="html" id="2883a2c78d97119d2ab3002336e04da6657a7dfd">
-        <source>(Unit ID: <x equiv-text="{{ data.project.id }}" id="INTERPOLATION"/>)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
-          <context context-type="linenumber">5</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit datatype="html" id="459457d652be00e6fe313f88d938d4f063c3b3e0">
-        <source>Copying creates a duplicate that will appear in “My Units”. You will be the owner and can edit the content and share the new unit with other WISE users.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
-          <context context-type="linenumber">7</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit datatype="html" id="1979da7460819153e11d2078244645d94291b69c">
-        <source>Copy</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
-          <context context-type="linenumber">17</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/library/library-project-menu/library-project-menu.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="4c49a9bb7a99a9da256c6e678cbb49baa70e268a">
@@ -1728,7 +1742,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="77bd1ad738d92e35036a6caa0afba8152299876b">
@@ -1750,10 +1764,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/library-project-menu/library-project-menu.component.html</context>
           <context context-type="linenumber">17</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/run-menu/run-menu.component.html</context>
-          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="1ada756975a68f38f92477600b2ca2864ea89533">
@@ -5101,7 +5111,7 @@
         <source>Launch Unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/team-sign-in-dialog/team-sign-in-dialog.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">70</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="dbe6d72ccb1cef61c338292357b793077b7ed08a">
@@ -5407,8 +5417,8 @@
           <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="a164f074813172df85048d4ce91c4e922abfcdf9">
-        <source>Share Classroom Unit</source>
+      <trans-unit datatype="html" id="88d53bd596808b844983e5bb4ec7b23a032ab84b">
+        <source>Share Classroom Access</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
           <context context-type="linenumber">1</context>
@@ -5421,46 +5431,60 @@
           <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
+      <trans-unit datatype="html" id="024fbeb663ba44da37aa2e09552c26e13d489420">
+        <source>Sharing access allows other WISE teachers to view student work and optionally view student names, grade, manage teams, and edit unit content.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="07ea4c59d728355192870ed4608485551a2c376c">
+        <source>If you have customized the content in this unit and want to share so other teachers can use with their students, <x ctype="x-a" equiv-text="&lt;a&gt;" id="START_LINK"/>make a copy<x ctype="x-a" equiv-text="&lt;/a&gt;" id="CLOSE_LINK"/> of the unit.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
       <trans-unit datatype="html" id="ba04cd26cfc1093921e7196b9c934a2e45c5ca2d">
         <source>View Student Work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">69</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="93315f528b07c5cc6aa5eba3c97ac7815711d320">
         <source>View Student Names</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="f95fae4dbd1692e5faa4c26a1c3b6ea1ae55f862">
         <source>Grade and Manage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="b26220770d5f6b450e9df4fbcadd454f492b7872">
         <source>Are you sure you want to make <x equiv-text="{{teacherSearchControl.value}}" id="INTERPOLATION"/> the new owner of this unit?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="5b45cfc4c7c5c38692885d9d8eb056f42dd48a05">
         <source>You will still be able to access the unit but the new owner will have the ability to take away or change your access permissions.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="987c58bf54a75a2dad4d366b6546d80749bc5a30">
         <source>Transfer Ownership</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">94</context>
+          <context context-type="linenumber">99</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="a2a99d70cee0c47626832a30636f0ede3c84c2eb">
@@ -5566,6 +5590,13 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/run-menu/run-menu.component.html</context>
           <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="c182679b176fe796dea0ffeba15359edec6fffbc">
+        <source>Share Access</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/run-menu/run-menu.component.html</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="6a7bd392c66daf784d909ea00e8530e93c232dd6">

--- a/src/main/webapp/site/src/style/abstracts/_mixins.scss
+++ b/src/main/webapp/site/src/style/abstracts/_mixins.scss
@@ -91,6 +91,10 @@
     }
   }
 
+  .mat-divider {
+    margin: 16px 0;
+  }
+
   .mat-card-actions {
     margin-left: 0;
     margin-right: 0;
@@ -102,6 +106,10 @@
 
     >.mat-card-actions:last-child {
       margin-bottom: 0;
+    }
+
+    .mat-divider {
+      margin: 0;
     }
   }
 

--- a/src/main/webapp/site/src/style/components/_dialog.scss
+++ b/src/main/webapp/site/src/style/components/_dialog.scss
@@ -5,6 +5,7 @@
   .mat-dialog-content {
     margin: 0 -16px;
     padding: 0 16px;
+    font-size: mat-font-size($config, body-1);
   }
 
   .mat-dialog-content--scroll {
@@ -35,6 +36,6 @@
 
 .cdk-overlay-pane {
   @media (max-width: breakpoint('xs.max')) {
-    max-width: 90vw;
+    max-width: 95vw;
   }
 }

--- a/src/main/webapp/site/src/style/components/_menu.scss
+++ b/src/main/webapp/site/src/style/components/_menu.scss
@@ -1,5 +1,1 @@
-.mat-menu-content {
-  .mat-divider {
-    margin: 8px 0;
-  }
-}
+


### PR DESCRIPTION
To test:
- Verify that share run option in run menu now reads "Share Access" (instead of "Share") and has new icon
- Verify that share run dialog title is now "Share Classroom Access" (instead of "Share Classroom Unit")
- Review new text in share run dialog that explains functionality and ensure that sharing runs still works
- Verify that you can copy a unit by clicking "create a copy" link text in share run dialog
- Verify that copying a unit from unit menu (in the unit libraries) still works properly
- Review new text in share unit dialog that explains functionality and ensure that sharing units still works

Closes #2787 .