### PR TITLE
Hide globally-pinned discourse topics from teacher home page latest topics

### DIFF
--- a/src/main/webapp/site/src/app/teacher/discourse-recent-activity/discourse-recent-activity.component.ts
+++ b/src/main/webapp/site/src/app/teacher/discourse-recent-activity/discourse-recent-activity.component.ts
@@ -11,7 +11,6 @@ export class DiscourseRecentActivityComponent {
 
   discourseURL: string;
   topics: any;
-  users: any;
 
   constructor(private configService: ConfigService, private http: HttpClient) {
   }
@@ -20,8 +19,9 @@ export class DiscourseRecentActivityComponent {
     this.discourseURL = this.configService.getDiscourseURL();
     this.http.get(`${this.discourseURL}/latest.json?order=activity`)
         .subscribe(({topic_list, users}: any)=> {
-      this.topics = topic_list.topics.slice(0,3);
-      this.users = users;
+      this.topics = topic_list.topics
+          .filter(topic => { return !topic.pinned_globally; })
+          .slice(0, 3);
     });
   }
 }


### PR DESCRIPTION
Test that globally pinning/unpinning topics in discourse hides/shows them in the teacher homepage.

Closes #2832