### PR TITLE
Extracted and upgraded advanced component authoring: width, max-score, tags

### DIFF
--- a/src/main/webapp/site/src/app/authoring-tool/edit-component-json/edit-component-json.component.html
+++ b/src/main/webapp/site/src/app/authoring-tool/edit-component-json/edit-component-json.component.html
@@ -10,7 +10,7 @@
   <span i18n>Close the JSON view to save the changes</span>
   <mat-form-field fxFlex appearance="outline">
     <mat-label i18n>Edit Component JSON</mat-label>
-    <textarea class="mat-body-1" matInput cdkTextareaAutosize  [(ngModel)]="componentContentJSONString"
+    <textarea class="mat-body-1" matInput cdkTextareaAutosize [(ngModel)]="componentContentJSONString"
         (ngModelChange)='jsonChanged.next($event)'></textarea>
   </mat-form-field>
 </div>

--- a/src/main/webapp/site/src/app/authoring-tool/edit-component-max-score/edit-component-max-score.component.html
+++ b/src/main/webapp/site/src/app/authoring-tool/edit-component-max-score/edit-component-max-score.component.html
@@ -1,0 +1,7 @@
+<mat-form-field>
+  <mat-label i18n>Max Score</mat-label>
+  <input matInput
+         type='number'
+         [(ngModel)]='authoringComponentContent.maxScore'
+         (ngModelChange)='maxScoreChanged.next($event)'/>
+</mat-form-field>

--- a/src/main/webapp/site/src/app/authoring-tool/edit-component-max-score/edit-component-max-score.component.ts
+++ b/src/main/webapp/site/src/app/authoring-tool/edit-component-max-score/edit-component-max-score.component.ts
@@ -1,0 +1,34 @@
+import { Component, Input } from "@angular/core";
+import { Subject, Subscription } from "rxjs";
+import { debounceTime, distinctUntilChanged } from "rxjs/operators";
+import { TeacherProjectService } from "../../../../../wise5/services/teacherProjectService";
+
+@Component({
+  selector: 'edit-component-max-score',
+  templateUrl: 'edit-component-max-score.component.html'
+})
+export class EditComponentMaxScoreComponent {
+
+  @Input()
+  authoringComponentContent: any;
+  maxScoreChanged: Subject<string> = new Subject<string>();
+  maxScoreChangedSubscription: Subscription;
+
+  constructor(private ProjectService: TeacherProjectService) {
+  }
+
+  ngOnInit() {
+    this.maxScoreChangedSubscription = this.maxScoreChanged
+        .pipe(
+          debounceTime(1000),
+          distinctUntilChanged()
+        )
+        .subscribe(() => {
+          this.ProjectService.componentChanged();
+        });
+  }
+
+  ngOnDestroy() {
+    this.maxScoreChangedSubscription.unsubscribe();
+  }
+}

--- a/src/main/webapp/site/src/app/authoring-tool/edit-component-tags/edit-component-tags.component.html
+++ b/src/main/webapp/site/src/app/authoring-tool/edit-component-tags/edit-component-tags.component.html
@@ -1,0 +1,44 @@
+<div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="start center">
+  <mat-label class="node__label--vertical-alignment" i18n>Tags</mat-label>
+  <button mat-button
+      class="topButton mat-raised-button mat-primary"
+      matTooltip="Add Tag"
+      i18n-matTooltip
+      matTooltipPosition="above"
+      (click)="addTag()">
+    <mat-icon>add</mat-icon>
+  </button>
+</div>
+<div *ngFor="let tag of authoringComponentContent.tags; let i = index"
+    fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="start center" style="margin-top: 16px">
+  <mat-form-field>
+    <mat-label i18n>Tag Name</mat-label>
+    <input matInput
+            [ngModel]="tag"
+            (ngModelChange)="tagChanged.next({tagIndex: i, tag: $event})"/>
+  </mat-form-field>
+  <button mat-button
+      class="moveComponentButton mat-raised-button mat-primary"
+      matTooltip="Move Up"
+      i18n-matTooltip
+      matTooltipPosition="above"
+      (click)="moveTagUp(i)">
+    <mat-icon>arrow_upward</mat-icon>
+  </button>
+  <button mat-button
+      class="moveComponentButton mat-raised-button mat-primary"
+      matTooltip="Move Down"
+      i18n-matTooltip
+      matTooltipPosition="above"
+      (click)="moveTagDown(i)">
+    <mat-icon>arrow_downward</mat-icon>
+  </button>
+  <button mat-button
+      class="moveComponentButton mat-raised-button mat-primary"
+      matTooltip="Delete"
+      i18n-matTooltip
+      matTooltipPosition="above"
+      (click)="deleteTag(i)">
+    <mat-icon>delete</mat-icon>
+  </button>
+</div>

--- a/src/main/webapp/site/src/app/authoring-tool/edit-component-tags/edit-component-tags.component.ts
+++ b/src/main/webapp/site/src/app/authoring-tool/edit-component-tags/edit-component-tags.component.ts
@@ -1,0 +1,70 @@
+import { Component, Input } from "@angular/core";
+import { UpgradeModule } from "@angular/upgrade/static";
+import { Subject, Subscription } from "rxjs";
+import { debounceTime, distinctUntilChanged } from "rxjs/operators";
+import { TeacherProjectService } from "../../../../../wise5/services/teacherProjectService";
+
+@Component({
+  selector: 'edit-component-tags',
+  templateUrl: 'edit-component-tags.component.html'
+})
+export class EditComponentTagsComponent {
+
+  @Input()
+  authoringComponentContent: any;
+  tagChanged: Subject<any> = new Subject<any>();
+  tagChangedSubscription: Subscription;
+
+  constructor(private ProjectService: TeacherProjectService, private upgrade: UpgradeModule) {
+  }
+
+  ngOnInit() {
+    this.tagChangedSubscription = this.tagChanged
+        .pipe(
+          debounceTime(1000),
+          distinctUntilChanged()
+        )
+        .subscribe(({tagIndex, tag}) => {
+          this.authoringComponentContent.tags[tagIndex] = tag;
+          this.ProjectService.componentChanged();
+        });
+  }
+
+  ngOnDestroy() {
+    this.tagChangedSubscription.unsubscribe();
+  }
+
+  addTag() {
+    if (this.authoringComponentContent.tags == null) {
+      this.authoringComponentContent.tags = [];
+    }
+    this.authoringComponentContent.tags.push('');
+    this.ProjectService.componentChanged();
+  }
+
+  moveTagUp(index: number) {
+    if (index > 0) {
+      const tag = this.authoringComponentContent.tags[index];
+      this.authoringComponentContent.tags.splice(index, 1);
+      this.authoringComponentContent.tags.splice(index - 1, 0, tag);
+      this.ProjectService.componentChanged();
+    }
+  }
+
+  moveTagDown(index: number) {
+    if (index < this.authoringComponentContent.tags.length - 1) {
+      const tag = this.authoringComponentContent.tags[index];
+      this.authoringComponentContent.tags.splice(index, 1);
+      this.authoringComponentContent.tags.splice(index + 1, 0, tag);
+      this.ProjectService.componentChanged();
+    }
+  }
+
+  deleteTag(indexOfTagToDelete: number) {
+    if (confirm(
+        this.upgrade.$injector.get('$filter')('translate')('areYouSureYouWantToDeleteThisTag'))) {
+      this.authoringComponentContent.tags.splice(indexOfTagToDelete, 1);
+      this.ProjectService.componentChanged();
+    }
+  }
+}

--- a/src/main/webapp/site/src/app/authoring-tool/edit-component-width/edit-component-width.component.html
+++ b/src/main/webapp/site/src/app/authoring-tool/edit-component-width/edit-component-width.component.html
@@ -1,0 +1,7 @@
+<mat-form-field>
+  <mat-label i18n>Component Width</mat-label>
+  <input matInput
+         type='number'
+         [(ngModel)]='authoringComponentContent.componentWidth'
+         (ngModelChange)='widthChanged.next($event)'/>
+</mat-form-field>

--- a/src/main/webapp/site/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
+++ b/src/main/webapp/site/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
@@ -1,0 +1,34 @@
+import { Component, Input } from "@angular/core";
+import { Subject, Subscription } from "rxjs";
+import { debounceTime, distinctUntilChanged } from "rxjs/operators";
+import { TeacherProjectService } from "../../../../../wise5/services/teacherProjectService";
+
+@Component({
+  selector: 'edit-component-width',
+  templateUrl: 'edit-component-width.component.html'
+})
+export class EditComponentWidthComponent {
+
+  @Input()
+  authoringComponentContent: any;
+  widthChanged: Subject<string> = new Subject<string>();
+  widthChangedSubscription: Subscription;
+
+  constructor(private ProjectService: TeacherProjectService) {
+  }
+
+  ngOnInit() {
+    this.widthChangedSubscription = this.widthChanged
+        .pipe(
+          debounceTime(1000),
+          distinctUntilChanged()
+        )
+        .subscribe(() => {
+          this.ProjectService.componentChanged();
+        });
+  }
+
+  ngOnDestroy() {
+    this.widthChangedSubscription.unsubscribe();
+  }
+}

--- a/src/main/webapp/site/src/app/teacher-hybrid-angular.module.ts
+++ b/src/main/webapp/site/src/app/teacher-hybrid-angular.module.ts
@@ -30,8 +30,9 @@ import { NodeAdvancedGeneralAuthoringComponent } from '../../../wise5/authoringT
 import { WiseAuthoringTinymceEditorComponent } from '../../../wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component';
 import { EditComponentJsonComponent } from './authoring-tool/edit-component-json/edit-component-json.component';
 import { EditComponentMaxScoreComponent } from './authoring-tool/edit-component-max-score/edit-component-max-score.component';
