### PR TITLE
Wrap latest Discourse post links on teacher homepage

### DIFF
--- a/src/main/webapp/site/src/app/teacher/discourse-recent-activity/discourse-recent-activity.component.scss
+++ b/src/main/webapp/site/src/app/teacher/discourse-recent-activity/discourse-recent-activity.component.scss
@@ -13,11 +13,11 @@ li {
 
   a {
     max-width: 660px;
-    display: inline-block;
     vertical-align: middle;
     
     @media (min-width: breakpoint('md.min')) {
       max-width: 300px;
+      display: inline-block;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
@@ -25,6 +25,12 @@ li {
 
     @media (min-width: breakpoint('lg.min')) {
       max-width: 360px;
+    }
+  }
+
+  span {
+    @media (max-width: breakpoint('sm.max')) {
+      display: inline-block;
     }
   }
 }

--- a/src/main/webapp/site/src/app/teacher/discourse-recent-activity/discourse-recent-activity.component.scss
+++ b/src/main/webapp/site/src/app/teacher/discourse-recent-activity/discourse-recent-activity.component.scss
@@ -13,13 +13,17 @@ li {
 
   a {
     max-width: 660px;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
     display: inline-block;
     vertical-align: middle;
     
     @media (min-width: breakpoint('md.min')) {
+      max-width: 300px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    @media (min-width: breakpoint('lg.min')) {
       max-width: 360px;
     }
   }


### PR DESCRIPTION
To test:
- On teacher homepage, verify that Discourse post titles wrap on screens less than 960px wide.

Closes #2839.