### PR TITLE
Added Serializer for Achievement

### DIFF
--- a/src/main/java/org/wise/portal/service/work/AchievementJsonModule.java
+++ b/src/main/java/org/wise/portal/service/work/AchievementJsonModule.java
@@ -1,0 +1,21 @@
+package org.wise.portal.service.work;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.wise.vle.domain.achievement.Achievement;
+import org.wise.vle.domain.achievement.AchievementSerializer;
+
+@Service
+public class AchievementJsonModule extends SimpleModule {
+
+  private static final long serialVersionUID = 1L;
+
+  public AchievementJsonModule() {}
+
+  @Autowired
+  public AchievementJsonModule(AchievementSerializer serializer) {
+    this.addSerializer(Achievement.class, serializer);
+  }
+}

--- a/src/main/java/org/wise/vle/domain/achievement/Achievement.java
+++ b/src/main/java/org/wise/vle/domain/achievement/Achievement.java
@@ -96,40 +96,19 @@ public class Achievement extends PersistableDomain {
 
   public JSONObject toJSON() {
     JSONObject achievementJSONObject = new JSONObject();
-
     try {
       if (id != null) {
         achievementJSONObject.put("id", id);
       }
-
-      if (run != null) {
-        Long runId = run.getId();
-        achievementJSONObject.put("runId", runId);
-      }
-
-      if (workgroup != null) {
-        Long workgroupId = workgroup.getId();
-        achievementJSONObject.put("workgroupId", workgroupId);
-      }
-
-      if (achievementId != null) {
-        achievementJSONObject.put("achievementId", achievementId);
-      }
-
-      if (type != null) {
-        achievementJSONObject.put("type", type);
-      }
-
-      if (achievementTime != null) {
-        achievementJSONObject.put("achievementTime", achievementTime.getTime());
-      }
-
-      if (data != null) {
-        try {
-          achievementJSONObject.put("data", new JSONObject(data));
-        } catch (JSONException e) {
-          achievementJSONObject.put("data", data);
-        }
+      achievementJSONObject.put("runId", run.getId());
+      achievementJSONObject.put("workgroupId", workgroup.getId());
+      achievementJSONObject.put("achievementId", achievementId);
+      achievementJSONObject.put("type", type);
+      achievementJSONObject.put("achievementTime", achievementTime.getTime());
+      try {
+        achievementJSONObject.put("data", new JSONObject(data));
+      } catch (JSONException e) {
+        achievementJSONObject.put("data", data);
       }
     } catch (JSONException e) {
       e.printStackTrace();

--- a/src/main/java/org/wise/vle/domain/achievement/AchievementSerializer.java
+++ b/src/main/java/org/wise/vle/domain/achievement/AchievementSerializer.java
@@ -1,0 +1,30 @@
+package org.wise.vle.domain.achievement;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AchievementSerializer extends JsonSerializer<Achievement> {
+
+  @Override
+  public void serialize(Achievement achievement, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeStartObject();
+    gen.writeObjectField("id", achievement.getId());
+    gen.writeObjectField("runId", achievement.getRun().getId());
+    gen.writeObjectField("workgroupId", achievement.getWorkgroup().getId());
+    gen.writeObjectField("achievementId", achievement.getAchievementId());
+    gen.writeObjectField("type", achievement.getType());
+    gen.writeObjectField("achievementTime", achievement.getAchievementTime().getTime());
+    String data = achievement.getData();
+    ObjectMapper mapper = new ObjectMapper();
+    gen.writeObjectField("data", mapper.readTree(data));
+    gen.writeEndObject();
+  }
+}

--- a/src/main/java/org/wise/vle/web/wise5/AchievementController.java
+++ b/src/main/java/org/wise/vle/web/wise5/AchievementController.java
@@ -1,0 +1,118 @@
+package org.wise.vle.web.wise5;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.run.RunService;
+import org.wise.portal.service.user.UserService;
+import org.wise.portal.service.vle.wise5.VLEService;
+import org.wise.portal.service.workgroup.WorkgroupService;
+import org.wise.portal.spring.data.redis.MessagePublisher;
+import org.wise.vle.domain.achievement.Achievement;
+
+@RestController
+public class AchievementController {
+
+  @Autowired
+  private MessagePublisher redisPublisher;
+
+  @Autowired
+  private RunService runService;
+
+  @Autowired
+  private UserService userService;
+
+  @Autowired
+  private VLEService vleService;
+
+  @Autowired
+  private WorkgroupService workgroupService;
+
+  @GetMapping("/achievement/{runId}")
+  public List<Achievement> getWISE5StudentAchievements(@PathVariable Integer runId,
+      @RequestParam(value = "id", required = false) Integer id,
+      @RequestParam(value = "workgroupId", required = false) Integer workgroupId,
+      @RequestParam(value = "achievementId", required = false) String achievementId,
+      @RequestParam(value = "type", required = false) String type,
+      Authentication auth) throws ObjectNotFoundException {
+    User user = userService.retrieveUserByUsername(auth.getName());
+    Workgroup workgroup = null;
+    Run run = runService.retrieveById(new Long(runId));
+    if (workgroupId != null) {
+      workgroup = workgroupService.retrieveById(new Long(workgroupId));
+    }
+    if (!isAssociatedWithRun(run, user, workgroup)) {
+      throw new AccessDeniedException("Not associated with run");
+    }
+    return vleService.getAchievements(id, runId, workgroupId, achievementId, type);
+  }
+
+  private Boolean isAssociatedWithRun(Run run, User user, Workgroup workgroup) {
+    return isStudentAssociatedWithRun(run, user, workgroup)
+        || isTeacherAssociatedWithRun(run, user);
+  }
+
+  private Boolean isStudentAssociatedWithRun(Run run, User user, Workgroup workgroup) {
+    return user.isStudent() && run.isStudentAssociatedToThisRun(user)
+        && workgroupService.isUserInWorkgroupForRun(user, run, workgroup);
+  }
+
+  private Boolean isTeacherAssociatedWithRun(Run run, User user) {
+    return (user.isTeacher() && run.isTeacherAssociatedToThisRun(user)) || user.isAdmin();
+  }
+
+  @PostMapping("/achievement/{runId}")
+  public Achievement saveAchievement(@PathVariable Integer runId,
+      @RequestParam(value = "id", required = false) Integer id,
+      @RequestParam(value = "workgroupId", required = true) Integer workgroupId,
+      @RequestParam(value = "achievementId", required = true) String achievementId,
+      @RequestParam(value = "type", required = true) String type,
+      @RequestParam(value = "data", required = true) String data,
+      Authentication auth) throws JSONException, ObjectNotFoundException, IOException {
+    User user = userService.retrieveUserByUsername(auth.getName());
+    Run run = runService.retrieveById(new Long(runId));
+    Workgroup workgroup = workgroupService.retrieveById(new Long(workgroupId));
+    if (isAllowedToSave(run, user, workgroup)) {
+      Achievement achievement = vleService.saveAchievement(id, runId, workgroupId, achievementId,
+          type, data);
+      achievement.convertToClientAchievement();
+      broadcastAchievementToTeacher(achievement);
+      return achievement;
+    }
+    throw new AccessDeniedException("Not allowed to save achievement");
+  }
+
+  private boolean isAllowedToSave(Run run, User user, Workgroup workgroup) {
+    if (user.isStudent() && run.isStudentAssociatedToThisRun(user) &&
+        workgroupService.isUserInWorkgroupForRun(user, run, workgroup)) {
+      return true;
+    } else if (user.isTeacher() &&
+        (run.getOwner().equals(user) || run.getSharedowners().contains(user))) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public void broadcastAchievementToTeacher(Achievement achievement) throws JSONException {
+    JSONObject message = new JSONObject();
+    message.put("type", "achievementToTeacher");
+    message.put("topic", String.format("/topic/teacher/%s", achievement.getRunId()));
+    message.put("achievement", achievement.toJSON());
+    redisPublisher.publish(message.toString());
+  }
+}

--- a/src/test/java/org/wise/portal/domain/work/AchievementTest.java
+++ b/src/test/java/org/wise/portal/domain/work/AchievementTest.java
@@ -1,0 +1,50 @@
+package org.wise.portal.domain.work;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Timestamp;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.easymock.EasyMockRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.domain.DomainTest;
+import org.wise.portal.service.work.AchievementJsonModule;
+import org.wise.vle.domain.achievement.Achievement;
+import org.wise.vle.domain.achievement.AchievementSerializer;
+
+@RunWith(EasyMockRunner.class)
+public class AchievementTest extends DomainTest {
+
+  Achievement achievement;
+
+  ObjectMapper mapper;
+
+  AchievementJsonModule jsonModule = new AchievementJsonModule();
+
+  @Before
+  public void setup() {
+    super.setup();
+    jsonModule.addSerializer(Achievement.class, new AchievementSerializer());
+    mapper = new ObjectMapper();
+    mapper.registerModule(jsonModule);
+    achievement = new Achievement();
+    achievement.setId(12);
+    achievement.setRun(run);
+    achievement.setWorkgroup(workgroup);
+    achievement.setAchievementId("achievement_1");
+    achievement.setType("milestoneReport");
+    achievement.setData("{}");
+    achievement.setAchievementTime(new Timestamp(1L));
+  }
+
+  @Test
+  public void serialize() throws JsonProcessingException {
+    String json = mapper.writeValueAsString(achievement);
+    assertEquals("{\"id\":12,\"runId\":1,\"workgroupId\":64,\"achievementId\":\"achievement_1\"," +
+        "\"type\":\"milestoneReport\",\"achievementTime\":1,\"data\":{}}", json);
+  }
+}


### PR DESCRIPTION
Also extracted Achievement-related methods from StudentDataController into AchievementController.

I left Achievement.toJSON() method because it is still being used to send WebSocket payload in broadcastAchievementToTeacher method. The way we handle WebSocket payload is a bit different from HTTP payload. This should be refactored separately later.

Test that saving and retrieving Achievements work as before in these scenarios:
- loading student vle should retrieve student's achievements.
- loading teacher grading tool should retrieve all the achievements for a run.
- completing a milestone activity (e.g. CRater) should create a new achievement. It should also send that Achievement to the teacher's grading tool in real-time and update the Milestone view.

Closes #2815