-import { EditComponentWidthComponent } from './authoring-tool/edit-component-width/edit-component-width.component';
 import { EditComponentRubricComponent } from './authoring-tool/edit-component-rubric/edit-component-rubric.component';
+import { EditComponentTagsComponent } from './authoring-tool/edit-component-tags/edit-component-tags.component';
+import { EditComponentWidthComponent } from './authoring-tool/edit-component-width/edit-component-width.component';
 import { RubricAuthoringComponent } from '../../../wise5/authoringTool/rubric/rubric-authoring.component';
 
 @NgModule({
@@ -45,6 +46,7 @@ import { RubricAuthoringComponent } from '../../../wise5/authoringTool/rubric/ru
     EditComponentRubricComponent,
     EditComponentJsonComponent,
     EditComponentMaxScoreComponent,
+    EditComponentTagsComponent,
     EditComponentWidthComponent,
     ManageStudentsComponent,
     MilestoneReportDataComponent,

--- a/src/main/webapp/site/src/app/teacher-hybrid-angular.module.ts
+++ b/src/main/webapp/site/src/app/teacher-hybrid-angular.module.ts
@@ -31,6 +31,7 @@ import { WiseAuthoringTinymceEditorComponent } from '../../../wise5/directives/w
 import { EditComponentRubricComponent } from './authoring-tool/edit-component-rubric/edit-component-rubric.component';
 import { EditComponentJsonComponent } from './authoring-tool/edit-component-json/edit-component-json.component';
 import { RubricAuthoringComponent } from '../../../wise5/authoringTool/rubric/rubric-authoring.component';
+import { EditComponentWidthComponent } from './authoring-tool/edit-component-width/edit-component-width.component';
 
 @NgModule({
   declarations: [
@@ -42,6 +43,7 @@ import { RubricAuthoringComponent } from '../../../wise5/authoringTool/rubric/ru
     ComponentNewWorkBadgeComponent,
     EditComponentRubricComponent,
     EditComponentJsonComponent,
+    EditComponentWidthComponent,
     ManageStudentsComponent,
     MilestoneReportDataComponent,
     NodeAdvancedGeneralAuthoringComponent,

--- a/src/main/webapp/site/src/app/teacher-hybrid-angular.module.ts
+++ b/src/main/webapp/site/src/app/teacher-hybrid-angular.module.ts
@@ -28,10 +28,11 @@ import { NodeAdvancedJsonAuthoringComponent } from '../../../wise5/authoringTool
 import { WorkgroupInfoComponent } from '../../../wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component';
 import { NodeAdvancedGeneralAuthoringComponent } from '../../../wise5/authoringTool/node/advanced/general/node-advanced-general-authoring.component';
 import { WiseAuthoringTinymceEditorComponent } from '../../../wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component';
-import { EditComponentRubricComponent } from './authoring-tool/edit-component-rubric/edit-component-rubric.component';
 import { EditComponentJsonComponent } from './authoring-tool/edit-component-json/edit-component-json.component';
-import { RubricAuthoringComponent } from '../../../wise5/authoringTool/rubric/rubric-authoring.component';
+import { EditComponentMaxScoreComponent } from './authoring-tool/edit-component-max-score/edit-component-max-score.component';
 import { EditComponentWidthComponent } from './authoring-tool/edit-component-width/edit-component-width.component';
+import { EditComponentRubricComponent } from './authoring-tool/edit-component-rubric/edit-component-rubric.component';
+import { RubricAuthoringComponent } from '../../../wise5/authoringTool/rubric/rubric-authoring.component';
 
 @NgModule({
   declarations: [
@@ -43,6 +44,7 @@ import { EditComponentWidthComponent } from './authoring-tool/edit-component-wid
     ComponentNewWorkBadgeComponent,
     EditComponentRubricComponent,
     EditComponentJsonComponent,
+    EditComponentMaxScoreComponent,
     EditComponentWidthComponent,
     ManageStudentsComponent,
     MilestoneReportDataComponent,

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -6003,6 +6003,20 @@
           <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
+      <trans-unit datatype="html" id="2af3e40232b763ae8a6cba9f4bb455ed49d4f86c">
+        <source>Max Score</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/edit-component-max-score/edit-component-max-score.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="2485299eb70909a6cfa961bfac54f062a220806c">
+        <source>Component Width</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/edit-component-width/edit-component-width.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
       <trans-unit datatype="html" id="bfab7f41cfc32a926c55987d6a9c3349ae417131">
         <source> Show Save Button </source>
         <context-group purpose="location">

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -6010,6 +6010,48 @@
           <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
+      <trans-unit datatype="html" id="cafc87479686947e2590b9f588a88040aeaf660b">
+        <source>Tags</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/edit-component-tags/edit-component-tags.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="d9a6d2f30e57a02a6b36a7773c39a3791c42ae9c">
+        <source>Add Tag</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/edit-component-tags/edit-component-tags.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="f339508e35745934e4cfe06c1f4eb888b0fda212">
+        <source>Tag Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/edit-component-tags/edit-component-tags.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="ab36fe6b1ac84106333447d7c1c4e20fb79c7de3">
+        <source>Move Up</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/edit-component-tags/edit-component-tags.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="3a12bd96093f8972cbd9d52a68fb9178aaee4388">
+        <source>Move Down</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/edit-component-tags/edit-component-tags.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="826b25211922a1b46436589233cb6f1a163d89b7">
+        <source>Delete</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/edit-component-tags/edit-component-tags.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit>
       <trans-unit datatype="html" id="2485299eb70909a6cfa961bfac54f062a220806c">
         <source>Component Width</source>
         <context-group purpose="location">

--- a/src/main/webapp/wise5/authoringTool/components/editComponentController.ts
+++ b/src/main/webapp/wise5/authoringTool/components/editComponentController.ts
@@ -105,39 +105,6 @@ export abstract class EditComponentController {
     });
   }
 
-  addTag() {
-    if (this.authoringComponentContent.tags == null) {
-      this.authoringComponentContent.tags = [];
-    }
-    this.authoringComponentContent.tags.push('');
-    this.authoringViewComponentChanged();
-  }
-
-  moveTagUp(index) {
-    if (index > 0) {
-      const tag = this.authoringComponentContent.tags[index];
-      this.authoringComponentContent.tags.splice(index, 1);
-      this.authoringComponentContent.tags.splice(index - 1, 0, tag);
-      this.authoringViewComponentChanged();
-    }
-  }
-
-  moveTagDown(index) {
-    if (index < this.authoringComponentContent.tags.length - 1) {
-      const tag = this.authoringComponentContent.tags[index];
-      this.authoringComponentContent.tags.splice(index, 1);
-      this.authoringComponentContent.tags.splice(index + 1, 0, tag);
-      this.authoringViewComponentChanged();
-    }
-  }
-
-  deleteTag(indexOfTagToDelete) {
-    if (confirm(this.$translate('areYouSureYouWantToDeleteThisTag'))) {
-      this.authoringComponentContent.tags.splice(indexOfTagToDelete, 1);
-      this.authoringViewComponentChanged();
-    }
-  }
-
   connectedComponentTypeChanged(connectedComponent) {
     this.authoringViewComponentChanged();
   }

--- a/src/main/webapp/wise5/components/animation/authoring.html
+++ b/src/main/webapp/wise5/components/animation/authoring.html
@@ -51,17 +51,8 @@
                  ng-change='animationController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-          <input type='number'
-                 ng-model='animationController.authoringComponentContent.componentWidth'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='animationController.authoringViewComponentChanged()'/>
-        </md-input-container>
-      </div>
-      <edit-component-rubric [authoring-component-content]="animationController.authoringComponentContent">
-      </edit-component-rubric>
+      <edit-component-width [authoring-component-content]="animationController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="animationController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/animation/authoring.html
+++ b/src/main/webapp/wise5/components/animation/authoring.html
@@ -42,17 +42,11 @@
                  ng-change='animationController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'MAX_SCORE' | translate }}</label>
-          <input type='number'
-                 ng-model='animationController.authoringComponentContent.maxScore'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='animationController.authoringViewComponentChanged()'/>
-        </md-input-container>
+      <div layout="column" layout-align="start start">
+        <edit-component-max-score [authoring-component-content]="animationController.authoringComponentContent"></edit-component-max-score>
+        <edit-component-width [authoring-component-content]="animationController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="animationController.authoringComponentContent"></edit-component-rubric>
       </div>
-      <edit-component-width [authoring-component-content]="animationController.authoringComponentContent"></edit-component-width>
-      <edit-component-rubric [authoring-component-content]="animationController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/animation/authoring.html
+++ b/src/main/webapp/wise5/components/animation/authoring.html
@@ -46,6 +46,7 @@
         <edit-component-max-score [authoring-component-content]="animationController.authoringComponentContent"></edit-component-max-score>
         <edit-component-width [authoring-component-content]="animationController.authoringComponentContent"></edit-component-width>
         <edit-component-rubric [authoring-component-content]="animationController.authoringComponentContent"></edit-component-rubric>
+        <edit-component-tags [authoring-component-content]="animationController.authoringComponentContent"></edit-component-tags>
       </div>
       <div>
         <div style='height: 50;'>
@@ -116,57 +117,6 @@
                 </md-tooltip>
               </md-button>
             </md-input-container>
-          </div>
-        </div>
-      </div>
-      <div style='margin-top: 10px; margin-bottom: 10px;'>
-        <div style='height: 50;'>
-          <label class='node__label--vertical-alignment'>
-            {{ ::'tags' | translate }}
-          </label>
-          <md-button class='topButton md-raised md-primary'
-                     ng-click='animationController.addTag()'>
-            <md-icon>add</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'addTag' | translate }}
-            </md-tooltip>
-          </md-button>
-        </div>
-        <div ng-repeat='tag in animationController.authoringComponentContent.tags track by $index'>
-          <div layout='row'>
-            <md-input-container style='margin-bottom: 0px'>
-              <label></label>
-              <input ng-model='animationController.authoringComponentContent.tags[$index]'
-                     ng-change='animationController.authoringViewComponentChanged()'
-                     ng-model-options='{ debounce: 1000 }'
-                     size='100'
-                     placeholder='{{ ::"enterTag" | translate }}'/>
-            </md-input-container>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='animationController.moveTagUp($index)'>
-              <md-icon>arrow_upward</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'moveUp' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='animationController.moveTagDown($index)'>
-              <md-icon>arrow_downward</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'moveDown' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='animationController.deleteTag($index)'>
-              <md-icon>delete</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'DELETE' | translate }}
-              </md-tooltip>
-            </md-button>
           </div>
         </div>
       </div>

--- a/src/main/webapp/wise5/components/audioOscillator/authoring.html
+++ b/src/main/webapp/wise5/components/audioOscillator/authoring.html
@@ -38,17 +38,11 @@
                  ng-change='audioOscillatorController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'MAX_SCORE' | translate }}</label>
-          <input type='number'
-                 ng-model='audioOscillatorController.authoringComponentContent.maxScore'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='audioOscillatorController.authoringViewComponentChanged()'/>
-        </md-input-container>
+      <div layout="column" layout-align="start start">
+        <edit-component-max-score [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-max-score>
+        <edit-component-width [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-rubric>
       </div>
-      <edit-component-width [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-width>
-      <edit-component-rubric [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/audioOscillator/authoring.html
+++ b/src/main/webapp/wise5/components/audioOscillator/authoring.html
@@ -47,17 +47,8 @@
                  ng-change='audioOscillatorController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-          <input type='number'
-                 ng-model='audioOscillatorController.authoringComponentContent.componentWidth'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='audioOscillatorController.authoringViewComponentChanged()'/>
-        </md-input-container>
-      </div>
-      <edit-component-rubric [authoring-component-content]="audioOscillatorController.authoringComponentContent">
-      </edit-component-rubric>
+      <edit-component-width [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/audioOscillator/authoring.html
+++ b/src/main/webapp/wise5/components/audioOscillator/authoring.html
@@ -42,6 +42,7 @@
         <edit-component-max-score [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-max-score>
         <edit-component-width [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-width>
         <edit-component-rubric [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-rubric>
+        <edit-component-tags [authoring-component-content]="audioOscillatorController.authoringComponentContent"></edit-component-tags>
       </div>
       <div>
         <div style='height: 50;'>
@@ -112,57 +113,6 @@
                 </md-tooltip>
               </md-button>
             </md-input-container>
-          </div>
-        </div>
-      </div>
-      <div style='margin-top: 10px; margin-bottom: 10px;'>
-        <div style='height: 50;'>
-          <label class='node__label--vertical-alignment'>
-            {{ 'tags' | translate }}
-          </label>
-          <md-button class='topButton md-raised md-primary'
-                     ng-click='audioOscillatorController.addTag()'>
-            <md-icon>add</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ 'addTag' | translate }}
-            </md-tooltip>
-          </md-button>
-        </div>
-        <div ng-repeat='tag in audioOscillatorController.authoringComponentContent.tags track by $index'>
-          <div layout='row'>
-            <md-input-container style='margin-bottom: 0px'>
-              <label></label>
-              <input ng-model='audioOscillatorController.authoringComponentContent.tags[$index]'
-                     ng-change='audioOscillatorController.authoringViewComponentChanged()'
-                     ng-model-options='{ debounce: 1000 }'
-                     size='100'
-                     placeholder='{{ "enterTag" | translate }}'/>
-            </md-input-container>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='audioOscillatorController.moveTagUp($index)'>
-              <md-icon>arrow_upward</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ 'moveUp' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='audioOscillatorController.moveTagDown($index)'>
-              <md-icon>arrow_downward</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ 'moveDown' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='audioOscillatorController.deleteTag($index)'>
-              <md-icon>delete</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ 'DELETE' | translate }}
-              </md-tooltip>
-            </md-button>
           </div>
         </div>
       </div>

--- a/src/main/webapp/wise5/components/conceptMap/authoring.html
+++ b/src/main/webapp/wise5/components/conceptMap/authoring.html
@@ -133,6 +133,7 @@
         <edit-component-max-score [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-max-score>
         <edit-component-width [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-width>
         <edit-component-rubric [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-rubric>
+        <edit-component-tags [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-tags>
       </div>
       <div>
         <div style='height: 50;'>
@@ -213,57 +214,6 @@
                 </md-checkbox>
               </md-input-container>
             </div>
-          </div>
-        </div>
-      </div>
-      <div style='margin-top: 10px; margin-bottom: 10px;'>
-        <div style='height: 50;'>
-          <label class='node__label--vertical-alignment'>
-            {{ ::'tags' | translate }}
-          </label>
-          <md-button class='topButton md-raised md-primary'
-                     ng-click='conceptMapController.addTag()'>
-            <md-icon>add</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'addTag' | translate }}
-            </md-tooltip>
-          </md-button>
-        </div>
-        <div ng-repeat='tag in conceptMapController.authoringComponentContent.tags track by $index'>
-          <div layout='row'>
-            <md-input-container style='margin-bottom: 0px'>
-              <label></label>
-              <input ng-model='conceptMapController.authoringComponentContent.tags[$index]'
-                     ng-change='conceptMapController.authoringViewComponentChanged()'
-                     ng-model-options='{ debounce: 1000 }'
-                     size='100'
-                     placeholder='{{ ::"enterTag" | translate }}'/>
-            </md-input-container>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='conceptMapController.moveTagUp($index)'>
-              <md-icon>arrow_upward</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'moveUp' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='conceptMapController.moveTagDown($index)'>
-              <md-icon>arrow_downward</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'moveDown' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='conceptMapController.deleteTag($index)'>
-              <md-icon>delete</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'DELETE' | translate }}
-              </md-tooltip>
-            </md-button>
           </div>
         </div>
       </div>

--- a/src/main/webapp/wise5/components/conceptMap/authoring.html
+++ b/src/main/webapp/wise5/components/conceptMap/authoring.html
@@ -129,17 +129,11 @@
                  ng-change='conceptMapController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'MAX_SCORE' | translate }}</label>
-          <input type='number'
-                 ng-model='conceptMapController.authoringComponentContent.maxScore'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='conceptMapController.authoringViewComponentChanged()'/>
-        </md-input-container>
+      <div layout="column" layout-align="start start">
+        <edit-component-max-score [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-max-score>
+        <edit-component-width [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-rubric>
       </div>
-      <edit-component-width [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-width>
-      <edit-component-rubric [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/conceptMap/authoring.html
+++ b/src/main/webapp/wise5/components/conceptMap/authoring.html
@@ -138,17 +138,8 @@
                  ng-change='conceptMapController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-          <input type='number'
-                 ng-model='conceptMapController.authoringComponentContent.componentWidth'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='conceptMapController.authoringViewComponentChanged()'/>
-        </md-input-container>
-      </div>
-      <edit-component-rubric [authoring-component-content]="conceptMapController.authoringComponentContent">
-      </edit-component-rubric>
+      <edit-component-width [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="conceptMapController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/discussion/authoring.html
+++ b/src/main/webapp/wise5/components/discussion/authoring.html
@@ -8,6 +8,7 @@
       <edit-component-max-score [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-max-score>
       <edit-component-width [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-width>
       <edit-component-rubric [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-rubric>
+      <edit-component-tags [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-tags>
     </div>
     <div>
       <div style='height: 50;'>
@@ -78,55 +79,6 @@
               </md-tooltip>
             </md-button>
           </md-input-container>
-        </div>
-      </div>
-    </div>
-    <div style='margin-top: 10px; margin-bottom: 10px;'>
-      <div style='height: 50;'>
-        <label class='node__label--vertical-alignment'>{{ ::'tags' | translate }}</label>
-        <md-button class='topButton md-raised md-primary'
-                    ng-click='discussionController.addTag()'>
-          <md-icon>add</md-icon>
-          <md-tooltip md-direction='top'
-                      class='projectButtonTooltip'>
-            {{ ::'addTag' | translate }}
-          </md-tooltip>
-        </md-button>
-      </div>
-      <div ng-repeat='tag in discussionController.authoringComponentContent.tags track by $index'>
-        <div layout='row'>
-          <md-input-container style='margin-bottom: 0px'>
-            <label></label>
-            <input ng-model='discussionController.authoringComponentContent.tags[$index]'
-                    ng-change='discussionController.authoringViewComponentChanged()'
-                    ng-model-options='{ debounce: 1000 }'
-                    size='100'
-                    placeholder='{{ ::"enterTag" | translate }}'/>
-          </md-input-container>
-          <md-button class='moveComponentButton md-raised md-primary'
-                      ng-click='discussionController.moveTagUp($index)'>
-            <md-icon>arrow_upward</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'moveUp' | translate }}
-            </md-tooltip>
-          </md-button>
-          <md-button class='moveComponentButton md-raised md-primary'
-                      ng-click='discussionController.moveTagDown($index)'>
-            <md-icon>arrow_downward</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'moveDown' | translate }}
-            </md-tooltip>
-          </md-button>
-          <md-button class='moveComponentButton md-raised md-primary'
-                      ng-click='discussionController.deleteTag($index)'>
-            <md-icon>delete</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'DELETE' | translate }}
-            </md-tooltip>
-          </md-button>
         </div>
       </div>
     </div>

--- a/src/main/webapp/wise5/components/discussion/authoring.html
+++ b/src/main/webapp/wise5/components/discussion/authoring.html
@@ -13,17 +13,8 @@
                 ng-change='discussionController.authoringViewComponentChanged()'/>
       </md-input-container>
     </div>
-    <div>
-      <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-        <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-        <input type='number'
-                ng-model='discussionController.authoringComponentContent.componentWidth'
-                ng-model-options='{ debounce: 1000 }'
-                ng-change='discussionController.authoringViewComponentChanged()'/>
-      </md-input-container>
-    </div>
-    <edit-component-rubric [authoring-component-content]="discussionController.authoringComponentContent">
-    </edit-component-rubric>
+    <edit-component-width [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-width>
+    <edit-component-rubric [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-rubric>
     <div>
       <div style='height: 50;'>
         <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/discussion/authoring.html
+++ b/src/main/webapp/wise5/components/discussion/authoring.html
@@ -4,17 +4,11 @@
     <div>
       <h6>{{ ::'advancedAuthoringOptions' | translate }}</h6>
     </div>
-    <div>
-      <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-        <label>{{ ::'MAX_SCORE' | translate }}</label>
-        <input type='number'
-                ng-model='discussionController.authoringComponentContent.maxScore'
-                ng-model-options='{ debounce: 1000 }'
-                ng-change='discussionController.authoringViewComponentChanged()'/>
-      </md-input-container>
+    <div layout="column" layout-align="start start">
+      <edit-component-max-score [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-max-score>
+      <edit-component-width [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-rubric>
     </div>
-    <edit-component-width [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-width>
-    <edit-component-rubric [authoring-component-content]="discussionController.authoringComponentContent"></edit-component-rubric>
     <div>
       <div style='height: 50;'>
         <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/draw/authoring.html
+++ b/src/main/webapp/wise5/components/draw/authoring.html
@@ -52,17 +52,8 @@
                  ng-change='drawController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-          <input type='number'
-                 ng-model='drawController.authoringComponentContent.componentWidth'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='drawController.authoringViewComponentChanged()'/>
-        </md-input-container>
-      </div>
-      <edit-component-rubric [authoring-component-content]="drawController.authoringComponentContent">
-      </edit-component-rubric>
+      <edit-component-width [authoring-component-content]="drawController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="drawController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/draw/authoring.html
+++ b/src/main/webapp/wise5/components/draw/authoring.html
@@ -47,6 +47,7 @@
         <edit-component-max-score [authoring-component-content]="drawController.authoringComponentContent"></edit-component-max-score>
         <edit-component-width [authoring-component-content]="drawController.authoringComponentContent"></edit-component-width>
         <edit-component-rubric [authoring-component-content]="drawController.authoringComponentContent"></edit-component-rubric>
+        <edit-component-tags [authoring-component-content]="drawController.authoringComponentContent"></edit-component-tags>
       </div>
       <div>
         <div style='height: 50;'>
@@ -127,57 +128,6 @@
                 </md-checkbox>
               </md-input-container>
             </div>
-          </div>
-        </div>
-      </div>
-      <div style='margin-top: 10px; margin-bottom: 10px;'>
-        <div style='height: 50;'>
-          <label class='node__label--vertical-alignment'>
-            {{ ::'tags' | translate }}
-          </label>
-          <md-button class='topButton md-raised md-primary'
-                     ng-click='drawController.addTag()'>
-            <md-icon>add</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'addTag' | translate }}
-            </md-tooltip>
-          </md-button>
-        </div>
-        <div ng-repeat='tag in drawController.authoringComponentContent.tags track by $index'>
-          <div layout='row'>
-            <md-input-container style='margin-bottom: 0px'>
-              <label></label>
-              <input ng-model='drawController.authoringComponentContent.tags[$index]'
-                     ng-change='drawController.authoringViewComponentChanged()'
-                     ng-model-options='{ debounce: 1000 }'
-                     size='100'
-                     placeholder='{{ ::"enterTag" | translate }}'/>
-            </md-input-container>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='drawController.moveTagUp($index)'>
-              <md-icon>arrow_upward</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'moveUp' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='drawController.moveTagDown($index)'>
-              <md-icon>arrow_downward</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'moveDown' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='drawController.deleteTag($index)'>
-              <md-icon>delete</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'DELETE' | translate }}
-              </md-tooltip>
-            </md-button>
           </div>
         </div>
       </div>

--- a/src/main/webapp/wise5/components/draw/authoring.html
+++ b/src/main/webapp/wise5/components/draw/authoring.html
@@ -43,17 +43,11 @@
                  ng-change='drawController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'MAX_SCORE' | translate }}</label>
-          <input type='number'
-                 ng-model='drawController.authoringComponentContent.maxScore'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='drawController.authoringViewComponentChanged()'/>
-        </md-input-container>
+      <div layout="column" layout-align="start start">
+        <edit-component-max-score [authoring-component-content]="drawController.authoringComponentContent"></edit-component-max-score>
+        <edit-component-width [authoring-component-content]="drawController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="drawController.authoringComponentContent"></edit-component-rubric>
       </div>
-      <edit-component-width [authoring-component-content]="drawController.authoringComponentContent"></edit-component-width>
-      <edit-component-rubric [authoring-component-content]="drawController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/embedded/authoring.html
+++ b/src/main/webapp/wise5/components/embedded/authoring.html
@@ -47,17 +47,11 @@
                 ng-change='embeddedController.authoringViewComponentChanged()'/>
           </md-input-container>
         </div>
-        <div>
-          <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-            <label>{{ ::'MAX_SCORE' | translate }}</label>
-            <input type='number'
-                ng-model='embeddedController.authoringComponentContent.maxScore'
-                ng-model-options='{ debounce: 1000 }'
-                ng-change='embeddedController.authoringViewComponentChanged()'/>
-          </md-input-container>
+        <div layout="column" layout-align="start start">
+          <edit-component-max-score [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-max-score>
+          <edit-component-width [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-width>
+          <edit-component-rubric [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-rubric>
         </div>
-        <edit-component-width [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-width>
-        <edit-component-rubric [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-rubric>
         <div>
           <div style='height: 50;'>
             <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/embedded/authoring.html
+++ b/src/main/webapp/wise5/components/embedded/authoring.html
@@ -51,6 +51,7 @@
           <edit-component-max-score [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-max-score>
           <edit-component-width [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-width>
           <edit-component-rubric [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-rubric>
+          <edit-component-tags [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-tags>
         </div>
         <div>
           <div style='height: 50;'>
@@ -110,41 +111,6 @@
                   <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'DELETE' | translate }}</md-tooltip>
                 </md-button>
               </md-input-container>
-            </div>
-          </div>
-        </div>
-        <div style='margin-top: 10px; margin-bottom: 10px;'>
-          <div style='height: 50px;'>
-            <label class='node__label--vertical-alignment'>{{ ::'tags' | translate }}</label>
-            <md-button class='topButton md-raised md-primary' ng-click='embeddedController.addTag()'>
-              <md-icon>add</md-icon>
-              <md-tooltip md-direction='top' class='projectButtonTooltip'>
-                {{ ::'addTag' | translate }}
-              </md-tooltip>
-            </md-button>
-          </div>
-          <div ng-repeat='tag in embeddedController.authoringComponentContent.tags track by $index'>
-            <div layout='row'>
-              <md-input-container style='margin-bottom: 0px'>
-                <label></label>
-                <input ng-model='embeddedController.authoringComponentContent.tags[$index]'
-                    ng-change='embeddedController.authoringViewComponentChanged()'
-                    ng-model-options='{ debounce: 1000 }'
-                    size='100'
-                    placeholder='{{ ::"enterTag" | translate }}'/>
-              </md-input-container>
-              <md-button class='moveComponentButton md-raised md-primary' ng-click='embeddedController.moveTagUp($index)'>
-                <md-icon>arrow_upward</md-icon>
-                <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'moveUp' | translate }}</md-tooltip>
-              </md-button>
-              <md-button class='moveComponentButton md-raised md-primary' ng-click='embeddedController.moveTagDown($index)'>
-                <md-icon>arrow_downward</md-icon>
-                <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'moveDown' | translate }}</md-tooltip>
-              </md-button>
-              <md-button class='moveComponentButton md-raised md-primary' ng-click='embeddedController.deleteTag($index)'>
-                <md-icon>delete</md-icon>
-                <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'DELETE' | translate }}</md-tooltip>
-              </md-button>
             </div>
           </div>
         </div>

--- a/src/main/webapp/wise5/components/embedded/authoring.html
+++ b/src/main/webapp/wise5/components/embedded/authoring.html
@@ -56,17 +56,8 @@
                 ng-change='embeddedController.authoringViewComponentChanged()'/>
           </md-input-container>
         </div>
-        <div>
-          <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-            <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-            <input type='number'
-                ng-model='embeddedController.authoringComponentContent.componentWidth'
-                ng-model-options='{ debounce: 1000 }'
-                ng-change='embeddedController.authoringViewComponentChanged()'/>
-          </md-input-container>
-        </div>
-        <edit-component-rubric [authoring-component-content]="embeddedController.authoringComponentContent">
-        </edit-component-rubric>
+        <edit-component-width [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="embeddedController.authoringComponentContent"></edit-component-rubric>
         <div>
           <div style='height: 50;'>
             <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/graph/authoring.html
+++ b/src/main/webapp/wise5/components/graph/authoring.html
@@ -184,6 +184,7 @@
           <edit-component-max-score [authoring-component-content]="graphController.authoringComponentContent"></edit-component-max-score>
           <edit-component-width [authoring-component-content]="graphController.authoringComponentContent"></edit-component-width>
           <edit-component-rubric [authoring-component-content]="graphController.authoringComponentContent"></edit-component-rubric>
+          <edit-component-tags [authoring-component-content]="graphController.authoringComponentContent"></edit-component-tags>
         </div>
         <div>
           <div style='height: 50;'>
@@ -338,43 +339,6 @@
                   {{ ::'importWorkAsBackground' | translate }}
                 </md-checkbox>
               </md-input-container>
-            </div>
-          </div>
-        </div>
-        <div style='margin-top: 10px; margin-bottom: 10px;'>
-          <div style='height: 50px;'>
-            <label class='node__label--vertical-alignment'>{{ ::'tags' | translate }}</label>
-            <md-button class='topButton md-raised md-primary'
-                       ng-click='graphController.addTag()'>
-              <md-icon>add</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'addTag' | translate }}
-              </md-tooltip>
-            </md-button>
-          </div>
-          <div ng-repeat='tag in graphController.authoringComponentContent.tags track by $index'>
-            <div layout='row'>
-              <md-input-container style='margin-bottom: 0px'>
-                <label></label>
-                <input ng-model='graphController.authoringComponentContent.tags[$index]'
-                       ng-change='graphController.authoringViewComponentChanged()'
-                       ng-model-options='{ debounce: 1000 }'
-                       size='100'
-                       placeholder='{{ ::"enterTag" | translate }}'/>
-              </md-input-container>
-              <md-button class='moveComponentButton md-raised md-primary' ng-click='graphController.moveTagUp($index)'>
-                <md-icon>arrow_upward</md-icon>
-                <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'moveUp' | translate }}</md-tooltip>
-              </md-button>
-              <md-button class='moveComponentButton md-raised md-primary' ng-click='graphController.moveTagDown($index)'>
-                <md-icon>arrow_downward</md-icon>
-                <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'moveDown' | translate }}</md-tooltip>
-              </md-button>
-              <md-button class='moveComponentButton md-raised md-primary' ng-click='graphController.deleteTag($index)'>
-                <md-icon>delete</md-icon>
-                <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'DELETE' | translate }}</md-tooltip>
-              </md-button>
             </div>
           </div>
         </div>

--- a/src/main/webapp/wise5/components/graph/authoring.html
+++ b/src/main/webapp/wise5/components/graph/authoring.html
@@ -189,17 +189,8 @@
                    ng-change='graphController.authoringViewComponentChanged()'/>
           </md-input-container>
         </div>
-        <div>
-          <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-            <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-            <input type='number'
-                   ng-model='graphController.authoringComponentContent.componentWidth'
-                   ng-model-options='{ debounce: 1000 }'
-                   ng-change='graphController.authoringViewComponentChanged()'/>
-          </md-input-container>
-        </div>
-        <edit-component-rubric [authoring-component-content]="graphController.authoringComponentContent">
-        </edit-component-rubric>
+        <edit-component-width [authoring-component-content]="graphController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="graphController.authoringComponentContent"></edit-component-rubric>
         <div>
           <div style='height: 50;'>
             <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/graph/authoring.html
+++ b/src/main/webapp/wise5/components/graph/authoring.html
@@ -180,17 +180,11 @@
             </md-button>
           </div>
         </div>
-        <div>
-          <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-            <label>{{ ::'MAX_SCORE' | translate }}</label>
-            <input type='number'
-                   ng-model='graphController.authoringComponentContent.maxScore'
-                   ng-model-options='{ debounce: 1000 }'
-                   ng-change='graphController.authoringViewComponentChanged()'/>
-          </md-input-container>
+        <div layout="column" layout-align="start start">
+          <edit-component-max-score [authoring-component-content]="graphController.authoringComponentContent"></edit-component-max-score>
+          <edit-component-width [authoring-component-content]="graphController.authoringComponentContent"></edit-component-width>
+          <edit-component-rubric [authoring-component-content]="graphController.authoringComponentContent"></edit-component-rubric>
         </div>
-        <edit-component-width [authoring-component-content]="graphController.authoringComponentContent"></edit-component-width>
-        <edit-component-rubric [authoring-component-content]="graphController.authoringComponentContent"></edit-component-rubric>
         <div>
           <div style='height: 50;'>
             <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/html/authoring.html
+++ b/src/main/webapp/wise5/components/html/authoring.html
@@ -3,17 +3,8 @@
     <div>
       <h6>{{ ::'advancedAuthoringOptions' | translate }}</h6>
     </div>
-    <div>
-      <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-        <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-        <input type='number'
-               ng-model='htmlController.authoringComponentContent.componentWidth'
-               ng-model-options='{ debounce: 1000 }'
-               ng-change='htmlController.authoringViewComponentChanged()'/>
-      </md-input-container>
-    </div>
-    <edit-component-rubric [authoring-component-content]="htmlController.authoringComponentContent">
-    </edit-component-rubric>
+    <edit-component-width [authoring-component-content]="htmlController.authoringComponentContent"></edit-component-width>
+    <edit-component-rubric [authoring-component-content]="htmlController.authoringComponentContent"></edit-component-rubric>
     <edit-component-json [node-id]="htmlController.nodeId" [component-id]="htmlController.componentId"></edit-component-json>
   </div>
   <br/>

--- a/src/main/webapp/wise5/components/label/authoring.html
+++ b/src/main/webapp/wise5/components/label/authoring.html
@@ -48,6 +48,7 @@
       <edit-component-max-score [authoring-component-content]="labelController.authoringComponentContent"></edit-component-max-score>
       <edit-component-width [authoring-component-content]="labelController.authoringComponentContent"></edit-component-width>
       <edit-component-rubric [authoring-component-content]="labelController.authoringComponentContent"></edit-component-rubric>
+      <edit-component-tags [authoring-component-content]="labelController.authoringComponentContent"></edit-component-tags>
     </div>
     <div>
       <div>
@@ -157,57 +158,6 @@
               {{ ::'importWorkAsBackground' | translate }}
             </md-checkbox>
           </md-input-container>
-        </div>
-      </div>
-    </div>
-    <div style='margin-top: 10px; margin-bottom: 10px;'>
-      <div style='height: 50px;'>
-        <label class='node__label--vertical-alignment'>
-          {{ ::'tags' | translate }}
-        </label>
-        <md-button class='topButton md-raised md-primary'
-                   ng-click='labelController.addTag()'>
-          <md-icon>add</md-icon>
-          <md-tooltip md-direction='top'
-                      class='projectButtonTooltip'>
-            {{ ::'addTag' | translate }}
-          </md-tooltip>
-        </md-button>
-      </div>
-      <div ng-repeat='tag in labelController.authoringComponentContent.tags track by $index'>
-        <div layout='row'>
-          <md-input-container style='margin-bottom: 0px'>
-            <label></label>
-            <input ng-model='labelController.authoringComponentContent.tags[$index]'
-                   ng-change='labelController.authoringViewComponentChanged()'
-                   ng-model-options='{ debounce: 1000 }'
-                   size='100'
-                   placeholder='{{ ::"enterTag" | translate }}'/>
-          </md-input-container>
-          <md-button class='moveComponentButton md-raised md-primary'
-                     ng-click='labelController.moveTagUp($index)'>
-            <md-icon>arrow_upward</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'moveUp' | translate }}
-            </md-tooltip>
-          </md-button>
-          <md-button class='moveComponentButton md-raised md-primary'
-                     ng-click='labelController.moveTagDown($index)'>
-            <md-icon>arrow_downward</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'moveDown' | translate }}
-            </md-tooltip>
-          </md-button>
-          <md-button class='moveComponentButton md-raised md-primary'
-                     ng-click='labelController.deleteTag($index)'>
-            <md-icon>delete</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'DELETE' | translate }}
-            </md-tooltip>
-          </md-button>
         </div>
       </div>
     </div>

