### PR TITLE
Refactored ProjectService.getAllPaths()

### DIFF
--- a/src/main/webapp/site/src/app/services/projectService.spec.ts
+++ b/src/main/webapp/site/src/app/services/projectService.spec.ts
@@ -1109,15 +1109,14 @@ function consolidatePaths() {
 
 function getParentGroup() {
   describe('getParentGroup()', () => {
+    beforeEach(() => {
+      service.setProject(twoStepsProjectJSON);
+    });
     it('should get the parent group of an active node', () => {
-      service.setProject(oneBranchTwoPathsProjectJSON);
-      const parentGroup = service.getParentGroup('node1');
-      expect(parentGroup.id).toEqual('group1');
+      expect(service.getParentGroup('node1').id).toEqual('group1');
     });
     it('should get the parent group of an inactive node', () => {
-      service.setProject(twoStepsProjectJSON);
-      const parentGroup = service.getParentGroup('node3');
-      expect(parentGroup.id).toEqual('group2');
+      expect(service.getParentGroup('node3').id).toEqual('group2');
     });
   });
 }

--- a/src/main/webapp/site/src/app/services/projectService.spec.ts
+++ b/src/main/webapp/site/src/app/services/projectService.spec.ts
@@ -5,8 +5,10 @@ import { ProjectService } from '../../../../wise5/services/projectService';
 import { ConfigService } from '../../../../wise5/services/configService';
 import { UtilService } from '../../../../wise5/services/utilService';
 import demoProjectJSON_import from './sampleData/curriculum/Demo.project.json';
+import oneBranchTwoPathsProjectJSON_import from './sampleData/curriculum/OneBranchTwoPaths.project.json';
 import scootersProjectJSON_import from './sampleData/curriculum/SelfPropelledVehiclesChallenge.project.json';
 import { getAuthServiceConfigs } from '../app.module';
+import twoStepsProjectJSON_import from './sampleData/curriculum/TwoSteps.project.json';
 import { SessionService } from '../../../../wise5/services/sessionService';
 const projectIdDefault = 1;
 const projectBaseURL = 'http://localhost:8080/curriculum/12345/';
@@ -19,7 +21,9 @@ let sessionService: SessionService;
 let utilService: UtilService;
 let http: HttpTestingController;
 let demoProjectJSON: any;
+let oneBranchTwoPathsProjectJSON: any;
 let scootersProjectJSON: any;
+let twoStepsProjectJSON: any;
 
 describe('ProjectService', () => {
   beforeEach(() => {
@@ -34,7 +38,9 @@ describe('ProjectService', () => {
     spyOn(utilService, 'broadcastEventInRootScope').and.callFake(() => {});
     service = TestBed.get(ProjectService);
     demoProjectJSON = JSON.parse(JSON.stringify(demoProjectJSON_import));
+    oneBranchTwoPathsProjectJSON = JSON.parse(JSON.stringify(oneBranchTwoPathsProjectJSON_import));
     scootersProjectJSON = JSON.parse(JSON.stringify(scootersProjectJSON_import));
+    twoStepsProjectJSON = JSON.parse(JSON.stringify(twoStepsProjectJSON_import));
   });
   shouldReplaceAssetPathsInNonHtmlComponentContent();
   shouldReplaceAssetPathsInHtmlComponentContent();
@@ -87,9 +93,10 @@ describe('ProjectService', () => {
   deleteAllStepsInAnActivity();
   getTags();
   addCurrentUserToAuthors_CM_shouldAddUserInfo();
+  getAllPaths();
+  consolidatePaths();
+  getParentGroup();
   // TODO: add test for service.getFlattenedProjectAsNodeIds()
-  // TODO: add test for service.getAllPaths()
-  // TODO: add test for service.consolidatePaths()
   // TODO: add test for service.consumePathsUntilNodeId()
   // TODO: add test for service.getFirstNodeIdInPathAtIndex()
   // TODO: add test for service.removeNodeIdFromPaths()
@@ -1058,5 +1065,59 @@ function addCurrentUserToAuthors_CM_shouldAddUserInfo() {
     const authors = service.addCurrentUserToAuthors([]);
     expect(authors.length).toEqual(1);
     expect(authors[0].id).toEqual(1);
+  });
+}
+
+function getAllPaths() {
+  describe('getAllPaths()', () => {
+    it ('should get all paths in a unit with no branches', () => {
+      service.setProject(twoStepsProjectJSON);
+      const allPaths = service.getAllPaths([], service.getStartNodeId(), true);
+      expect(allPaths.length).toEqual(1);
+      expect(allPaths[0]).toEqual(['group1', 'node1', 'node2']);
+    });
+    it ('should get all paths in a unit with a branch with two paths', () => {
+      service.setProject(oneBranchTwoPathsProjectJSON);
+      const allPaths = service.getAllPaths([], service.getStartNodeId(), true);
+      expect(allPaths.length).toEqual(2);
+      expect(allPaths[0]).toEqual(['group1', 'node1', 'node2', 'node3', 'node4', 'node8']);
+      expect(allPaths[1]).toEqual(['group1', 'node1', 'node2', 'node5', 'node6', 'node7', 'node8']);
+    });
+    it ('should get all paths in a unit starting with a node in a branch path', () => {
+      service.setProject(oneBranchTwoPathsProjectJSON);
+      const allPaths1 = service.getAllPaths(['group1', 'node1', 'node2'], 'node3', true);
+      expect(allPaths1.length).toEqual(1);
+      expect(allPaths1[0]).toEqual(['node3', 'node4', 'node8']);
+      const allPaths2 = service.getAllPaths(['group1', 'node1', 'node2'], 'node5', true);
+      expect(allPaths2.length).toEqual(1);
+      expect(allPaths2[0]).toEqual(['node5', 'node6', 'node7', 'node8']);
+    });
+  });
+}
+
+function consolidatePaths() {
+  describe('consolidatePaths()', () => {
+    it('should consolidate all the paths into a linear list of node ids', () => {
+      service.setProject(oneBranchTwoPathsProjectJSON);
+      const allPaths = service.getAllPaths([], service.getStartNodeId(), true);
+      const consolidatedPaths = service.consolidatePaths(allPaths);
+      expect(consolidatedPaths).toEqual(['group1', 'node1', 'node2', 'node3', 'node4', 'node5',
+        'node6', 'node7', 'node8']);
+    });
+  });
+}
+
+function getParentGroup() {
+  describe('getParentGroup()', () => {
+    it('should get the parent group of an active node', () => {
+      service.setProject(oneBranchTwoPathsProjectJSON);
+      const parentGroup = service.getParentGroup('node1');
+      expect(parentGroup.id).toEqual('group1');
+    });
+    it('should get the parent group of an inactive node', () => {
+      service.setProject(twoStepsProjectJSON);
+      const parentGroup = service.getParentGroup('node3');
+      expect(parentGroup.id).toEqual('group2');
+    });
   });
 }

--- a/src/main/webapp/site/src/app/services/sampleData/curriculum/OneBranchTwoPaths.project.json
+++ b/src/main/webapp/site/src/app/services/sampleData/curriculum/OneBranchTwoPaths.project.json
@@ -1,0 +1,429 @@
+{
+  "nodes": [
+      {
+          "id": "group0",
+          "type": "group",
+          "title": "Master",
+          "startId": "group1",
+          "ids": [
+              "group1"
+          ]
+      },
+      {
+          "id": "group1",
+          "type": "group",
+          "title": "First Lesson",
+          "startId": "node1",
+          "ids": [
+              "node1",
+              "node2",
+              "node3",
+              "node4",
+              "node5",
+              "node6",
+              "node7",
+              "node8"
+          ],
+          "icons": {
+              "default": {
+                  "color": "#2196F3",
+                  "type": "font",
+                  "fontSet": "material-icons",
+                  "fontName": "info"
+              }
+          },
+          "transitionLogic": {
+              "transitions": []
+          }
+      },
+      {
+          "id": "node1",
+          "type": "node",
+          "title": "First Step",
+          "components": [],
+          "constraints": [],
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "transitionLogic": {
+              "transitions": [
+                  {
+                      "to": "node2"
+                  }
+              ]
+          }
+      },
+      {
+          "id": "node2",
+          "title": "Branch point",
+          "type": "node",
+          "constraints": [],
+          "transitionLogic": {
+              "transitions": [
+                  {
+                      "to": "node3"
+                  },
+                  {
+                      "to": "node5"
+                  }
+              ],
+              "howToChooseAmongAvailablePaths": "random",
+              "whenToChoosePath": "enterNode",
+              "canChangePath": false,
+              "maxPathsVisitable": 1
+          },
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "components": []
+      },
+      {
+          "id": "node3",
+          "title": "Path 1 first step",
+          "type": "node",
+          "constraints": [
+              {
+                  "id": "node3Constraint1",
+                  "action": "makeThisNodeNotVisible",
+                  "targetId": "node3",
+                  "removalConditional": "all",
+                  "removalCriteria": [
+                      {
+                          "name": "branchPathTaken",
+                          "params": {
+                              "fromNodeId": "node2",
+                              "toNodeId": "node3"
+                          }
+                      }
+                  ]
+              },
+              {
+                  "id": "node3Constraint2",
+                  "action": "makeThisNodeNotVisitable",
+                  "targetId": "node3",
+                  "removalConditional": "all",
+                  "removalCriteria": [
+                      {
+                          "name": "branchPathTaken",
+                          "params": {
+                              "fromNodeId": "node2",
+                              "toNodeId": "node3"
+                          }
+                      }
+                  ]
+              }
+          ],
+          "transitionLogic": {
+              "transitions": [
+                  {
+                      "to": "node4"
+                  }
+              ]
+          },
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "components": []
+      },
+      {
+          "id": "node4",
+          "title": "Path 1 second step",
+          "type": "node",
+          "constraints": [
+              {
+                  "id": "node4Constraint1",
+                  "action": "makeThisNodeNotVisible",
+                  "targetId": "node4",
+                  "removalConditional": "all",
+                  "removalCriteria": [
+                      {
+                          "name": "branchPathTaken",
+                          "params": {
+                              "fromNodeId": "node2",
+                              "toNodeId": "node3"
+                          }
+                      }
+                  ]
+              },
+              {
+                  "id": "node4Constraint2",
+                  "action": "makeThisNodeNotVisitable",
+                  "targetId": "node4",
+                  "removalConditional": "all",
+                  "removalCriteria": [
+                      {
+                          "name": "branchPathTaken",
+                          "params": {
+                              "fromNodeId": "node2",
+                              "toNodeId": "node3"
+                          }
+                      }
+                  ]
+              }
+          ],
+          "transitionLogic": {
+              "transitions": [
+                  {
+                      "to": "node8"
+                  }
+              ]
+          },
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "components": []
+      },
+      {
+          "id": "node5",
+          "title": "Path 2 first step",
+          "type": "node",
+          "constraints": [
+              {
+                  "id": "node5Constraint1",
+                  "action": "makeThisNodeNotVisible",
+                  "targetId": "node5",
+                  "removalConditional": "all",
+                  "removalCriteria": [
+                      {
+                          "name": "branchPathTaken",
+                          "params": {
+                              "fromNodeId": "node2",
+                              "toNodeId": "node5"
+                          }
+                      }
+                  ]
+              },
+              {
+                  "id": "node5Constraint2",
+                  "action": "makeThisNodeNotVisitable",
+                  "targetId": "node5",
+                  "removalConditional": "all",
+                  "removalCriteria": [
+                      {
+                          "name": "branchPathTaken",
+                          "params": {
+                              "fromNodeId": "node2",
+                              "toNodeId": "node5"
+                          }
+                      }
+                  ]
+              }
+          ],
+          "transitionLogic": {
+              "transitions": [
+                  {
+                      "to": "node6"
+                  }
+              ]
+          },
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "components": []
+      },
+      {
+          "id": "node6",
+          "title": "Path 2 second step",
+          "type": "node",
+          "constraints": [
+              {
+                  "id": "node6Constraint1",
+                  "action": "makeThisNodeNotVisible",
+                  "targetId": "node6",
+                  "removalConditional": "all",
+                  "removalCriteria": [
+                      {
+                          "name": "branchPathTaken",
+                          "params": {
+                              "fromNodeId": "node2",
+                              "toNodeId": "node5"
+                          }
+                      }
+                  ]
+              },
+              {
+                  "id": "node6Constraint2",
+                  "action": "makeThisNodeNotVisitable",
+                  "targetId": "node6",
+                  "removalConditional": "all",
+                  "removalCriteria": [
+                      {
+                          "name": "branchPathTaken",
+                          "params": {
+                              "fromNodeId": "node2",
+                              "toNodeId": "node5"
+                          }
+                      }
+                  ]
+              }
+          ],
+          "transitionLogic": {
+              "transitions": [
+                  {
+                      "to": "node7"
+                  }
+              ]
+          },
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "components": []
+      },
+      {
+          "id": "node7",
+          "title": "Path 2 third step",
+          "type": "node",
+          "constraints": [
+              {
+                  "id": "node7Constraint1",
+                  "action": "makeThisNodeNotVisible",
+                  "targetId": "node7",
+                  "removalConditional": "all",
+                  "removalCriteria": [
+                      {
+                          "name": "branchPathTaken",
+                          "params": {
+                              "fromNodeId": "node2",
+                              "toNodeId": "node5"
+                          }
+                      }
+                  ]
+              },
+              {
+                  "id": "node7Constraint2",
+                  "action": "makeThisNodeNotVisitable",
+                  "targetId": "node7",
+                  "removalConditional": "all",
+                  "removalCriteria": [
+                      {
+                          "name": "branchPathTaken",
+                          "params": {
+                              "fromNodeId": "node2",
+                              "toNodeId": "node5"
+                          }
+                      }
+                  ]
+              }
+          ],
+          "transitionLogic": {
+              "transitions": [
+                  {
+                      "to": "node8"
+                  }
+              ]
+          },
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "components": []
+      },
+      {
+          "id": "node8",
+          "title": "merge step",
+          "type": "node",
+          "constraints": [],
+          "transitionLogic": {
+              "transitions": []
+          },
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "components": []
+      }
+  ],
+  "constraints": [],
+  "startGroupId": "group0",
+  "startNodeId": "node1",
+  "navigationMode": "guided",
+  "layout": {
+      "template": "starmap|leftNav|rightNav"
+  },
+  "metadata": {
+      "title": "Just one branch project",
+      "authors": [
+          {
+              "firstName": "h",
+              "lastName": "t",
+              "id": 3,
+              "username": "ht"
+          }
+      ]
+  },
+  "notebook": {
+      "enabled": false,
+      "label": "Notebook",
+      "enableAddNew": true,
+      "itemTypes": {
+          "note": {
+              "type": "note",
+              "enabled": true,
+              "enableLink": true,
+              "enableAddNote": true,
+              "enableClipping": true,
+              "enableStudentUploads": true,
+              "requireTextOnEveryNote": false,
+              "label": {
+                  "singular": "note",
+                  "plural": "notes",
+                  "link": "Notes",
+                  "icon": "note",
+                  "color": "#1565C0"
+              }
+          },
+          "report": {
+              "enabled": false,
+              "label": {
+                  "singular": "report",
+                  "plural": "reports",
+                  "link": "Report",
+                  "icon": "assignment",
+                  "color": "#AD1457"
+              },
+              "notes": [
+                  {
+                      "reportId": "finalReport",
+                      "title": "Final Report",
+                      "description": "Final summary report of what you learned in this unit",
+                      "prompt": "Use this space to write your final report using evidence from your notebook.",
+                      "content": "<h3>This is a heading</h3><p>This is a paragraph.</p>"
+                  }
+              ]
+          }
+      }
+  },
+  "teacherNotebook": {
+      "enabled": true,
+      "label": "Teacher Notebook",
+      "enableAddNew": true,
+      "itemTypes": {
+          "note": {
+              "type": "note",
+              "enabled": false,
+              "enableLink": true,
+              "enableAddNote": true,
+              "enableClipping": true,
+              "enableStudentUploads": true,
+              "requireTextOnEveryNote": false,
+              "label": {
+                  "singular": "note",
+                  "plural": "notes",
+                  "link": "Notes",
+                  "icon": "note",
+                  "color": "#1565C0"
+              }
+          },
+          "report": {
+              "enabled": true,
+              "label": {
+                  "singular": "teacher notes",
+                  "plural": "teacher notes",
+                  "link": "Teacher Notes",
+                  "icon": "assignment",
+                  "color": "#AD1457"
+              },
+              "notes": [
+                  {
+                      "reportId": "teacherReport",
+                      "title": "Teacher Notes",
+                      "description": "Notes for the teacher as they're running the WISE unit",
+                      "prompt": "Use this space to take notes for this unit",
+                      "content": "<p>Use this space to take notes for this unit</p>"
+                  }
+              ]
+          }
+      }
+  },
+  "inactiveNodes": []
+}

--- a/src/main/webapp/site/src/app/services/sampleData/curriculum/TwoSteps.project.json
+++ b/src/main/webapp/site/src/app/services/sampleData/curriculum/TwoSteps.project.json
@@ -1,0 +1,196 @@
+{
+  "nodes": [
+      {
+          "id": "group0",
+          "type": "group",
+          "title": "Master",
+          "startId": "group1",
+          "ids": [
+              "group1"
+          ],
+          "transitionLogic": {
+              "transitions": []
+          }
+      },
+      {
+          "id": "group1",
+          "type": "group",
+          "title": "First Lesson",
+          "startId": "node1",
+          "ids": [
+              "node1",
+              "node2"
+          ],
+          "icons": {
+              "default": {
+                  "color": "#2196F3",
+                  "type": "font",
+                  "fontSet": "material-icons",
+                  "fontName": "info"
+              }
+          },
+          "transitionLogic": {
+              "transitions": []
+          }
+      },
+      {
+          "id": "node1",
+          "type": "node",
+          "title": "First Step",
+          "components": [],
+          "constraints": [],
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "transitionLogic": {
+              "transitions": [
+                  {
+                      "to": "node2"
+                  }
+              ]
+          }
+      },
+      {
+          "id": "node2",
+          "title": "Second Step",
+          "type": "node",
+          "constraints": [],
+          "transitionLogic": {
+              "transitions": []
+          },
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "components": []
+      }
+  ],
+  "constraints": [],
+  "startGroupId": "group0",
+  "startNodeId": "node1",
+  "navigationMode": "guided",
+  "layout": {
+      "template": "starmap|leftNav|rightNav"
+  },
+  "metadata": {
+      "title": "Just two steps project",
+      "authors": [
+          {
+              "firstName": "h",
+              "lastName": "t",
+              "id": 3,
+              "username": "ht"
+          }
+      ]
+  },
+  "notebook": {
+      "enabled": false,
+      "label": "Notebook",
+      "enableAddNew": true,
+      "itemTypes": {
+          "note": {
+              "type": "note",
+              "enabled": true,
+              "enableLink": true,
+              "enableAddNote": true,
+              "enableClipping": true,
+              "enableStudentUploads": true,
+              "requireTextOnEveryNote": false,
+              "label": {
+                  "singular": "note",
+                  "plural": "notes",
+                  "link": "Notes",
+                  "icon": "note",
+                  "color": "#1565C0"
+              }
+          },
+          "report": {
+              "enabled": false,
+              "label": {
+                  "singular": "report",
+                  "plural": "reports",
+                  "link": "Report",
+                  "icon": "assignment",
+                  "color": "#AD1457"
+              },
+              "notes": [
+                  {
+                      "reportId": "finalReport",
+                      "title": "Final Report",
+                      "description": "Final summary report of what you learned in this unit",
+                      "prompt": "Use this space to write your final report using evidence from your notebook.",
+                      "content": "<h3>This is a heading</h3><p>This is a paragraph.</p>"
+                  }
+              ]
+          }
+      }
+  },
+  "teacherNotebook": {
+      "enabled": true,
+      "label": "Teacher Notebook",
+      "enableAddNew": true,
+      "itemTypes": {
+          "note": {
+              "type": "note",
+              "enabled": false,
+              "enableLink": true,
+              "enableAddNote": true,
+              "enableClipping": true,
+              "enableStudentUploads": true,
+              "requireTextOnEveryNote": false,
+              "label": {
+                  "singular": "note",
+                  "plural": "notes",
+                  "link": "Notes",
+                  "icon": "note",
+                  "color": "#1565C0"
+              }
+          },
+          "report": {
+              "enabled": true,
+              "label": {
+                  "singular": "teacher notes",
+                  "plural": "teacher notes",
+                  "link": "Teacher Notes",
+                  "icon": "assignment",
+                  "color": "#AD1457"
+              },
+              "notes": [
+                  {
+                      "reportId": "teacherReport",
+                      "title": "Teacher Notes",
+                      "description": "Notes for the teacher as they're running the WISE unit",
+                      "prompt": "Use this space to take notes for this unit",
+                      "content": "<p>Use this space to take notes for this unit</p>"
+                  }
+              ]
+          }
+      }
+  },
+  "inactiveNodes": [
+      {
+          "id": "group2",
+          "type": "group",
+          "title": "inactive lesson",
+          "startId": "node3",
+          "constraints": [],
+          "transitionLogic": {
+              "transitions": []
+          },
+          "ids": [
+              "node3"
+          ],
+          "checked": false
+      },
+      {
+          "id": "node3",
+          "title": "first inactive step",
+          "type": "node",
+          "constraints": [],
+          "transitionLogic": {
+              "transitions": []
+          },
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "components": [],
+          "checked": false
+      }
+  ]
+}

--- a/src/main/webapp/wise5/services/projectService.ts
+++ b/src/main/webapp/wise5/services/projectService.ts
@@ -722,7 +722,7 @@ export class ProjectService {
     return nodeIcon;
   }
 
-  getParentGroup(nodeId = '') {
+  getParentGroup(nodeId = ''): any {
     const node = this.getNodeById(nodeId);
     if (node != null) {
       for (const groupNode of this.getGroupNodes()) {
@@ -739,12 +739,10 @@ export class ProjectService {
     return null;
   }
 
-  getParentGroupId(nodeId) {
-    if (nodeId != null) {
-      const parentGroup = this.getParentGroup(nodeId);
-      if (parentGroup != null) {
-        return parentGroup.id;
-      }
+  getParentGroupId(nodeId = ''): string {
+    const parentGroup = this.getParentGroup(nodeId);
+    if (parentGroup != null) {
+      return parentGroup.id;
     }
     return null;
   }

--- a/src/main/webapp/wise5/services/projectService.ts
+++ b/src/main/webapp/wise5/services/projectService.ts
@@ -722,35 +722,23 @@ export class ProjectService {
     return nodeIcon;
   }
 
-  getParentGroup(nodeId) {
-    if (nodeId != null) {
-      const node = this.getNodeById(nodeId);
-      if (node != null) {
-        // Check if the node is a child of an active group.
-        const groupNodes = this.getGroupNodes();
-        for (let groupNode of groupNodes) {
-          if (this.isNodeDirectChildOfGroup(node, groupNode)) {
-            return groupNode;
-          }
+  getParentGroup(nodeId = '') {
+    const node = this.getNodeById(nodeId);
+    if (node != null) {
+      for (const groupNode of this.getGroupNodes()) {
+        if (this.isNodeDirectChildOfGroup(node, groupNode)) {
+          return groupNode;
         }
-
-        // Check if the node is a child of an inactive group.
-        const inactiveGroupNodes = this.getInactiveGroupNodes();
-        for (let inactiveGroupNode of inactiveGroupNodes) {
-          if (this.isNodeDirectChildOfGroup(node, inactiveGroupNode)) {
-            return inactiveGroupNode;
-          }
+      }
+      for (const inactiveGroupNode of this.getInactiveGroupNodes()) {
+        if (this.isNodeDirectChildOfGroup(node, inactiveGroupNode)) {
+          return inactiveGroupNode;
         }
       }
     }
     return null;
   }
 
-  /**
-   * Get the parent group id
-   * @param nodeId the parent group id
-   * @returns the parent group id
-   */
   getParentGroupId(nodeId) {
     if (nodeId != null) {
       const parentGroup = this.getParentGroup(nodeId);
@@ -1018,7 +1006,7 @@ export class ProjectService {
    * @param fromNodeId the node to get transitions from
    * @returns {Array} an array of transitions
    */
-  getTransitionsByFromNodeId(fromNodeId) {
+  getTransitionsByFromNodeId(fromNodeId: string) {
     const transitionLogic = this.getTransitionLogicByFromNodeId(fromNodeId);
     return transitionLogic.transitions;
   }
@@ -1294,19 +1282,9 @@ export class ProjectService {
      * depth first
      */
     const pathsSoFar = [];
-
-    // get all the possible paths through the project
     const allPaths = this.getAllPaths(pathsSoFar, startNodeId);
-
-    // consolidate all the paths to create a single list of node ids
     const nodeIds = this.consolidatePaths(allPaths);
-
-    /*
-     * Remember the flattened node ids so that we don't have to calculate
-     * it again.
-     */
-    this.flattenedProjectAsNodeIds = nodeIds;
-
+    this.flattenedProjectAsNodeIds = nodeIds; // cache flatted node ids
     return nodeIds;
   }
 
@@ -1320,178 +1298,22 @@ export class ProjectService {
    * @param includeGroups whether to include the group node ids in the paths
    * @return an array of paths. each path is an array of node ids.
    */
-  getAllPaths(pathSoFar: string[], nodeId: string, includeGroups: boolean = false) {
+  getAllPaths(pathSoFar: string[], nodeId: string = '', includeGroups: boolean = false) {
     const allPaths = [];
-    if (nodeId != null) {
-      if (this.isApplicationNode(nodeId)) {
-        const path = [];
-        const transitions = this.getTransitionsByFromNodeId(nodeId);
-        if (transitions != null) {
-          if (includeGroups) {
-            const parentGroup = this.getParentGroup(nodeId);
-            if (parentGroup != null) {
-              const parentGroupId = parentGroup.id;
-              if (parentGroupId != null && pathSoFar.indexOf(parentGroupId) == -1) {
-                pathSoFar.push(parentGroup.id);
-              }
-            }
-          }
-
-          /*
-           * add the node id to the path so far so we can later check
-           * which nodes are already in the path to prevent looping
-           * back in the path
-           */
-          pathSoFar.push(nodeId);
-
-          if (transitions.length === 0) {
-            /*
-             * there are no transitions from the node id so we will
-             * look for a transition in the parent group
-             */
-
-            let addedCurrentNodeId = false;
-            const parentGroupId = this.getParentGroupId(nodeId);
-            const parentGroupTransitions = this.getTransitionsByFromNodeId(parentGroupId);
-
-            if (parentGroupTransitions != null) {
-              for (let parentGroupTransition of parentGroupTransitions) {
-                if (parentGroupTransition != null) {
-                  const toNodeId = parentGroupTransition.to;
-                  if (pathSoFar.indexOf(toNodeId) == -1) {
-                    /*
-                     * recursively get the paths by getting all
-                     * the paths for the to node
-                     */
-                    const allPathsFromToNode = this.getAllPaths(pathSoFar, toNodeId, includeGroups);
-
-                    for (let tempPath of allPathsFromToNode) {
-                      tempPath.unshift(nodeId);
-                      allPaths.push(tempPath);
-                      addedCurrentNodeId = true;
-                    }
-                  }
-                }
-              }
-            }
-
-            if (!addedCurrentNodeId) {
-              /*
-               * if the parent group doesn't have any transitions we will
-               * need to add the current node id to the path
-               */
-              path.push(nodeId);
-              allPaths.push(path);
-            }
-          } else {
-            // there are transitions from this node id
-
-            for (let transition of transitions) {
-              if (transition != null) {
-                const toNodeId = transition.to;
-                if (toNodeId != null && pathSoFar.indexOf(toNodeId) == -1) {
-                  // we have not found the to node in the path yet so we can traverse it
-
-                  /*
-                   * recursively get the paths by getting all
-                   * the paths from the to node
-                   */
-                  const allPathsFromToNode = this.getAllPaths(pathSoFar, toNodeId, includeGroups);
-
-                  if (allPathsFromToNode != null) {
-                    for (let tempPath of allPathsFromToNode) {
-                      if (includeGroups) {
-                        // we need to add the group id to the path
-
-                        if (tempPath.length > 0) {
-                          const firstNodeId = tempPath[0];
-                          const firstParentGroupId = this.getParentGroupId(firstNodeId);
-                          const parentGroupId = this.getParentGroupId(nodeId);
-                          if (parentGroupId != firstParentGroupId) {
-                            /*
-                             * the parent ids are different which means this is a boundary
-                             * between two groups. for example if the project looked like
-                             * group1>node1>node2>group2>node3>node4
-                             * and the current node was node2 then the first node in the
-                             * path would be node3 which means we would need to place
-                             * group2 on the path before node3
-                             */
-                            tempPath.unshift(firstParentGroupId);
-                          }
-                        }
-                      }
-
-                      tempPath.unshift(nodeId);
-                      allPaths.push(tempPath);
-                    }
-                  }
-                } else {
-                  /*
-                   * the node is already in the path so far which means
-                   * the transition is looping back to a previous node.
-                   * we do not want to take this transition because
-                   * it will lead to an infinite loop. we will just
-                   * add the current node id to the path and not take
-                   * the transition which essentially ends the path.
-                   */
-                  path.push(nodeId);
-                  allPaths.push(path);
-                }
-              }
-            }
-          }
-
-          if (pathSoFar.length > 0) {
-            const lastNodeId = pathSoFar[pathSoFar.length - 1];
-            if (this.isGroupNode(lastNodeId)) {
-              /*
-               * the last node id is a group id so we will remove it
-               * since we are moving back up the path as we traverse
-               * the nodes depth first
-               */
-              pathSoFar.pop();
-            }
-          }
-
-          /*
-           * remove the latest node id (this will be a step node id)
-           * since we are moving back up the path as we traverse the
-           * nodes depth first
-           */
-          pathSoFar.pop();
-
-          if (includeGroups) {
-            if (pathSoFar.length == 1) {
-              /*
-               * we are including groups and we have traversed
-               * back up to the start node id for the project.
-               * the only node id left in pathSoFar is now the
-               * parent group of the start node id. we will
-               * now add this parent group of the start node id
-               * to all of the paths
-               */
-
-              for (let path of allPaths) {
-                if (path != null) {
-                  /*
-                   * prepend the parent group of the start node id
-                   * to the path
-                   */
-                  path.unshift(pathSoFar[0]);
-                }
-              }
-
-              /*
-               * remove the parent group of the start node id from
-               * pathSoFar which leaves us with an empty pathSoFar
-               * which means we are completely done with
-               * calculating all the paths
-               */
-              pathSoFar.pop();
+    if (this.isApplicationNode(nodeId)) {
+      const path = [];
+      const transitions = this.getTransitionsByFromNodeId(nodeId);
+      if (transitions != null) {
+        if (includeGroups) {
+          const parentGroup = this.getParentGroup(nodeId);
+          if (parentGroup != null) {
+            const parentGroupId = parentGroup.id;
+            if (parentGroupId != null && pathSoFar.indexOf(parentGroupId) == -1) {
+              pathSoFar.push(parentGroup.id);
             }
           }
         }
-      } else if (this.isGroupNode(nodeId)) {
+
         /*
          * add the node id to the path so far so we can later check
          * which nodes are already in the path to prevent looping
@@ -1499,59 +1321,213 @@ export class ProjectService {
          */
         pathSoFar.push(nodeId);
 
-        const groupNode = this.getNodeById(nodeId);
-        if (groupNode != null) {
-          const startId = groupNode.startId;
-          if (startId == null || startId == '') {
-            // there is no start id so we will take the transition from the group
-            // TODO? there is no start id so we will loop through all the child nodes
+        if (transitions.length === 0) {
+          /*
+           * there are no transitions from the node id so we will
+           * look for a transition in the parent group
+           */
 
-            const transitions = this.getTransitionsByFromNodeId(groupNode.id);
-            if (transitions != null && transitions.length > 0) {
-              for (let transition of transitions) {
-                if (transition != null) {
-                  const toNodeId = transition.to;
+          let addedCurrentNodeId = false;
+          const parentGroupId = this.getParentGroupId(nodeId);
+          const parentGroupTransitions = this.getTransitionsByFromNodeId(parentGroupId);
 
+          if (parentGroupTransitions != null) {
+            for (let parentGroupTransition of parentGroupTransitions) {
+              if (parentGroupTransition != null) {
+                const toNodeId = parentGroupTransition.to;
+                if (pathSoFar.indexOf(toNodeId) == -1) {
+                  /*
+                   * recursively get the paths by getting all
+                   * the paths for the to node
+                   */
                   const allPathsFromToNode = this.getAllPaths(pathSoFar, toNodeId, includeGroups);
 
-                  if (allPathsFromToNode != null) {
-                    for (let tempPath of allPathsFromToNode) {
-                      tempPath.unshift(nodeId);
-                      allPaths.push(tempPath);
-                    }
+                  for (let tempPath of allPathsFromToNode) {
+                    tempPath.unshift(nodeId);
+                    allPaths.push(tempPath);
+                    addedCurrentNodeId = true;
                   }
                 }
               }
-            } else {
-              /*
-               * this activity does not have any transitions so
-               * we have reached the end of this path
-               */
-
-              const tempPath = [];
-              tempPath.unshift(nodeId);
-              allPaths.push(tempPath);
             }
-          } else {
-            // there is a start id so we will traverse it
+          }
 
-            const allPathsFromToNode = this.getAllPaths(pathSoFar, startId, includeGroups);
+          if (!addedCurrentNodeId) {
+            /*
+             * if the parent group doesn't have any transitions we will
+             * need to add the current node id to the path
+             */
+            path.push(nodeId);
+            allPaths.push(path);
+          }
+        } else {
+          // there are transitions from this node id
 
-            if (allPathsFromToNode != null) {
-              for (let tempPath of allPathsFromToNode) {
-                tempPath.unshift(nodeId);
-                allPaths.push(tempPath);
+          for (let transition of transitions) {
+            if (transition != null) {
+              const toNodeId = transition.to;
+              if (toNodeId != null && pathSoFar.indexOf(toNodeId) == -1) {
+                // we have not found the to node in the path yet so we can traverse it
+
+                /*
+                 * recursively get the paths by getting all
+                 * the paths from the to node
+                 */
+                const allPathsFromToNode = this.getAllPaths(pathSoFar, toNodeId, includeGroups);
+
+                if (allPathsFromToNode != null) {
+                  for (let tempPath of allPathsFromToNode) {
+                    if (includeGroups) {
+                      // we need to add the group id to the path
+
+                      if (tempPath.length > 0) {
+                        const firstNodeId = tempPath[0];
+                        const firstParentGroupId = this.getParentGroupId(firstNodeId);
+                        const parentGroupId = this.getParentGroupId(nodeId);
+                        if (parentGroupId != firstParentGroupId) {
+                          /*
+                           * the parent ids are different which means this is a boundary
+                           * between two groups. for example if the project looked like
+                           * group1>node1>node2>group2>node3>node4
+                           * and the current node was node2 then the first node in the
+                           * path would be node3 which means we would need to place
+                           * group2 on the path before node3
+                           */
+                          tempPath.unshift(firstParentGroupId);
+                        }
+                      }
+                    }
+
+                    tempPath.unshift(nodeId);
+                    allPaths.push(tempPath);
+                  }
+                }
+              } else {
+                /*
+                 * the node is already in the path so far which means
+                 * the transition is looping back to a previous node.
+                 * we do not want to take this transition because
+                 * it will lead to an infinite loop. we will just
+                 * add the current node id to the path and not take
+                 * the transition which essentially ends the path.
+                 */
+                path.push(nodeId);
+                allPaths.push(path);
               }
             }
           }
         }
 
+        if (pathSoFar.length > 0) {
+          const lastNodeId = pathSoFar[pathSoFar.length - 1];
+          if (this.isGroupNode(lastNodeId)) {
+            /*
+             * the last node id is a group id so we will remove it
+             * since we are moving back up the path as we traverse
+             * the nodes depth first
+             */
+            pathSoFar.pop();
+          }
+        }
+
         /*
-         * remove the latest node id since we are moving back
-         * up the path as we traverse the nodes depth first
+         * remove the latest node id (this will be a step node id)
+         * since we are moving back up the path as we traverse the
+         * nodes depth first
          */
         pathSoFar.pop();
+
+        if (includeGroups) {
+          if (pathSoFar.length == 1) {
+            /*
+             * we are including groups and we have traversed
+             * back up to the start node id for the project.
+             * the only node id left in pathSoFar is now the
+             * parent group of the start node id. we will
+             * now add this parent group of the start node id
+             * to all of the paths
+             */
+
+            for (let path of allPaths) {
+              if (path != null) {
+                /*
+                 * prepend the parent group of the start node id
+                 * to the path
+                 */
+                path.unshift(pathSoFar[0]);
+              }
+            }
+
+            /*
+             * remove the parent group of the start node id from
+             * pathSoFar which leaves us with an empty pathSoFar
+             * which means we are completely done with
+             * calculating all the paths
+             */
+            pathSoFar.pop();
+          }
+        }
       }
+    } else {
+      /*
+       * add the node id to the path so far so we can later check
+       * which nodes are already in the path to prevent looping
+       * back in the path
+       */
+      pathSoFar.push(nodeId);
+
+      const groupNode = this.getNodeById(nodeId);
+      if (groupNode != null) {
+        const startId = groupNode.startId;
+        if (startId == null || startId == '') {
+          // there is no start id so we will take the transition from the group
+          // TODO? there is no start id so we will loop through all the child nodes
+
+          const transitions = this.getTransitionsByFromNodeId(groupNode.id);
+          if (transitions != null && transitions.length > 0) {
+            for (let transition of transitions) {
+              if (transition != null) {
+                const toNodeId = transition.to;
+
+                const allPathsFromToNode = this.getAllPaths(pathSoFar, toNodeId, includeGroups);
+
+                if (allPathsFromToNode != null) {
+                  for (let tempPath of allPathsFromToNode) {
+                    tempPath.unshift(nodeId);
+                    allPaths.push(tempPath);
+                  }
+                }
+              }
+            }
+          } else {
+            /*
+             * this activity does not have any transitions so
+             * we have reached the end of this path
+             */
+
+            const tempPath = [];
+            tempPath.unshift(nodeId);
+            allPaths.push(tempPath);
+          }
+        } else {
+          // there is a start id so we will traverse it
+
+          const allPathsFromToNode = this.getAllPaths(pathSoFar, startId, includeGroups);
+
+          if (allPathsFromToNode != null) {
+            for (let tempPath of allPathsFromToNode) {
+              tempPath.unshift(nodeId);
+              allPaths.push(tempPath);
+            }
+          }
+        }
+      }
+
+      /*
+       * remove the latest node id since we are moving back
+       * up the path as we traverse the nodes depth first
+       */
+      pathSoFar.pop();
     }
     return allPaths;
   }
@@ -1561,59 +1537,56 @@ export class ProjectService {
    * @param paths an array of paths. each path is an array of node ids.
    * @return an array of node ids that have been properly ordered
    */
-  consolidatePaths(paths) {
+  consolidatePaths(paths = []) {
     let consolidatedPath = [];
+    /*
+     * continue until all the paths are empty. as we consolidate
+     * node ids, we will remove them from the paths. once all the
+     * paths are empty we will be done consolidating the paths.
+     */
+    while (!this.arePathsEmpty(paths)) {
+      // start with the first path
+      const currentPath = this.getNonEmptyPathIndex(paths);
 
-    if (paths != null) {
-      /*
-       * continue until all the paths are empty. as we consolidate
-       * node ids, we will remove them from the paths. once all the
-       * paths are empty we will be done consolidating the paths.
-       */
-      while (!this.arePathsEmpty(paths)) {
-        // start with the first path
-        const currentPath = this.getNonEmptyPathIndex(paths);
+      // get the first node id in the current path
+      const nodeId = this.getFirstNodeIdInPathAtIndex(paths, currentPath);
+      if (this.areFirstNodeIdsInPathsTheSame(paths)) {
+        // the first node ids in all the paths are the same
 
-        // get the first node id in the current path
-        const nodeId = this.getFirstNodeIdInPathAtIndex(paths, currentPath);
-        if (this.areFirstNodeIdsInPathsTheSame(paths)) {
-          // the first node ids in all the paths are the same
+        // remove the node id from all the paths
+        this.removeNodeIdFromPaths(nodeId, paths);
 
-          // remove the node id from all the paths
-          this.removeNodeIdFromPaths(nodeId, paths);
+        // add the node id to our consolidated path
+        consolidatedPath.push(nodeId);
+      } else {
+        // not all the top node ids are the same which means we have branched
 
-          // add the node id to our consolidated path
-          consolidatedPath.push(nodeId);
-        } else {
-          // not all the top node ids are the same which means we have branched
+        // get all the paths that contain the node id
+        const pathsThatContainNodeId = this.getPathsThatContainNodeId(nodeId, paths);
 
-          // get all the paths that contain the node id
-          const pathsThatContainNodeId = this.getPathsThatContainNodeId(nodeId, paths);
+        if (pathsThatContainNodeId != null) {
+          if (pathsThatContainNodeId.length === 1) {
+            // only the current path we are on has the node id
 
-          if (pathsThatContainNodeId != null) {
-            if (pathsThatContainNodeId.length === 1) {
-              // only the current path we are on has the node id
+            // remove the node id from the path
+            this.removeNodeIdFromPath(nodeId, paths, currentPath);
 
-              // remove the node id from the path
-              this.removeNodeIdFromPath(nodeId, paths, currentPath);
+            // add the node id to our consolidated path
+            consolidatedPath.push(nodeId);
+          } else {
+            // there are multiple paths that have this node id
 
-              // add the node id to our consolidated path
-              consolidatedPath.push(nodeId);
-            } else {
-              // there are multiple paths that have this node id
+            // consume all the node ids up to the given node id
+            const consumedPath = this.consumePathsUntilNodeId(paths, nodeId);
 
-              // consume all the node ids up to the given node id
-              const consumedPath = this.consumePathsUntilNodeId(paths, nodeId);
+            // remove the node id from the paths
+            this.removeNodeIdFromPaths(nodeId, paths);
 
-              // remove the node id from the paths
-              this.removeNodeIdFromPaths(nodeId, paths);
+            // add the node id to the end of the consumed path
+            consumedPath.push(nodeId);
 
-              // add the node id to the end of the consumed path
-              consumedPath.push(nodeId);
-
-              // add the consumed path to our consolidated path
-              consolidatedPath = consolidatedPath.concat(consumedPath);
-            }
+            // add the consumed path to our consolidated path
+            consolidatedPath = consolidatedPath.concat(consumedPath);
           }
         }
       }


### PR DESCRIPTION
Also refactored consolidatePaths() and getParentGroup() and added tests. 

Code complexity went down from 228 to 192 just by removing the outer-most null check. I did the same for consolidatePaths() and getParentGroup(). We can take a closer look at getAllPaths() in a future task and get the complexity down even more.

Test that the unit preview and authoring work as before. Test with various units, with and without branches.

Closes #2396