--- a/src/main/webapp/wise5/components/label/authoring.html
+++ b/src/main/webapp/wise5/components/label/authoring.html
@@ -53,17 +53,8 @@
                ng-change='labelController.authoringViewComponentChanged()'/>
       </md-input-container>
     </div>
-    <div>
-      <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-        <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-        <input type='number'
-               ng-model='labelController.authoringComponentContent.componentWidth'
-               ng-model-options='{ debounce: 1000 }'
-               ng-change='labelController.authoringViewComponentChanged()'/>
-      </md-input-container>
-    </div>
-    <edit-component-rubric [authoring-component-content]="labelController.authoringComponentContent">
-    </edit-component-rubric>
+    <edit-component-width [authoring-component-content]="labelController.authoringComponentContent"></edit-component-width>
+    <edit-component-rubric [authoring-component-content]="labelController.authoringComponentContent"></edit-component-rubric>
     <div>
       <div>
         <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/label/authoring.html
+++ b/src/main/webapp/wise5/components/label/authoring.html
@@ -44,17 +44,11 @@
                ng-change='labelController.authoringViewComponentChanged()'/>
       </md-input-container>
     </div>
-    <div>
-      <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-        <label>{{ 'MAX_SCORE' | translate }}</label>
-        <input type='number'
-               ng-model='labelController.authoringComponentContent.maxScore'
-               ng-model-options='{ debounce: 1000 }'
-               ng-change='labelController.authoringViewComponentChanged()'/>
-      </md-input-container>
+    <div layout="column" layout-align="start start">
+      <edit-component-max-score [authoring-component-content]="labelController.authoringComponentContent"></edit-component-max-score>
+      <edit-component-width [authoring-component-content]="labelController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="labelController.authoringComponentContent"></edit-component-rubric>
     </div>
-    <edit-component-width [authoring-component-content]="labelController.authoringComponentContent"></edit-component-width>
-    <edit-component-rubric [authoring-component-content]="labelController.authoringComponentContent"></edit-component-rubric>
     <div>
       <div>
         <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/match/authoring.html
+++ b/src/main/webapp/wise5/components/match/authoring.html
@@ -51,17 +51,11 @@
                  ng-change='matchController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'MAX_SCORE' | translate }}</label>
-          <input type='number'
-                 ng-model='matchController.authoringComponentContent.maxScore'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='matchController.authoringViewComponentChanged()'/>
-        </md-input-container>
+      <div layout="column" layout-align="start start">
+        <edit-component-max-score [authoring-component-content]="matchController.authoringComponentContent"></edit-component-max-score>
+        <edit-component-width [authoring-component-content]="matchController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="matchController.authoringComponentContent"></edit-component-rubric>
       </div>
-      <edit-component-width [authoring-component-content]="matchController.authoringComponentContent"></edit-component-width>
-      <edit-component-rubric [authoring-component-content]="matchController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/match/authoring.html
+++ b/src/main/webapp/wise5/components/match/authoring.html
@@ -60,17 +60,8 @@
                  ng-change='matchController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-          <input type='number'
-                 ng-model='matchController.authoringComponentContent.componentWidth'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='matchController.authoringViewComponentChanged()'/>
-        </md-input-container>
-      </div>
-      <edit-component-rubric [authoring-component-content]="matchController.authoringComponentContent">
-      </edit-component-rubric>
+      <edit-component-width [authoring-component-content]="matchController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="matchController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/match/authoring.html
+++ b/src/main/webapp/wise5/components/match/authoring.html
@@ -55,6 +55,7 @@
         <edit-component-max-score [authoring-component-content]="matchController.authoringComponentContent"></edit-component-max-score>
         <edit-component-width [authoring-component-content]="matchController.authoringComponentContent"></edit-component-width>
         <edit-component-rubric [authoring-component-content]="matchController.authoringComponentContent"></edit-component-rubric>
+        <edit-component-tags [authoring-component-content]="matchController.authoringComponentContent"></edit-component-tags>
       </div>
       <div>
         <div style='height: 50;'>
@@ -125,57 +126,6 @@
                 </md-tooltip>
               </md-button>
             </md-input-container>
-          </div>
-        </div>
-      </div>
-      <div style='margin-top: 10px; margin-bottom: 10px;'>
-        <div style='height: 50;'>
-          <label class='node__label--vertical-alignment'>
-            {{ ::'tags' | translate }}
-          </label>
-          <md-button class='topButton md-raised md-primary'
-                     ng-click='matchController.addTag()'>
-            <md-icon>add</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'addTag' | translate }}
-            </md-tooltip>
-          </md-button>
-        </div>
-        <div ng-repeat='tag in matchController.authoringComponentContent.tags track by $index'>
-          <div layout='row'>
-            <md-input-container style='margin-bottom: 0px'>
-              <label></label>
-              <input ng-model='matchController.authoringComponentContent.tags[$index]'
-                     ng-change='matchController.authoringViewComponentChanged()'
-                     ng-model-options='{ debounce: 1000 }'
-                     size='100'
-                     placeholder='{{ "enterTag" | translate }}'/>
-            </md-input-container>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='matchController.moveTagUp($index)'>
-              <md-icon>arrow_upward</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'moveUp' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='matchController.moveTagDown($index)'>
-              <md-icon>arrow_downward</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'moveDown' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                       ng-click='matchController.deleteTag($index)'>
-              <md-icon>delete</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'DELETE' | translate }}
-              </md-tooltip>
-            </md-button>
           </div>
         </div>
       </div>

--- a/src/main/webapp/wise5/components/multipleChoice/authoring.html
+++ b/src/main/webapp/wise5/components/multipleChoice/authoring.html
@@ -44,17 +44,8 @@
               ng-change='multipleChoiceController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ 'COMPONENT_WIDTH' | translate }}</label>
-          <input type='number'
-              ng-model='multipleChoiceController.authoringComponentContent.componentWidth'
-              ng-model-options='{ debounce: 1000 }'
-              ng-change='multipleChoiceController.authoringViewComponentChanged()'/>
-        </md-input-container>
-      </div>
-      <edit-component-rubric [authoring-component-content]="multipleChoiceController.authoringComponentContent">
-      </edit-component-rubric>
+      <edit-component-width [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/multipleChoice/authoring.html
+++ b/src/main/webapp/wise5/components/multipleChoice/authoring.html
@@ -39,6 +39,7 @@
         <edit-component-max-score [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-max-score>
         <edit-component-width [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-width>
         <edit-component-rubric [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-rubric>
+        <edit-component-tags [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-tags>
       </div>
       <div>
         <div style='height: 50;'>
@@ -103,51 +104,6 @@
                 </md-tooltip>
               </md-button>
             </md-input-container>
-          </div>
-        </div>
-      </div>
-      <div style='margin-top: 10px; margin-bottom: 10px;'>
-        <div style='height: 50;'>
-          <label class='node__label--vertical-alignment'>{{ 'tags' | translate }}</label>
-          <md-button class='topButton md-raised md-primary'
-              ng-click='multipleChoiceController.addTag()'>
-            <md-icon>add</md-icon>
-            <md-tooltip md-direction='top' class='projectButtonTooltip'>
-              {{ 'addTag' | translate }}
-            </md-tooltip>
-          </md-button>
-        </div>
-        <div ng-repeat='tag in multipleChoiceController.authoringComponentContent.tags track by $index'>
-          <div layout='row'>
-            <md-input-container style='margin-bottom: 0px'>
-              <label></label>
-              <input ng-model='multipleChoiceController.authoringComponentContent.tags[$index]'
-                  ng-change='multipleChoiceController.authoringViewComponentChanged()'
-                  ng-model-options='{ debounce: 1000 }'
-                  size='100'
-                  placeholder='{{ "enterTag" | translate }}'/>
-            </md-input-container>
-            <md-button class='moveComponentButton md-raised md-primary'
-                ng-click='multipleChoiceController.moveTagUp($index)'>
-              <md-icon>arrow_upward</md-icon>
-              <md-tooltip md-direction='top' class='projectButtonTooltip'>
-                {{ 'moveUp' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                ng-click='multipleChoiceController.moveTagDown($index)'>
-              <md-icon>arrow_downward</md-icon>
-              <md-tooltip md-direction='top' class='projectButtonTooltip'>
-                {{ 'moveDown' | translate }}
-              </md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary'
-                ng-click='multipleChoiceController.deleteTag($index)'>
-              <md-icon>delete</md-icon>
-              <md-tooltip md-direction='top' class='projectButtonTooltip'>
-                {{ 'DELETE' | translate }}
-              </md-tooltip>
-            </md-button>
           </div>
         </div>
       </div>

--- a/src/main/webapp/wise5/components/multipleChoice/authoring.html
+++ b/src/main/webapp/wise5/components/multipleChoice/authoring.html
@@ -35,17 +35,11 @@
               ng-change='multipleChoiceController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ 'MAX_SCORE' | translate }}</label>
-          <input type='number'
-              ng-model='multipleChoiceController.authoringComponentContent.maxScore'
-              ng-model-options='{ debounce: 1000 }'
-              ng-change='multipleChoiceController.authoringViewComponentChanged()'/>
-        </md-input-container>
+      <div layout="column" layout-align="start start">
+        <edit-component-max-score [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-max-score>
+        <edit-component-width [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-rubric>
       </div>
-      <edit-component-width [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-width>
-      <edit-component-rubric [authoring-component-content]="multipleChoiceController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/openResponse/authoring.html
+++ b/src/main/webapp/wise5/components/openResponse/authoring.html
@@ -228,17 +228,8 @@
                  ng-change='openResponseController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-          <input type='number'
-                 ng-model='openResponseController.authoringComponentContent.componentWidth'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='openResponseController.authoringViewComponentChanged()'/>
-        </md-input-container>
-      </div>
-      <edit-component-rubric [authoring-component-content]="openResponseController.authoringComponentContent">
-      </edit-component-rubric>
+      <edit-component-width [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style="border: 2px solid #dddddd; border-radius: 5px; margin-bottom: 10px; padding: 20px 20px 10px 20px;">
           <md-checkbox class='md-primary'

--- a/src/main/webapp/wise5/components/openResponse/authoring.html
+++ b/src/main/webapp/wise5/components/openResponse/authoring.html
@@ -223,6 +223,7 @@
         <edit-component-max-score [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-max-score>
         <edit-component-width [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-width>
         <edit-component-rubric [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-rubric>
+        <edit-component-tags [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-tags>
       </div>
       <div>
         <div style="border: 2px solid #dddddd; border-radius: 5px; margin-bottom: 10px; padding: 20px 20px 10px 20px;">
@@ -362,45 +363,6 @@
                 <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'DELETE' | translate }}</md-tooltip>
               </md-button>
             </md-input-container>
-          </div>
-        </div>
-      </div>
-      <div style='margin-top: 10px; margin-bottom: 10px;'>
-        <div style='height: 50;'>
-          <label class='node__label--vertical-alignment'>
-            {{ ::'tags' | translate }}
-          </label>
-          <md-button class='topButton md-raised md-primary'
-                     ng-click='openResponseController.addTag()'>
-            <md-icon>add</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'addTag' | translate }}
-            </md-tooltip>
-          </md-button>
-        </div>
-        <div ng-repeat='tag in openResponseController.authoringComponentContent.tags track by $index'>
-          <div layout='row'>
-            <md-input-container style='margin-bottom: 0px'>
-              <label></label>
-              <input ng-model='openResponseController.authoringComponentContent.tags[$index]'
-                     ng-change='openResponseController.authoringViewComponentChanged()'
-                     ng-model-options='{ debounce: 1000 }'
-                     size='100'
-                     placeholder='{{ "enterTag" | translate }}'/>
-            </md-input-container>
-            <md-button class='moveComponentButton md-raised md-primary' ng-click='openResponseController.moveTagUp($index)'>
-              <md-icon>arrow_upward</md-icon>
-              <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'moveUp' | translate }}</md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary' ng-click='openResponseController.moveTagDown($index)'>
-              <md-icon>arrow_downward</md-icon>
-              <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'moveDown' | translate }}</md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary' ng-click='openResponseController.deleteTag($index)'>
-              <md-icon>delete</md-icon>
-              <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'DELETE' | translate }}</md-tooltip>
-            </md-button>
           </div>
         </div>
       </div>

--- a/src/main/webapp/wise5/components/openResponse/authoring.html
+++ b/src/main/webapp/wise5/components/openResponse/authoring.html
@@ -219,17 +219,11 @@
                  ng-change='openResponseController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'MAX_SCORE' | translate }}</label>
-          <input type='number'
-                 ng-model='openResponseController.authoringComponentContent.maxScore'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='openResponseController.authoringViewComponentChanged()'/>
-        </md-input-container>
+      <div layout="column" layout-align="start start">
+        <edit-component-max-score [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-max-score>
+        <edit-component-width [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-rubric>
       </div>
-      <edit-component-width [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-width>
-      <edit-component-rubric [authoring-component-content]="openResponseController.authoringComponentContent"></edit-component-rubric>
       <div>
         <div style="border: 2px solid #dddddd; border-radius: 5px; margin-bottom: 10px; padding: 20px 20px 10px 20px;">
           <md-checkbox class='md-primary'

--- a/src/main/webapp/wise5/components/outsideURL/authoring.html
+++ b/src/main/webapp/wise5/components/outsideURL/authoring.html
@@ -4,17 +4,8 @@
       <div>
         <h6>{{ ::'advancedAuthoringOptions' | translate }}</h6>
       </div>
-      <div>
-        <md-input-container style="margin-right: 20px; width: 400px; height: 25px;">
-          <label>{{ ::'COMPONENT_WIDTH' | translate }} ({{ ::'outsideURL.integerPercentageOfPageWidth' | translate }})</label>
-          <input type="number"
-                 ng-model="outsideURLController.authoringComponentContent.componentWidth"
-                 ng-model-options="{ debounce: 1000 }"
-                 ng-change="outsideURLController.authoringViewComponentChanged()"/>
-        </md-input-container>
-      </div>
-      <edit-component-rubric [authoring-component-content]="outsideURLController.authoringComponentContent">
-      </edit-component-rubric>
+      <edit-component-width [authoring-component-content]="outsideURLController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="outsideURLController.authoringComponentContent"></edit-component-rubric>
       <edit-component-json [node-id]="outsideURLController.nodeId" [component-id]="outsideURLController.componentId"></edit-component-json>
     </div>
   </div>

--- a/src/main/webapp/wise5/components/summary/authoring.html
+++ b/src/main/webapp/wise5/components/summary/authoring.html
@@ -40,17 +40,8 @@
                  ng-change='summaryController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <div>
-        <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-          <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-          <input type='number'
-                 ng-model='summaryController.authoringComponentContent.componentWidth'
-                 ng-model-options='{ debounce: 1000 }'
-                 ng-change='summaryController.authoringViewComponentChanged()'/>
-        </md-input-container>
-      </div>
-      <edit-component-rubric [authoring-component-content]="summaryController.authoringComponentContent">
-      </edit-component-rubric>
+      <edit-component-width [authoring-component-content]="summaryController.authoringComponentContent"></edit-component-width>
+      <edit-component-rubric [authoring-component-content]="summaryController.authoringComponentContent"></edit-component-rubric>
       <div style='margin-top: 10px; margin-bottom: 10px;'>
         <div style='height: 50;'>
           <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/summary/authoring.html
+++ b/src/main/webapp/wise5/components/summary/authoring.html
@@ -40,46 +40,10 @@
                  ng-change='summaryController.authoringViewComponentChanged()'/>
         </md-input-container>
       </div>
-      <edit-component-width [authoring-component-content]="summaryController.authoringComponentContent"></edit-component-width>
-      <edit-component-rubric [authoring-component-content]="summaryController.authoringComponentContent"></edit-component-rubric>
-      <div style='margin-top: 10px; margin-bottom: 10px;'>
-        <div style='height: 50;'>
-          <label class='node__label--vertical-alignment'>
-            {{ ::'tags' | translate }}
-          </label>
-          <md-button class='topButton md-raised md-primary'
-                     ng-click='summaryController.addTag()'>
-            <md-icon>add</md-icon>
-            <md-tooltip md-direction='top'
-                        class='projectButtonTooltip'>
-              {{ ::'addTag' | translate }}
-            </md-tooltip>
-          </md-button>
-        </div>
-        <div ng-repeat='tag in summaryController.authoringComponentContent.tags track by $index'>
-          <div layout='row'>
-            <md-input-container style='margin-bottom: 0px'>
-              <label></label>
-              <input ng-model='summaryController.authoringComponentContent.tags[$index]'
-                     ng-change='summaryController.authoringViewComponentChanged()'
-                     ng-model-options='{ debounce: 1000 }'
-                     size='100'
-                     placeholder='{{ "enterTag" | translate }}'/>
-            </md-input-container>
-            <md-button class='moveComponentButton md-raised md-primary' ng-click='summaryController.moveTagUp($index)'>
-              <md-icon>arrow_upward</md-icon>
-              <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'moveUp' | translate }}</md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary' ng-click='summaryController.moveTagDown($index)'>
-              <md-icon>arrow_downward</md-icon>
-              <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'moveDown' | translate }}</md-tooltip>
-            </md-button>
-            <md-button class='moveComponentButton md-raised md-primary' ng-click='summaryController.deleteTag($index)'>
-              <md-icon>delete</md-icon>
-              <md-tooltip md-direction='top' class='projectButtonTooltip'>{{ ::'DELETE' | translate }}</md-tooltip>
-            </md-button>
-          </div>
-        </div>
+      <div layout="column" layout-align="start start">
+        <edit-component-width [authoring-component-content]="summaryController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="summaryController.authoringComponentContent"></edit-component-rubric>
+        <edit-component-tags [authoring-component-content]="summaryController.authoringComponentContent"></edit-component-tags>
       </div>
       <edit-component-json [node-id]="summaryController.nodeId" [component-id]="summaryController.componentId"></edit-component-json>
     </div>

--- a/src/main/webapp/wise5/components/table/authoring.html
+++ b/src/main/webapp/wise5/components/table/authoring.html
@@ -48,15 +48,6 @@
                    ng-change='tableController.authoringViewComponentChanged()'/>
           </md-input-container>
         </div>
-        <div>
-          <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-            <label>{{ ::'MAX_SCORE' | translate }}</label>
-            <input type='number'
-                   ng-model='tableController.authoringComponentContent.maxScore'
-                   ng-model-options='{ debounce: 1000 }'
-                   ng-change='tableController.authoringViewComponentChanged()'/>
-          </md-input-container>
-        </div>
         <div style='border: 1px solid black'>
           <p>{{ ::'table.dataExplorer' | translate }}</p>
           <div>
@@ -139,8 +130,11 @@
             </div>
           </div>
         </div>
-        <edit-component-width [authoring-component-content]="tableController.authoringComponentContent"></edit-component-width>
-        <edit-component-rubric [authoring-component-content]="tableController.authoringComponentContent"></edit-component-rubric>
+        <div layout="column" layout-align="start start">
+          <edit-component-max-score [authoring-component-content]="tableController.authoringComponentContent"></edit-component-max-score>
+          <edit-component-width [authoring-component-content]="tableController.authoringComponentContent"></edit-component-width>
+          <edit-component-rubric [authoring-component-content]="tableController.authoringComponentContent"></edit-component-rubric>
+        </div>
         <div>
           <div style='height: 50;'>
             <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/table/authoring.html
+++ b/src/main/webapp/wise5/components/table/authoring.html
@@ -57,15 +57,6 @@
                    ng-change='tableController.authoringViewComponentChanged()'/>
           </md-input-container>
         </div>
-        <div>
-          <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
-            <label>{{ ::'COMPONENT_WIDTH' | translate }}</label>
-            <input type='number'
-                   ng-model='tableController.authoringComponentContent.componentWidth'
-                   ng-model-options='{ debounce: 1000 }'
-                   ng-change='tableController.authoringViewComponentChanged()'/>
-          </md-input-container>
-        </div>
         <div style='border: 1px solid black'>
           <p>{{ ::'table.dataExplorer' | translate }}</p>
           <div>
@@ -148,8 +139,8 @@
             </div>
           </div>
         </div>
-        <edit-component-rubric [authoring-component-content]="tableController.authoringComponentContent">
-        </edit-component-rubric>
+        <edit-component-width [authoring-component-content]="tableController.authoringComponentContent"></edit-component-width>
+        <edit-component-rubric [authoring-component-content]="tableController.authoringComponentContent"></edit-component-rubric>
         <div>
           <div style='height: 50;'>
             <label class='node__label--vertical-alignment'>

--- a/src/main/webapp/wise5/components/table/authoring.html
+++ b/src/main/webapp/wise5/components/table/authoring.html
@@ -134,6 +134,7 @@
           <edit-component-max-score [authoring-component-content]="tableController.authoringComponentContent"></edit-component-max-score>
           <edit-component-width [authoring-component-content]="tableController.authoringComponentContent"></edit-component-width>
           <edit-component-rubric [authoring-component-content]="tableController.authoringComponentContent"></edit-component-rubric>
+          <edit-component-tags [authoring-component-content]="tableController.authoringComponentContent"></edit-component-tags>
         </div>
         <div>
           <div style='height: 50;'>
@@ -224,57 +225,6 @@
                   {{ ::'table.onlyShowDataAtMouseXPosition' | translate }}
                 </md-checkbox>
               </md-input-container>
-            </div>
-          </div>
-        </div>
-        <div style='margin-top: 10px; margin-bottom: 10px;'>
-          <div style='height: 50px;'>
-            <label class='node__label--vertical-alignment'>
-              {{ ::'tags' | translate }}
-            </label>
-            <md-button class='topButton md-raised md-primary'
-                       ng-click='tableController.addTag()'>
-              <md-icon>add</md-icon>
-              <md-tooltip md-direction='top'
-                          class='projectButtonTooltip'>
-                {{ ::'addTag' | translate }}
-              </md-tooltip>
-            </md-button>
-          </div>
-          <div ng-repeat='tag in tableController.authoringComponentContent.tags track by $index'>
-            <div layout='row'>
-              <md-input-container style='margin-bottom: 0px'>
-                <label></label>
-                <input ng-model='tableController.authoringComponentContent.tags[$index]'
-                       ng-change='tableController.authoringViewComponentChanged()'
-                       ng-model-options='{ debounce: 1000 }'
-                       size='100'
-                       placeholder='{{ "enterTag" | translate }}'/>
-              </md-input-container>
-              <md-button class='moveComponentButton md-raised md-primary'
-                         ng-click='tableController.moveTagUp($index)'>
-                <md-icon>arrow_upward</md-icon>
-                <md-tooltip md-direction='top'
-                            class='projectButtonTooltip'>
-                  {{ ::'moveUp' | translate }}
-                </md-tooltip>
-              </md-button>
-              <md-button class='moveComponentButton md-raised md-primary'
-                         ng-click='tableController.moveTagDown($index)'>
-                <md-icon>arrow_downward</md-icon>
-                <md-tooltip md-direction='top'
-                            class='projectButtonTooltip'>
-                  {{ ::'moveDown' | translate }}
-                </md-tooltip>
-              </md-button>
-              <md-button class='moveComponentButton md-raised md-primary'
-                         ng-click='tableController.deleteTag($index)'>
-                <md-icon>delete</md-icon>
-                <md-tooltip md-direction='top'
-                            class='projectButtonTooltip'>
-                  {{ ::'DELETE' | translate }}
-                </md-tooltip>
-              </md-button>
             </div>
           </div>
         </div>

--- a/src/main/webapp/wise5/teacher/teacher-angular-js-module.ts
+++ b/src/main/webapp/wise5/teacher/teacher-angular-js-module.ts
@@ -36,6 +36,7 @@ import StudentProgressController from '../classroomMonitor/studentProgress/stude
 import WISELinkAuthoringController from '../authoringTool/wiseLink/wiseLinkAuthoringController';
 import { WiseAuthoringTinymceEditorComponent } from '../directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component';
 import { EditComponentJsonComponent } from '../../site/src/app/authoring-tool/edit-component-json/edit-component-json.component';
+import { EditComponentMaxScoreComponent } from '../../site/src/app/authoring-tool/edit-component-max-score/edit-component-max-score.component';
 import { EditComponentRubricComponent } from '../../site/src/app/authoring-tool/edit-component-rubric/edit-component-rubric.component';
 import { EditComponentWidthComponent } from '../../site/src/app/authoring-tool/edit-component-width/edit-component-width.component';
 
@@ -104,6 +105,8 @@ import '../components/table/tableAuthoringComponentModule';
         { component: EditComponentRubricComponent }) as angular.IDirectiveFactory)
     .directive('editComponentWidth', downgradeComponent(
         { component: EditComponentWidthComponent }) as angular.IDirectiveFactory)
+    .directive('editComponentMaxScore', downgradeComponent(
+        { component: EditComponentMaxScoreComponent }) as angular.IDirectiveFactory)
     .component('nodeAdvancedAuthoringComponent', NodeAdvancedAuthoringComponent)
     .component('nodeAdvancedBranchAuthoringComponent', NodeAdvancedBranchAuthoringComponent)
     .component('nodeAdvancedConstraintAuthoringComponent', NodeAdvancedConstraintAuthoringComponent)

--- a/src/main/webapp/wise5/teacher/teacher-angular-js-module.ts
+++ b/src/main/webapp/wise5/teacher/teacher-angular-js-module.ts
@@ -37,6 +37,7 @@ import WISELinkAuthoringController from '../authoringTool/wiseLink/wiseLinkAutho
 import { WiseAuthoringTinymceEditorComponent } from '../directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component';
 import { EditComponentJsonComponent } from '../../site/src/app/authoring-tool/edit-component-json/edit-component-json.component';
 import { EditComponentRubricComponent } from '../../site/src/app/authoring-tool/edit-component-rubric/edit-component-rubric.component';
+import { EditComponentWidthComponent } from '../../site/src/app/authoring-tool/edit-component-width/edit-component-width.component';
 
 import '../classroomMonitor/classroomMonitorComponents';
 import '../authoringTool/structure/structureAuthoringModule';
@@ -101,6 +102,8 @@ import '../components/table/tableAuthoringComponentModule';
         { component: EditComponentJsonComponent }) as angular.IDirectiveFactory)
     .directive('editComponentRubric', downgradeComponent(
         { component: EditComponentRubricComponent }) as angular.IDirectiveFactory)
+    .directive('editComponentWidth', downgradeComponent(
+        { component: EditComponentWidthComponent }) as angular.IDirectiveFactory)
     .component('nodeAdvancedAuthoringComponent', NodeAdvancedAuthoringComponent)
     .component('nodeAdvancedBranchAuthoringComponent', NodeAdvancedBranchAuthoringComponent)
     .component('nodeAdvancedConstraintAuthoringComponent', NodeAdvancedConstraintAuthoringComponent)

--- a/src/main/webapp/wise5/teacher/teacher-angular-js-module.ts
+++ b/src/main/webapp/wise5/teacher/teacher-angular-js-module.ts
@@ -38,6 +38,7 @@ import { WiseAuthoringTinymceEditorComponent } from '../directives/wise-tinymce-
 import { EditComponentJsonComponent } from '../../site/src/app/authoring-tool/edit-component-json/edit-component-json.component';
 import { EditComponentMaxScoreComponent } from '../../site/src/app/authoring-tool/edit-component-max-score/edit-component-max-score.component';
 import { EditComponentRubricComponent } from '../../site/src/app/authoring-tool/edit-component-rubric/edit-component-rubric.component';
+import { EditComponentTagsComponent } from '../../site/src/app/authoring-tool/edit-component-tags/edit-component-tags.component';
 import { EditComponentWidthComponent } from '../../site/src/app/authoring-tool/edit-component-width/edit-component-width.component';
 
 import '../classroomMonitor/classroomMonitorComponents';
@@ -103,6 +104,8 @@ import '../components/table/tableAuthoringComponentModule';
         { component: EditComponentJsonComponent }) as angular.IDirectiveFactory)
     .directive('editComponentRubric', downgradeComponent(
         { component: EditComponentRubricComponent }) as angular.IDirectiveFactory)
+    .directive('editComponentTags', downgradeComponent(
+        { component: EditComponentTagsComponent }) as angular.IDirectiveFactory)
     .directive('editComponentWidth', downgradeComponent(
         { component: EditComponentWidthComponent }) as angular.IDirectiveFactory)
     .directive('editComponentMaxScore', downgradeComponent(


### PR DESCRIPTION
I made the component width, maxScore, and tags authoring into edit-component-width, edit-component-max-score, and edit-component-tags directives. This reduced a lot of duplications in the template files.

Test that those features work as before.

Closes #2830