### PR TITLE
Unlinking Google account for teachers and students

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
@@ -14,7 +14,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.MessageSource;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.acls.model.Permission;
 import org.springframework.security.core.Authentication;
@@ -38,7 +37,6 @@ import org.wise.portal.presentation.web.exception.InvalidNameException;
 import org.wise.portal.presentation.web.response.SimpleResponse;
 import org.wise.portal.service.authentication.DuplicateUsernameException;
 import org.wise.portal.service.authentication.UserDetailsService;
-import org.wise.portal.service.mail.IMailFacade;
 
 /**
  * Teacher REST API
@@ -54,12 +52,6 @@ public class TeacherAPIController extends UserAPIController {
 
   @Autowired
   private UserDetailsService userDetailsService;
-
-  @Autowired
-  protected IMailFacade mailService;
-
-  @Autowired
-  protected MessageSource messageSource;
 
   @Value("${google.clientId:}")
   private String googleClientId;

--- a/src/main/java/org/wise/portal/presentation/web/controllers/user/GoogleUserAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/user/GoogleUserAPIController.java
@@ -1,0 +1,84 @@
+package org.wise.portal.presentation.web.controllers.user;
+
+import java.util.HashMap;
+import java.util.Locale;
+
+import javax.mail.MessagingException;
+
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.domain.authentication.impl.PersistentUserDetails;
+import org.wise.portal.domain.authentication.impl.TeacherUserDetails;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.presentation.web.exception.InvalidPasswordExcpetion;
+
+@RestController
+@RequestMapping("/api/google-user")
+public class GoogleUserAPIController extends UserAPIController {
+
+  @GetMapping("/check-user-exists")
+  boolean isGoogleIdExist(@RequestParam String googleUserId) {
+    return userService.retrieveUserByGoogleUserId(googleUserId) != null;
+  }
+
+  @GetMapping("/check-user-matches")
+  boolean isGoogleIdMatches(@RequestParam String googleUserId, @RequestParam String userId) {
+    User user = userService.retrieveUserByGoogleUserId(googleUserId);
+    return user != null && user.getId().toString().equals(userId);
+  }
+
+  @GetMapping("/get-user")
+  HashMap<String, Object> getUserByGoogleId(@RequestParam String googleUserId) {
+    User user = userService.retrieveUserByGoogleUserId(googleUserId);
+    HashMap<String, Object> response = new HashMap<String, Object>();
+    if (user == null) {
+      response.put("status", "error");
+    } else {
+      response.put("status", "success");
+      response.put("userId", user.getId());
+      response.put("username", user.getUserDetails().getUsername());
+      response.put("firstName", user.getUserDetails().getFirstname());
+      response.put("lastName", user.getUserDetails().getLastname());
+    }
+    return response;
+  }
+
+  @Secured("ROLE_USER")
+  @PostMapping("/unlink-account")
+  HashMap<String, Object> unlinkGoogleAccount(Authentication auth, @RequestParam String newPassword)
+      throws InvalidPasswordExcpetion {
+    if (newPassword.isEmpty()) {
+      throw new InvalidPasswordExcpetion();
+    }
+    String username = auth.getName();
+    User user = userService.retrieveUserByUsername(username);
+    ((PersistentUserDetails) user.getUserDetails()).setGoogleUserId(null);
+    userService.updateUserPassword(user, newPassword);
+    boolean isSendEmail = Boolean.parseBoolean(appProperties.getProperty("send_email_enabled", "false"));
+    if (isSendEmail && user.isTeacher()) {
+      this.sendUnlinkGoogleEmail((TeacherUserDetails) user.getUserDetails());
+    }
+    return this.getUserInfo(auth, username);
+  }
+
+  private void sendUnlinkGoogleEmail(TeacherUserDetails userDetails) {
+    String[] recipients = { userDetails.getEmailAddress() };
+    String subject = messageSource.getMessage("unlink_google_account_success_email_subject", null,
+      "Successfully Unlinked Google Account", new Locale(userDetails.getLanguage()));
+    String username = userDetails.getUsername();
+    String message = messageSource.getMessage("unlink_google_account_success_email_body",
+      new Object[]{username},
+      "You have unlinked your Google account from WISE. To sign in to WISE in the future, please use your username and the password you just created. Your username is: " + username,
+      new Locale(userDetails.getLanguage()));
+    try {
+      mailService.postMail(recipients, subject, message, appProperties.getProperty("portalemailaddress"));
+    } catch (MessagingException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.MessageSource;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.switchuser.SwitchUserFilter;
@@ -62,6 +63,9 @@ public class UserAPIController {
 
   @Autowired
   protected IMailFacade mailService;
+
+  @Autowired
+  protected MessageSource messageSource;
 
   @Value("${google.clientId:}")
   protected String googleClientId = "";
@@ -187,33 +191,6 @@ public class UserAPIController {
       langs.add(localeAndLang);
     }
     return langs;
-  }
-
-  @GetMapping("/check-google-user-exists")
-  boolean isGoogleIdExist(@RequestParam String googleUserId) {
-    return userService.retrieveUserByGoogleUserId(googleUserId) != null;
-  }
-
-  @GetMapping("/check-google-user-matches")
-  boolean isGoogleIdMatches(@RequestParam String googleUserId, @RequestParam String userId) {
-    User user = userService.retrieveUserByGoogleUserId(googleUserId);
-    return user != null && user.getId().toString().equals(userId);
-  }
-
-  @GetMapping("/google-user")
-  HashMap<String, Object> getUserByGoogleId(@RequestParam String googleUserId) {
-    User user = userService.retrieveUserByGoogleUserId(googleUserId);
-    HashMap<String, Object> response = new HashMap<String, Object>();
-    if (user == null) {
-      response.put("status", "error");
-    } else {
-      response.put("status", "success");
-      response.put("userId", user.getId());
-      response.put("username", user.getUserDetails().getUsername());
-      response.put("firstName", user.getUserDetails().getFirstname());
-      response.put("lastName", user.getUserDetails().getLastname());
-    }
-    return response;
   }
 
   private String getLanguageName(String localeString) {

--- a/src/main/java/org/wise/portal/presentation/web/exception/InvalidPasswordExcpetion.java
+++ b/src/main/java/org/wise/portal/presentation/web/exception/InvalidPasswordExcpetion.java
@@ -1,0 +1,6 @@
+package org.wise.portal.presentation.web.exception;
+
+public class InvalidPasswordExcpetion extends Exception {
+
+  private static final long serialVersionUID = 1L;
+}

--- a/src/main/resources/i18n/i18n.properties
+++ b/src/main/resources/i18n/i18n.properties
@@ -308,6 +308,12 @@ teacher_cap.description=Text for the word "Teacher"
 team_cap=Team
 team_cap.description=Text for the word "Team"
 
+unlink_google_account_success_email_subject=Successfully Unlinked Google Account
+unlink_google_account_success_email_subject.description=Subject text in email to notify user about successfuly unlinking google account
+
+unlink_google_account_success_email_body=You have unlinked your Google account from WISE. To sign in to WISE in the future, please use your username and the password you just created.\n\nYour username is: {0}\n\nThank you for using WISE,\nWISE Team
+unlink_google_account_success_email_body.description=Body text in email to notify user about successfully unlinking google account
+
 # Root (/) Pages #
 
 accountmenu.forgot=Forgot Username or Password?

--- a/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.ts
+++ b/src/main/webapp/site/src/app/modules/library/copy-project-dialog/copy-project-dialog.component.ts
@@ -5,7 +5,6 @@ import { finalize } from 'rxjs/operators';
 import { LibraryProject } from '../libraryProject';
 import { LibraryService } from '../../../services/library.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-copy-project-dialog',

--- a/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.html
+++ b/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.html
@@ -57,5 +57,13 @@
   </div>
 </form>
 <ng-container *ngIf="isGoogleUser">
-  <p class="notice" i18n>This account was created using Google and doesn't use a WISE password. If you would like to unlink your Google account, please <a routerLink="/contact">contact us</a>.</p>
+  <p class="notice" i18n>This account was created using Google and doesn't use a WISE password.</p>
+  <p class="notice">
+    <button mat-raised-button
+      id="unlinkGoogleAccount"
+      (click)="unlinkGoogleAccount()">
+      <mat-icon>link_off</mat-icon>
+      <ng-container i18n>Unlink Google Account</ng-container>
+    </button>
+  </p>
 </ng-container>

--- a/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.html
+++ b/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.html
@@ -57,13 +57,17 @@
   </div>
 </form>
 <ng-container *ngIf="isGoogleUser">
-  <p class="notice" i18n>This account was created using Google and doesn't use a WISE password.</p>
-  <p class="notice">
-    <button mat-raised-button
-      id="unlinkGoogleAccount"
-      (click)="unlinkGoogleAccount()">
-      <mat-icon>link_off</mat-icon>
-      <ng-container i18n>Unlink Google Account</ng-container>
+  <p fxLayoutAlign="start center" fxLayoutGap="8px" i18n>
+    <img class="google-icon" src="assets/img/icons/g-logo.png" i18n-alt alt="Google logo" />
+    <span>This account was created using Google and doesn't use a WISE password.</span>
+  </p>
+  <p>
+    <button id="unlinkGoogleAccount"
+        class="unlink"
+        type="button"
+        mat-raised-button
+        (click)="unlinkGoogleAccount()">
+      <span class="warn" i18n>Unlink Google Account</span>
     </button>
   </p>
 </ng-container>

--- a/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.scss
+++ b/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.scss
@@ -11,6 +11,11 @@ form {
   }
 }
 
-.notice {
-  margin: 0 auto;
+.google-icon {
+  height: 1.8em;
+  width: auto;
+}
+
+.unlink {
+  margin: 8px 0;
 }

--- a/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.spec.ts
@@ -1,14 +1,17 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { EditPasswordComponent } from './edit-password.component';
 import { UserService } from '../../../services/user.service';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
-import { NO_ERRORS_SCHEMA, Provider } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { By } from '@angular/platform-browser';
 import { User } from '../../../domain/user';
 import { configureTestSuite } from 'ng-bullet';
+import { MatDialogModule } from '@angular/material/dialog';
+const CORRECT_OLD_PASS = 'a';
+const INCORRECT_OLD_PASS = 'b';
 
 export class MockUserService {
   getUser(): BehaviorSubject<User> {
@@ -22,13 +25,13 @@ export class MockUserService {
   }
 
   changePassword(username, oldPassword, newPassword) {
-    if (oldPassword === 'a') {
-      return Observable.create((observer) => {
+    if (oldPassword === CORRECT_OLD_PASS) {
+      return new Observable((observer) => {
         observer.next({ status: 'success', messageCode: 'passwordChanged' });
         observer.complete();
       });
     } else {
-      return Observable.create((observer) => {
+      return new Observable((observer) => {
         observer.next({ status: 'error', messageCode: 'incorrectPassword' });
         observer.complete();
       });
@@ -36,22 +39,26 @@ export class MockUserService {
   }
 }
 
+let component: EditPasswordComponent;
+let fixture: ComponentFixture<EditPasswordComponent>;
+
+const getSubmitButton = () => {
+  return fixture.debugElement.nativeElement.querySelector('button[type="submit"]');
+};
+
+const getUnlinkGoogleAccountButton = () => {
+  return fixture.debugElement.nativeElement.querySelector('button[id="unlinkGoogleAccount"]');
+};
+
+const getForm = () => {
+  return fixture.debugElement.query(By.css('form'));
+};
+
 describe('EditPasswordComponent', () => {
-  let component: EditPasswordComponent;
-  let fixture: ComponentFixture<EditPasswordComponent>;
-
-  const getSubmitButton = () => {
-    return fixture.debugElement.nativeElement.querySelector('button[type="submit"]');
-  };
-
-  const getForm = () => {
-    return fixture.debugElement.query(By.css('form'));
-  };
-
   configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [EditPasswordComponent],
-      imports: [BrowserAnimationsModule, ReactiveFormsModule, MatSnackBarModule],
+      imports: [BrowserAnimationsModule, ReactiveFormsModule, MatSnackBarModule, MatDialogModule],
       providers: [{ provide: UserService, useValue: new MockUserService() }],
       schemas: [NO_ERRORS_SCHEMA]
     });
@@ -63,61 +70,60 @@ describe('EditPasswordComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+  initialState_disableSubmitButton();
+  validForm_enableSubmitButton();
+  passwordMismatch_disableSubmitButtonAndInvalidateForm();
+  oldPasswordIncorrect_disableSubmitButtonAndShowError();
+  formSubmit_disableSubmitButton();
+  passwordChanged_handleResponse();
+  incorrectPassword_showError();
+  notGoogleUser_showUnlinkOption();
+  unlinkGoogleButtonClick_showDialog();
+});
 
+function initialState_disableSubmitButton() {
   it('should disable submit button and invalidate form on initial state', () => {
     expect(component.changePasswordFormGroup.valid).toBeFalsy();
-    const submitButton = getSubmitButton();
-    expect(submitButton.disabled).toBe(true);
+    expectSubmitButtonDisabled();
   });
+}
 
+function validForm_enableSubmitButton() {
   it('should enable submit button when form is valid', () => {
-    component.changePasswordFormGroup.get('oldPassword').setValue('a');
-    component.newPasswordFormGroup.get('newPassword').setValue('b');
-    component.newPasswordFormGroup.get('confirmNewPassword').setValue('b');
-    fixture.detectChanges();
-    const submitButton = getSubmitButton();
-    expect(submitButton.disabled).toBe(false);
+    setPasswords(CORRECT_OLD_PASS, 'b', 'b');
+    expectSubmitButtonEnabled();
     expect(component.changePasswordFormGroup.valid).toBeTruthy();
   });
+}
 
+function passwordMismatch_disableSubmitButtonAndInvalidateForm() {
   it('should disable submit button and invalidate form when new password and confirm new password fields do not match', () => {
-    component.changePasswordFormGroup.get('oldPassword').setValue('a');
-    component.newPasswordFormGroup.get('newPassword').setValue('a');
-    component.newPasswordFormGroup.get('confirmNewPassword').setValue('b');
-    fixture.detectChanges();
-    const submitButton = getSubmitButton();
-    expect(submitButton.disabled).toBe(true);
+    setPasswords(CORRECT_OLD_PASS, 'a', 'b');
+    expectSubmitButtonDisabled();
     expect(component.changePasswordFormGroup.valid).toBeFalsy();
   });
+}
 
+function oldPasswordIncorrect_disableSubmitButtonAndShowError() {
   it('should disable submit button and set incorrectPassword error when old password is incorrect', async () => {
-    component.changePasswordFormGroup.get('oldPassword').setValue('b');
-    component.newPasswordFormGroup.get('newPassword').setValue('c');
-    component.newPasswordFormGroup.get('confirmNewPassword').setValue('c');
-    const form = getForm();
-    form.triggerEventHandler('submit', null);
-    fixture.detectChanges();
-    const submitButton = getSubmitButton();
-    expect(submitButton.disabled).toBe(true);
+    setPasswords(INCORRECT_OLD_PASS, 'c', 'c');
+    submitForm();
+    expectSubmitButtonDisabled();
     expect(component.changePasswordFormGroup.get('oldPassword').getError('incorrectPassword')).toBe(
       true
     );
   });
+}
 
+function formSubmit_disableSubmitButton() {
   it('should disable submit button when form is successfully submitted', async () => {
-    component.changePasswordFormGroup.get('oldPassword').setValue('a');
-    component.newPasswordFormGroup.get('newPassword').setValue('b');
-    component.newPasswordFormGroup.get('confirmNewPassword').setValue('b');
-    const form = getForm();
-    form.triggerEventHandler('submit', null);
-    fixture.detectChanges();
-    const submitButton = getSubmitButton();
-    expect(submitButton.disabled).toBe(true);
+    setPasswords(CORRECT_OLD_PASS, 'b', 'b');
+    submitForm();
+    expectSubmitButtonDisabled();
   });
+}
 
+function passwordChanged_handleResponse() {
   it('should handle the change password response when the password was successfully changed', () => {
     const resetFormSpy = spyOn(component, 'resetForm');
     const snackBarSpy = spyOn(component.snackBar, 'open');
@@ -129,7 +135,9 @@ describe('EditPasswordComponent', () => {
     expect(resetFormSpy).toHaveBeenCalled();
     expect(snackBarSpy).toHaveBeenCalled();
   });
+}
 
+function incorrectPassword_showError() {
   it('should handle the change password response when the password was incorrect', () => {
     const response = {
       status: 'error',
@@ -140,4 +148,44 @@ describe('EditPasswordComponent', () => {
       true
     );
   });
-});
+}
+
+function notGoogleUser_showUnlinkOption() {
+  it('should hide show option to unlink google account if the user is not a google user', () => {
+    expect(getUnlinkGoogleAccountButton()).toBeNull();
+  });
+}
+
+function unlinkGoogleButtonClick_showDialog() {
+  it('clicking on unlink google account link should open a dialog', () => {
+    const dialogSpy = spyOn(component.dialog, 'open');
+    setGoogleUser();
+    getUnlinkGoogleAccountButton().click();
+    expect(dialogSpy).toHaveBeenCalled();
+  });
+}
+
+export function expectSubmitButtonDisabled() {
+  expect(getSubmitButton().disabled).toBe(true);
+}
+
+function expectSubmitButtonEnabled() {
+  expect(getSubmitButton().disabled).toBe(false);
+}
+
+function submitForm() {
+  getForm().triggerEventHandler('submit', null);
+  fixture.detectChanges();
+}
+
+function setGoogleUser() {
+  component.isGoogleUser = true;
+  fixture.detectChanges();
+}
+
+function setPasswords(oldPass: string, newPass: string, newPassConfirm: string) {
+  component.changePasswordFormGroup.get('oldPassword').setValue(oldPass);
+  component.newPasswordFormGroup.get('newPassword').setValue(newPass);
+  component.newPasswordFormGroup.get('confirmNewPassword').setValue(newPassConfirm);
+  fixture.detectChanges();
+}

--- a/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.ts
+++ b/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.ts
@@ -83,7 +83,9 @@ export class EditPasswordComponent {
   }
 
   unlinkGoogleAccount() {
-    this.dialog.open(UnlinkGoogleAccountConfirmComponent);
+    this.dialog.open(UnlinkGoogleAccountConfirmComponent, {
+      panelClass: 'mat-dialog--sm'
+    });
   }
 
   resetForm() {

--- a/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.ts
+++ b/src/main/webapp/site/src/app/modules/shared/edit-password/edit-password.component.ts
@@ -1,15 +1,18 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, Validators, FormBuilder } from '@angular/forms';
 import { finalize } from 'rxjs/operators';
+import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { UserService } from '../../../services/user.service';
+import { UnlinkGoogleAccountConfirmComponent } from '../unlink-google-account-confirm/unlink-google-account-confirm.component';
+import { passwordMatchValidator } from '../validators/password-match.validator';
 
 @Component({
   selector: 'app-edit-password',
   templateUrl: './edit-password.component.html',
   styleUrls: ['./edit-password.component.scss']
 })
-export class EditPasswordComponent implements OnInit {
+export class EditPasswordComponent {
   @ViewChild('changePasswordForm', { static: false }) changePasswordForm;
   isSaving: boolean = false;
   isGoogleUser: boolean = false;
@@ -19,7 +22,7 @@ export class EditPasswordComponent implements OnInit {
       newPassword: new FormControl('', [Validators.required]),
       confirmNewPassword: new FormControl('', [Validators.required])
     },
-    { validator: this.passwordMatchValidator }
+    { validator: passwordMatchValidator }
   );
 
   changePasswordFormGroup: FormGroup = this.fb.group({
@@ -30,6 +33,7 @@ export class EditPasswordComponent implements OnInit {
   constructor(
     private fb: FormBuilder,
     private userService: UserService,
+    public dialog: MatDialog,
     public snackBar: MatSnackBar
   ) {}
 
@@ -37,18 +41,6 @@ export class EditPasswordComponent implements OnInit {
     this.userService.getUser().subscribe((user) => {
       this.isGoogleUser = user.isGoogleUser;
     });
-  }
-
-  passwordMatchValidator(passwordsFormGroup: FormGroup) {
-    const newPassword = passwordsFormGroup.get('newPassword').value;
-    const confirmNewPassword = passwordsFormGroup.get('confirmNewPassword').value;
-    if (newPassword === confirmNewPassword) {
-      return null;
-    } else {
-      const error = { passwordDoesNotMatch: true };
-      passwordsFormGroup.controls['confirmNewPassword'].setErrors(error);
-      return error;
-    }
   }
 
   saveChanges() {
@@ -88,6 +80,10 @@ export class EditPasswordComponent implements OnInit {
       const oldPasswordControl = this.changePasswordFormGroup.get('oldPassword');
       oldPasswordControl.setErrors(error);
     }
+  }
+
+  unlinkGoogleAccount() {
+    this.dialog.open(UnlinkGoogleAccountConfirmComponent);
   }
 
   resetForm() {

--- a/src/main/webapp/site/src/app/modules/shared/shared.module.ts
+++ b/src/main/webapp/site/src/app/modules/shared/shared.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -13,6 +14,7 @@ import { MatSelectModule } from '@angular/material/select';
 const materialModules = [
   MatButtonModule,
   MatCardModule,
+  MatDialogModule,
   MatIconModule,
   MatInputModule,
   MatFormFieldModule,
@@ -26,6 +28,9 @@ import { HeroSectionComponent } from './hero-section/hero-section.component';
 import { SearchBarComponent } from './search-bar/search-bar.component';
 import { SelectMenuComponent } from './select-menu/select-menu.component';
 import { EditPasswordComponent } from './edit-password/edit-password.component';
+import { UnlinkGoogleAccountConfirmComponent } from './unlink-google-account-confirm/unlink-google-account-confirm.component';
+import { UnlinkGoogleAccountPasswordComponent } from './unlink-google-account-password/unlink-google-account-password.component';
+import { UnlinkGoogleAccountSuccessComponent } from './unlink-google-account-success/unlink-google-account-success.component';
 
 @NgModule({
   imports: [
@@ -52,7 +57,10 @@ import { EditPasswordComponent } from './edit-password/edit-password.component';
     HeroSectionComponent,
     SearchBarComponent,
     SelectMenuComponent,
-    EditPasswordComponent
+    EditPasswordComponent,
+    UnlinkGoogleAccountConfirmComponent,
+    UnlinkGoogleAccountPasswordComponent,
+    UnlinkGoogleAccountSuccessComponent
   ]
 })
 export class SharedModule {}

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html
@@ -1,17 +1,16 @@
-<h2 class="mat-dialog-title" i18n>Unlink Google Account</h2>
+<h2 class="mat-dialog-title" fxLayoutAlign="start center" fxLayoutGap="8px">
+  <img class="google-icon" src="assets/img/icons/g-logo.png" i18n-alt alt="Google logo" />
+  <span i18n>Unlink Google Account</span>
+  <span fxFlex></span>
+  <mat-icon color="warn" i18n-aria-label aria-label="Warning">warning</mat-icon>
+</h2>
 <mat-dialog-content>
   <div class="info-block">
-    <p class="mat-subheading-2 accent-1" i18n>
-      If you remove the link to your Google account, you will be asked to create a WISE password. You will then need to sign in to WISE using your username and password in the future.
-    </p>
-    <p class='info-note' i18n>Note: You will no longer be able to sign in to this WISE account using Google. Do you want to continue?</p>
+    <p i18n>To remove the link to your Google account, you will be asked to create a WISE password. In the future, you'll sign in to WISE using your username and password.</p>
+    <p><strong i18n>You will no longer be able to sign in to WISE using Google. Would you like to continue?</strong></p>
   </div>
 </mat-dialog-content>
-<mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
-  <button mat-button mat-dialog-close i18n>Cancel</button>
-  <button mat-flat-button
-          color="primary"
-          (click)="continue()">
-    <ng-container i18n>Continue</ng-container>
-  </button>
+<mat-dialog-actions fxLayout="row" fxLayoutAlign="end">
+  <button mat-flat-button color="primary" mat-dialog-close i18n>Cancel</button>
+  <a mat-button color="warn" (click)="continue()" i18n>Continue</a>
 </mat-dialog-actions>

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html
@@ -1,0 +1,17 @@
+<h2 class="mat-dialog-title" i18n>Unlink Google Account</h2>
+<mat-dialog-content>
+  <div class="info-block">
+    <p class="mat-subheading-2 accent-1" i18n>
+      If you remove the link to your Google account, you will be asked to create a WISE password. You will then need to sign in to WISE using your username and password in the future.
+    </p>
+    <p class='info-note' i18n>Note: You will no longer be able to sign in to this WISE account using Google. Do you want to continue?</p>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
+  <button mat-button mat-dialog-close i18n>Cancel</button>
+  <button mat-flat-button
+          color="primary"
+          (click)="continue()">
+    <ng-container i18n>Continue</ng-container>
+  </button>
+</mat-dialog-actions>

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.scss
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.scss
@@ -1,3 +1,4 @@
-.info-note {
-  font-weight: bold;
+.google-icon {
+  height: 1.4em;
+  width: auto;
 }

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.scss
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.scss
@@ -1,0 +1,3 @@
+.info-note {
+  font-weight: bold;
+}

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.spec.ts
@@ -1,0 +1,37 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+import { configureTestSuite } from 'ng-bullet';
+import { UnlinkGoogleAccountConfirmComponent } from './unlink-google-account-confirm.component';
+
+let component: UnlinkGoogleAccountConfirmComponent;
+let fixture: ComponentFixture<UnlinkGoogleAccountConfirmComponent>;
+
+describe('UnlinkGoogleAccountConfirmComponent', () => {
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [UnlinkGoogleAccountConfirmComponent],
+      imports: [MatDialogModule],
+      providers: [],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UnlinkGoogleAccountConfirmComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  continue_closeAllDialogsAndOpenChangePasswordDialog();
+});
+
+function continue_closeAllDialogsAndOpenChangePasswordDialog() {
+  it('continue() should closeAllDialogs and open a new dialog to edit password', () => {
+    const closeAllDialogSpy = spyOn(component.dialog, 'closeAll');
+    const openDialogSpy = spyOn(component.dialog, 'open');
+    component.continue();
+    expect(closeAllDialogSpy).toHaveBeenCalled();
+    expect(openDialogSpy).toHaveBeenCalled();
+  });
+}

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.ts
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { UnlinkGoogleAccountPasswordComponent } from '../unlink-google-account-password/unlink-google-account-password.component';
+
+@Component({
+  styleUrls: ['./unlink-google-account-confirm.component.scss'],
+  templateUrl: './unlink-google-account-confirm.component.html'
+})
+export class UnlinkGoogleAccountConfirmComponent {
+  constructor(public dialog: MatDialog) {}
+
+  continue() {
+    this.dialog.closeAll();
+    this.dialog.open(UnlinkGoogleAccountPasswordComponent);
+  }
+}

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.ts
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.ts
@@ -11,6 +11,8 @@ export class UnlinkGoogleAccountConfirmComponent {
 
   continue() {
     this.dialog.closeAll();
-    this.dialog.open(UnlinkGoogleAccountPasswordComponent);
+    this.dialog.open(UnlinkGoogleAccountPasswordComponent, {
+      panelClass: 'mat-dialog--sm'
+    });
   }
 }

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html
@@ -1,0 +1,46 @@
+<h2 class="mat-dialog-title" i18n>Unlink Google Account</h2>
+<mat-dialog-content>
+  <div class="info-block">
+    <p class="mat-subheading-2 accent-1" i18n>Create a WISE password:</p>
+    <form [formGroup]="newPasswordFormGroup">
+      <p>
+        <mat-form-field fxFlex appearance="fill">
+          <mat-label i18n>New Password</mat-label>
+          <input matInput
+                id="newPassword"
+                type="password"
+                name="newPassword"
+                formControlName="newPassword"
+                required />
+          <mat-error *ngIf="newPasswordFormGroup.controls['newPassword'].hasError('required')" i18n>New Password required</mat-error>
+        </mat-form-field>
+      </p>
+      <p>
+        <mat-form-field fxFlex appearance="fill">
+          <mat-label i18n>Confirm New Password</mat-label>
+          <input matInput
+                id="confirmNewPassword"
+                type="password"
+                name="confirmNewPassword"
+                formControlName="confirmNewPassword"
+                required />
+          <mat-error *ngIf="newPasswordFormGroup.controls['confirmNewPassword'].hasError('required')" i18n>Confirm Password required</mat-error>
+          <mat-error *ngIf="newPasswordFormGroup.hasError('passwordDoesNotMatch')" i18n>Passwords do not match</mat-error>
+        </mat-form-field>
+      </p>
+    </form>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
+  <button mat-button mat-dialog-close i18n>Cancel</button>
+  <button mat-raised-button
+              color="primary"
+              type="submit"
+              [disabled]="!newPasswordFormGroup.valid || isSaving"
+              (click)="submit()"
+              fxFlex
+              fxFlex.gt-xs="0 0 auto">
+        <ng-container i18n>Submit</ng-container>
+        <mat-progress-bar mode="indeterminate" *ngIf="isSaving"></mat-progress-bar>
+      </button>
+</mat-dialog-actions>

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html
@@ -1,46 +1,41 @@
-<h2 class="mat-dialog-title" i18n>Unlink Google Account</h2>
-<mat-dialog-content>
-  <div class="info-block">
-    <p class="mat-subheading-2 accent-1" i18n>Create a WISE password:</p>
-    <form [formGroup]="newPasswordFormGroup">
-      <p>
-        <mat-form-field fxFlex appearance="fill">
-          <mat-label i18n>New Password</mat-label>
-          <input matInput
-                id="newPassword"
-                type="password"
-                name="newPassword"
-                formControlName="newPassword"
-                required />
-          <mat-error *ngIf="newPasswordFormGroup.controls['newPassword'].hasError('required')" i18n>New Password required</mat-error>
-        </mat-form-field>
-      </p>
-      <p>
-        <mat-form-field fxFlex appearance="fill">
-          <mat-label i18n>Confirm New Password</mat-label>
-          <input matInput
-                id="confirmNewPassword"
-                type="password"
-                name="confirmNewPassword"
-                formControlName="confirmNewPassword"
-                required />
-          <mat-error *ngIf="newPasswordFormGroup.controls['confirmNewPassword'].hasError('required')" i18n>Confirm Password required</mat-error>
-          <mat-error *ngIf="newPasswordFormGroup.hasError('passwordDoesNotMatch')" i18n>Passwords do not match</mat-error>
-        </mat-form-field>
-      </p>
-    </form>
-  </div>
-</mat-dialog-content>
-<mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
-  <button mat-button mat-dialog-close i18n>Cancel</button>
-  <button mat-raised-button
-              color="primary"
-              type="submit"
-              [disabled]="!newPasswordFormGroup.valid || isSaving"
-              (click)="submit()"
-              fxFlex
-              fxFlex.gt-xs="0 0 auto">
-        <ng-container i18n>Submit</ng-container>
-        <mat-progress-bar mode="indeterminate" *ngIf="isSaving"></mat-progress-bar>
-      </button>
-</mat-dialog-actions>
+<h2 class="mat-dialog-title" fxLayoutAlign="start center" fxLayoutGap="8px">
+  <img class="google-icon" src="assets/img/icons/g-logo.png" i18n-alt alt="Google logo" />
+  <span i18n>Unlink Google Account</span>
+</h2>
+<form [formGroup]="newPasswordFormGroup">
+  <mat-dialog-content class="mat-dialog-content--scroll" fxLayout="column">
+    <h3 i18n>Create a WISE password:</h3>
+    <mat-form-field appearance="fill">
+      <mat-label i18n>New Password</mat-label>
+      <input matInput
+          id="newPassword"
+          type="password"
+          name="newPassword"
+          formControlName="newPassword"
+          required />
+      <mat-error *ngIf="newPasswordFormGroup.controls['newPassword'].hasError('required')" i18n>New Password required</mat-error>
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label i18n>Confirm New Password</mat-label>
+      <input matInput
+          id="confirmNewPassword"
+          type="password"
+          name="confirmNewPassword"
+          formControlName="confirmNewPassword"
+          required />
+      <mat-error *ngIf="newPasswordFormGroup.controls['confirmNewPassword'].hasError('required')" i18n>Confirm Password required</mat-error>
+      <mat-error *ngIf="newPasswordFormGroup.hasError('passwordDoesNotMatch')" i18n>Passwords do not match</mat-error>
+    </mat-form-field>
+  </mat-dialog-content>
+  <mat-dialog-actions fxLayoutAlign="end">
+    <button mat-button mat-dialog-close i18n>Cancel</button>
+    <button mat-raised-button
+        color="primary"
+        type="submit"
+        [disabled]="!newPasswordFormGroup.valid || isSaving"
+        (click)="submit()">
+      <ng-container i18n>Submit</ng-container>
+      <mat-progress-bar mode="indeterminate" *ngIf="isSaving"></mat-progress-bar>
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.scss
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.scss
@@ -1,0 +1,3 @@
+mat-dialog-content {
+  min-width: 600px;
+}

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.scss
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.scss
@@ -1,3 +1,4 @@
-mat-dialog-content {
-  min-width: 600px;
+.google-icon {
+  height: 1.4em;
+  width: auto;
 }

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.spec.ts
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.spec.ts
@@ -1,0 +1,51 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatDialogModule } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { configureTestSuite } from 'ng-bullet';
+import { Subscription } from 'rxjs';
+import { UserService } from '../../../services/user.service';
+import { UnlinkGoogleAccountPasswordComponent } from './unlink-google-account-password.component';
+
+class MockUserService {
+  unlinkGoogleUser(newPassword: string) {
+    return new Subscription();
+  }
+}
+
+let component: UnlinkGoogleAccountPasswordComponent;
+let fixture: ComponentFixture<UnlinkGoogleAccountPasswordComponent>;
+let userService = new MockUserService();
+
+describe('UnlinkGoogleAccountPasswordComponent', () => {
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [UnlinkGoogleAccountPasswordComponent],
+      imports: [BrowserAnimationsModule, ReactiveFormsModule, MatDialogModule],
+      providers: [{ provide: UserService, useValue: userService }],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+  });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UnlinkGoogleAccountPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+  formSubmit_callUserServiceUnlinkGoogleUserFunction();
+});
+
+function formSubmit_callUserServiceUnlinkGoogleUserFunction() {
+  it('should call UserService.UnlinkGoogleUserFunction when form is submitted', () => {
+    const unlinkFunctionSpy = spyOn(userService, 'unlinkGoogleUser').and.returnValue(
+      new Subscription()
+    );
+    const newPassword = 'aloha';
+    component.newPasswordFormGroup.setValue({
+      newPassword: newPassword,
+      confirmNewPassword: newPassword
+    });
+    component.submit();
+    expect(unlinkFunctionSpy).toHaveBeenCalledWith(newPassword);
+  });
+}

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.ts
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { UserService } from '../../../services/user.service';
+import { UnlinkGoogleAccountSuccessComponent } from '../unlink-google-account-success/unlink-google-account-success.component';
+import { passwordMatchValidator } from '../validators/password-match.validator';
+
+@Component({
+  styleUrls: ['./unlink-google-account-password.component.scss'],
+  templateUrl: './unlink-google-account-password.component.html'
+})
+export class UnlinkGoogleAccountPasswordComponent {
+  isSaving: boolean = false;
+  newPasswordFormGroup: FormGroup = this.fb.group(
+    {
+      newPassword: new FormControl('', [Validators.required]),
+      confirmNewPassword: new FormControl('', [Validators.required])
+    },
+    { validator: passwordMatchValidator }
+  );
+
+  constructor(
+    private fb: FormBuilder,
+    public dialog: MatDialog,
+    private userService: UserService
+  ) {}
+
+  submit() {
+    this.isSaving = true;
+    this.userService
+      .unlinkGoogleUser(this.newPasswordFormGroup.get('newPassword').value)
+      .add(() => {
+        this.isSaving = false;
+        this.dialog.closeAll();
+        this.dialog.open(UnlinkGoogleAccountSuccessComponent);
+      });
+  }
+}

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.ts
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.ts
@@ -32,7 +32,9 @@ export class UnlinkGoogleAccountPasswordComponent {
       .add(() => {
         this.isSaving = false;
         this.dialog.closeAll();
-        this.dialog.open(UnlinkGoogleAccountSuccessComponent);
+        this.dialog.open(UnlinkGoogleAccountSuccessComponent, {
+          panelClass: 'mat-dialog--sm'
+        });
       });
   }
 }

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html
@@ -1,10 +1,11 @@
-<h2 class="mat-dialog-title" i18n>Unlink Google Account</h2>
+<h2 class="mat-dialog-title" fxLayoutAlign="start center" fxLayoutGap="8px">
+  <img class="google-icon" src="assets/img/icons/g-logo.png" i18n-alt alt="Google logo" />
+  <span i18n>Unlink Google Account</span>
+</h2>
 <mat-dialog-content>
   <div class="info-block">
-    <p class="mat-subheading-2 accent-1" i18n>
-      Success! You have unlinked your Google account from WISE. To sign in to WISE in the future, please use your username and password you just created.
-    </p>
-    <p class='info-note' i18n>Your username is: {{username}}</p>
+    <p i18n>Success! You have unlinked your Google account from WISE. To sign in to WISE in the future, please use your username and the password you just created.</p>
+    <p i18n>Your username is: <span class="mat-body-2">{{ username }}</span>.</p>
   </div>
 </mat-dialog-content>
 <mat-dialog-actions fxLayoutAlign="end">

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html
@@ -1,0 +1,12 @@
+<h2 class="mat-dialog-title" i18n>Unlink Google Account</h2>
+<mat-dialog-content>
+  <div class="info-block">
+    <p class="mat-subheading-2 accent-1" i18n>
+      Success! You have unlinked your Google account from WISE. To sign in to WISE in the future, please use your username and password you just created.
+    </p>
+    <p class='info-note' i18n>Your username is: {{username}}</p>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions fxLayoutAlign="end">
+  <button mat-button mat-dialog-close i18n>Done</button>
+</mat-dialog-actions>

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.scss
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.scss
@@ -1,3 +1,4 @@
-.info-note {
-  font-weight: bold;
+.google-icon {
+  height: 1.4em;
+  width: auto;
 }

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.scss
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.scss
@@ -1,0 +1,3 @@
+.info-note {
+  font-weight: bold;
+}

--- a/src/main/webapp/site/src/app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.ts
+++ b/src/main/webapp/site/src/app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { Teacher } from '../../../domain/teacher';
+import { UserService } from '../../../services/user.service';
+
+@Component({
+  styleUrls: ['unlink-google-account-success.component.scss'],
+  templateUrl: 'unlink-google-account-success.component.html'
+})
+export class UnlinkGoogleAccountSuccessComponent {
+  username: string;
+
+  constructor(private userService: UserService) {}
+
+  ngOnInit() {
+    const user = <Teacher>this.userService.getUser().getValue();
+    this.username = user.username;
+  }
+}

--- a/src/main/webapp/site/src/app/modules/shared/validators/password-match.validator.ts
+++ b/src/main/webapp/site/src/app/modules/shared/validators/password-match.validator.ts
@@ -1,0 +1,13 @@
+import { FormGroup } from '@angular/forms';
+
+export function passwordMatchValidator(passwordsFormGroup: FormGroup) {
+  const newPassword = passwordsFormGroup.get('newPassword').value;
+  const confirmNewPassword = passwordsFormGroup.get('confirmNewPassword').value;
+  if (newPassword === confirmNewPassword) {
+    return null;
+  } else {
+    const error = { passwordDoesNotMatch: true };
+    passwordsFormGroup.controls['confirmNewPassword'].setErrors(error);
+    return error;
+  }
+}

--- a/src/main/webapp/site/src/app/services/user.service.spec.ts
+++ b/src/main/webapp/site/src/app/services/user.service.spec.ts
@@ -1,8 +1,10 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { UserService } from './user.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ConfigService } from './config.service';
 
+let service: UserService;
+let http: HttpTestingController;
 export class MockConfigService {}
 
 describe('UserService', () => {
@@ -11,9 +13,21 @@ describe('UserService', () => {
       providers: [UserService, { provide: ConfigService, useClass: MockConfigService }],
       imports: [HttpClientTestingModule]
     });
+    service = TestBed.inject(UserService);
+    http = TestBed.inject(HttpTestingController);
   });
-
-  it('should be created', inject([UserService, ConfigService], (service: UserService) => {
-    expect(service).toBeTruthy();
-  }));
+  unlinkGoogleAccount_postToUrl();
 });
+
+function unlinkGoogleAccount_postToUrl() {
+  it('unlinkGoogleAccount() should make POST request to unlink google account', fakeAsync(() => {
+    const newPassword = 'my new pass';
+    service.unlinkGoogleUser(newPassword);
+    const unlinkRequest = http.expectOne({
+      url: '/api/google-user/unlink-account',
+      method: 'POST'
+    });
+    unlinkRequest.flush({ response: 'success' });
+    tick();
+  }));
+}

--- a/src/main/webapp/site/src/app/services/user.service.ts
+++ b/src/main/webapp/site/src/app/services/user.service.ts
@@ -12,13 +12,14 @@ import { Student } from '../domain/student';
 export class UserService {
   private userUrl = '/api/user/info';
   private user$: BehaviorSubject<User> = new BehaviorSubject<User>(null);
-  private checkGoogleUserExistsUrl = '/api/user/check-google-user-exists';
-  private checkGoogleUserMatchesUrl = '/api/user/check-google-user-matches';
-  private googleUserUrl = '/api/user/google-user';
+  private checkGoogleUserExistsUrl = '/api/google-user/check-user-exists';
+  private checkGoogleUserMatchesUrl = '/api/google-user/check-user-matches';
+  private googleUserUrl = '/api/google-user/get-user';
   private checkAuthenticationUrl = '/api/user/check-authentication';
   private changePasswordUrl = '/api/user/password';
   private languagesUrl = '/api/user/languages';
   private contactUrl = '/api/contact';
+  private unlinkGoogleAccountUrl = '/api/google-user/unlink-account';
   isAuthenticated = false;
   isRecaptchaRequired = false;
   redirectUrl: string; // redirect here after logging in
@@ -124,6 +125,17 @@ export class UserService {
     params = params.set('googleUserId', googleUserId);
     params = params.set('userId', userId);
     return this.http.get<User>(this.checkGoogleUserMatchesUrl, { params: params });
+  }
+
+  unlinkGoogleUser(newPassword: string) {
+    const headers = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
+    let body = new HttpParams();
+    body = body.set('newPassword', newPassword);
+    return this.http
+      .post<any>(this.unlinkGoogleAccountUrl, body, { headers: headers })
+      .subscribe((user) => {
+        this.user$.next(user);
+      });
   }
 
   getUserByGoogleId(googleUserId: string) {

--- a/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.html
+++ b/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.html
@@ -1,5 +1,5 @@
 <form role="form" (submit)="saveChanges()" [formGroup]="editProfileFormGroup">
-  <div fxLayout="column" fxLayoutAlign="start">
+  <div class="inputs">
     <p>
       <mat-form-field fxFlex appearance="fill">
         <mat-label i18n>First Name</mat-label>
@@ -42,28 +42,31 @@
         <mat-error *ngIf="editProfileFormGroup.controls['language'].hasError('required')" i18n>Language required</mat-error>
       </mat-form-field>
     </p>
-    <div fxLayout="row"
+  </div>
+  <div class="actions"
+      fxLayout="column"
+      fxLayout.gt-sm="row"
+      fxLayoutAlign="center start"
+      fxLayoutAlign.gt-sm="start center"
+      fxLayoutGap="24px">
+    <button mat-raised-button
+        color="primary"
+        type="submit"
+        [disabled]="!editProfileFormGroup.valid || !changed || isSaving">
+      <mat-progress-bar mode="indeterminate" *ngIf="isSaving"></mat-progress-bar>
+      <ng-container i18n>Save Changes</ng-container>
+    </button>
+    <div *ngIf="isGoogleUser"
+        fxLayout="row wrap"
         fxLayoutAlign="start center"
         fxLayoutGap="8px">
-      <button mat-raised-button
-              color="primary"
-              type="submit"
-              [disabled]="!editProfileFormGroup.valid || !changed || isSaving"
-              fxFlex
-              fxFlex.gt-xs="0 0 auto">
-        <mat-progress-bar mode="indeterminate" *ngIf="isSaving"></mat-progress-bar>
-        <ng-container i18n>Save Changes</ng-container>
+      <div fxLayoutAlign="start center" fxLayoutGap="8px">
+        <img class="google-icon" src="assets/img/icons/g-logo.png" i18n-alt alt="Google logo" />
+        <span i18n>This profile is linked to a Google account.</span>
+      </div>
+      <button class="unlink" type="button" mat-raised-button (click)="unlinkGoogleAccount()">
+        <span class="warn" i18n>Unlink Google Account</span>
       </button>
-      <ng-container *ngIf="isGoogleUser">
-        <div i18n>This profile is linked to a Google account.</div>
-        <button mat-raised-button
-            type="button"
-            id="unlinkGoogleAccount"
-            (click)="unlinkGoogleAccount()">
-          <mat-icon>link_off</mat-icon>
-          <ng-container i18n>Unlink Google Account</ng-container>
-        </button>
-      </ng-container>
     </div>
   </div>
 </form>

--- a/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.html
+++ b/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.html
@@ -42,7 +42,9 @@
         <mat-error *ngIf="editProfileFormGroup.controls['language'].hasError('required')" i18n>Language required</mat-error>
       </mat-form-field>
     </p>
-    <div>
+    <div fxLayout="row"
+        fxLayoutAlign="start center"
+        fxLayoutGap="8px">
       <button mat-raised-button
               color="primary"
               type="submit"
@@ -52,6 +54,16 @@
         <mat-progress-bar mode="indeterminate" *ngIf="isSaving"></mat-progress-bar>
         <ng-container i18n>Save Changes</ng-container>
       </button>
+      <ng-container *ngIf="isGoogleUser">
+        <div i18n>This profile is linked to a Google account.</div>
+        <button mat-raised-button
+            type="button"
+            id="unlinkGoogleAccount"
+            (click)="unlinkGoogleAccount()">
+          <mat-icon>link_off</mat-icon>
+          <ng-container i18n>Unlink Google Account</ng-container>
+        </button>
+      </ng-container>
     </div>
   </div>
 </form>

--- a/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.scss
+++ b/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.scss
@@ -3,10 +3,19 @@
   '~style/abstracts/functions',
   '~style/abstracts/mixins';
 
-form {
+.inputs {
   max-width: breakpoint('sm.min');
+}
 
-  @media (max-width: breakpoint('sm.max')) {
-    margin: 0 auto;
-  }
+.actions {
+  margin-top: 8px;
+}
+
+.google-icon {
+  height: 1.8em;
+  width: auto;
+}
+
+.unlink {
+  margin: 8px 0;
 }

--- a/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.spec.ts
+++ b/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.spec.ts
@@ -13,6 +13,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { Student } from '../../../domain/student';
 import { configureTestSuite } from 'ng-bullet';
+import { MatDialogModule } from '@angular/material/dialog';
 
 export class MockUserService {
   user: User;
@@ -76,6 +77,7 @@ describe('EditProfileComponent', () => {
       imports: [
         BrowserAnimationsModule,
         ReactiveFormsModule,
+        MatDialogModule,
         MatInputModule,
         MatSelectModule,
         MatSnackBarModule

--- a/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.ts
+++ b/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormGroup, FormControl, Validators, FormBuilder } from '@angular/forms';
 import { finalize } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';

--- a/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.ts
+++ b/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.ts
@@ -98,6 +98,8 @@ export class EditProfileComponent {
   }
 
   unlinkGoogleAccount() {
-    this.dialog.open(UnlinkGoogleAccountConfirmComponent);
+    this.dialog.open(UnlinkGoogleAccountConfirmComponent, {
+      panelClass: 'mat-dialog--sm'
+    });
   }
 }

--- a/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.ts
+++ b/src/main/webapp/site/src/app/student/account/edit-profile/edit-profile.component.ts
@@ -5,18 +5,22 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Student } from '../../../domain/student';
 import { UserService } from '../../../services/user.service';
 import { StudentService } from '../../student.service';
+import { Subscription } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+import { UnlinkGoogleAccountConfirmComponent } from '../../../modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component';
 
 @Component({
   selector: 'app-edit-profile',
   templateUrl: './edit-profile.component.html',
   styleUrls: ['./edit-profile.component.scss']
 })
-export class EditProfileComponent implements OnInit {
+export class EditProfileComponent {
   user: Student;
   languages: object[];
   changed: boolean = false;
   isSaving: boolean = false;
-
+  isGoogleUser: boolean = false;
+  userSubscription: Subscription;
   editProfileFormGroup: FormGroup = this.fb.group({
     firstName: new FormControl({ value: '', disabled: true }, [Validators.required]),
     lastName: new FormControl({ value: '', disabled: true }, [Validators.required]),
@@ -28,6 +32,7 @@ export class EditProfileComponent implements OnInit {
     private fb: FormBuilder,
     private studentService: StudentService,
     private userService: UserService,
+    public dialog: MatDialog,
     public snackBar: MatSnackBar
   ) {
     this.user = <Student>this.getUser().getValue();
@@ -37,10 +42,6 @@ export class EditProfileComponent implements OnInit {
     this.setControlFieldValue('language', this.user.language);
     this.userService.getLanguages().subscribe((response) => {
       this.languages = <object[]>response;
-    });
-
-    this.editProfileFormGroup.valueChanges.subscribe(() => {
-      this.changed = true;
     });
   }
 
@@ -52,7 +53,18 @@ export class EditProfileComponent implements OnInit {
     this.editProfileFormGroup.controls[name].setValue(value);
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.editProfileFormGroup.valueChanges.subscribe(() => {
+      this.changed = true;
+    });
+    this.userSubscription = this.userService.getUser().subscribe((user) => {
+      this.isGoogleUser = user.isGoogleUser;
+    });
+  }
+
+  ngOnDestroy() {
+    this.userSubscription.unsubscribe();
+  }
 
   saveChanges() {
     this.isSaving = true;
@@ -83,5 +95,9 @@ export class EditProfileComponent implements OnInit {
       this.snackBar.open($localize`An error occurred. Please try again.`);
     }
     this.isSaving = false;
+  }
+
+  unlinkGoogleAccount() {
+    this.dialog.open(UnlinkGoogleAccountConfirmComponent);
   }
 }

--- a/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.html
+++ b/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.html
@@ -109,7 +109,9 @@
       </mat-form-field>
     </p>
   </div>
-  <div>
+  <div fxLayout="row"
+      fxLayoutAlign="start center"
+      fxLayoutGap="8px">
     <button mat-raised-button
             color="primary"
             type="submit"
@@ -119,5 +121,15 @@
       <mat-progress-bar mode="indeterminate" *ngIf="isSaving"></mat-progress-bar>
       <ng-container i18n>Save Changes</ng-container>
     </button>
+    <ng-container *ngIf="isGoogleUser">
+      <div i18n>This profile is linked to a Google account.</div>
+      <button mat-raised-button
+          type="button"
+          id="unlinkGoogleAccount"
+          (click)="unlinkGoogleAccount()">
+        <mat-icon>link_off</mat-icon>
+        <ng-container i18n>Unlink Google Account</ng-container>
+      </button>
+    </ng-container>
   </div>
 </form>

--- a/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.html
+++ b/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.html
@@ -105,31 +105,36 @@
           </mat-option>
         </mat-select>
         <mat-hint i18n>Help us translate WISE! Visit <a href="https://crowdin.com/project/wise" target="_blank">https://crowdin.com/project/wise</a>.</mat-hint>
-        <mat-error *ngIf="editProfileFormGroup.controls['language'].hasError('required')" i18n>Language required</mat-error>
+        <mat-error *ngIf="editProfileFormGroup.controls['language'].hasError('required')" i18n>
+          Language required
+        </mat-error>
       </mat-form-field>
     </p>
   </div>
-  <div fxLayout="row"
-      fxLayoutAlign="start center"
-      fxLayoutGap="8px">
+  <div class="actions"
+      fxLayout="column"
+      fxLayout.gt-sm="row"
+      fxLayoutAlign="center start"
+      fxLayoutAlign.gt-sm="start center"
+      fxLayoutGap="24px">
     <button mat-raised-button
             color="primary"
             type="submit"
-            [disabled]="!editProfileFormGroup.valid || !changed || isSaving"
-            fxFlex
-            fxFlex.gt-xs="0 0 auto">
+            [disabled]="!editProfileFormGroup.valid || !changed || isSaving">
       <mat-progress-bar mode="indeterminate" *ngIf="isSaving"></mat-progress-bar>
       <ng-container i18n>Save Changes</ng-container>
     </button>
-    <ng-container *ngIf="isGoogleUser">
-      <div i18n>This profile is linked to a Google account.</div>
-      <button mat-raised-button
-          type="button"
-          id="unlinkGoogleAccount"
-          (click)="unlinkGoogleAccount()">
-        <mat-icon>link_off</mat-icon>
-        <ng-container i18n>Unlink Google Account</ng-container>
+    <div *ngIf="isGoogleUser" 
+        fxLayout="row wrap"
+        fxLayoutAlign="start center"
+        fxLayoutGap="8px">
+      <div fxLayoutAlign="start center" fxLayoutGap="8px">
+        <img class="google-icon" src="assets/img/icons/g-logo.png" i18n-alt alt="Google logo" />
+        <span i18n>This profile is linked to a Google account.</span>
+      </div>
+      <button class="unlink" type="button" mat-raised-button (click)="unlinkGoogleAccount()">
+        <span class="warn" i18n>Unlink Google Account</span>
       </button>
-    </ng-container>
+    </div>
   </div>
 </form>

--- a/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.scss
+++ b/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.scss
@@ -21,3 +21,16 @@
     }
   }
 }
+
+.actions {
+  margin-top: 8px;
+}
+
+.google-icon {
+  height: 1.8em;
+  width: auto;
+}
+
+.unlink {
+  margin: 8px 0;
+}

--- a/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.spec.ts
+++ b/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.spec.ts
@@ -13,6 +13,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { User } from '../../../domain/user';
 import { configureTestSuite } from 'ng-bullet';
+import { MatDialogModule } from '@angular/material/dialog';
 
 export class MockUserService {
   user: User;
@@ -89,6 +90,7 @@ describe('EditProfileComponent', () => {
       imports: [
         BrowserAnimationsModule,
         ReactiveFormsModule,
+        MatDialogModule,
         MatInputModule,
         MatSelectModule,
         MatSnackBarModule

--- a/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.ts
+++ b/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.ts
@@ -144,6 +144,8 @@ export class EditProfileComponent {
   }
 
   unlinkGoogleAccount() {
-    this.dialog.open(UnlinkGoogleAccountConfirmComponent);
+    this.dialog.open(UnlinkGoogleAccountConfirmComponent, {
+      panelClass: 'mat-dialog--sm'
+    });
   }
 }

--- a/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.ts
+++ b/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, FormGroup, Validators, FormBuilder } from '@angular/forms';
 import { finalize } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -141,5 +141,9 @@ export class EditProfileComponent {
     } else {
       this.snackBar.open($localize`An error occurred. Please try again.`);
     }
+  }
+
+  unlinkGoogleAccount() {
+    this.dialog.open(UnlinkGoogleAccountConfirmComponent);
   }
 }

--- a/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.ts
+++ b/src/main/webapp/site/src/app/teacher/account/edit-profile/edit-profile.component.ts
@@ -5,13 +5,16 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { UserService } from '../../../services/user.service';
 import { Teacher } from '../../../domain/teacher';
 import { TeacherService } from '../../teacher.service';
+import { MatDialog } from '@angular/material/dialog';
+import { UnlinkGoogleAccountConfirmComponent } from '../../../modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-edit-profile',
   templateUrl: './edit-profile.component.html',
   styleUrls: ['./edit-profile.component.scss']
 })
-export class EditProfileComponent implements OnInit {
+export class EditProfileComponent {
   user: Teacher;
   schoolLevels: any[] = [
     { id: 'ELEMENTARY_SCHOOL', label: $localize`Elementary School` },
@@ -23,6 +26,8 @@ export class EditProfileComponent implements OnInit {
   languages: object[];
   changed: boolean = false;
   isSaving: boolean = false;
+  isGoogleUser: boolean = false;
+  userSubscription: Subscription;
 
   editProfileFormGroup: FormGroup = this.fb.group({
     firstName: new FormControl({ value: '', disabled: true }, [Validators.required]),
@@ -41,6 +46,7 @@ export class EditProfileComponent implements OnInit {
     private fb: FormBuilder,
     private teacherService: TeacherService,
     private userService: UserService,
+    public dialog: MatDialog,
     public snackBar: MatSnackBar
   ) {
     this.user = <Teacher>this.getUser().getValue();
@@ -57,10 +63,6 @@ export class EditProfileComponent implements OnInit {
     this.userService.getLanguages().subscribe((response) => {
       this.languages = <object[]>response;
     });
-
-    this.editProfileFormGroup.valueChanges.subscribe(() => {
-      this.changed = true;
-    });
   }
 
   getUser() {
@@ -71,7 +73,19 @@ export class EditProfileComponent implements OnInit {
     this.editProfileFormGroup.controls[name].setValue(value);
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.editProfileFormGroup.valueChanges.subscribe(() => {
+      this.changed = true;
+    });
+
+    this.userSubscription = this.userService.getUser().subscribe((user) => {
+      this.isGoogleUser = user.isGoogleUser;
+    });
+  }
+
+  ngOnDestroy() {
+    this.userSubscription.unsubscribe();
+  }
 
   saveChanges() {
     this.isSaving = true;

--- a/src/main/webapp/site/src/app/teacher/edit-run-warning-dialog/edit-run-warning-dialog.component.html
+++ b/src/main/webapp/site/src/app/teacher/edit-run-warning-dialog/edit-run-warning-dialog.component.html
@@ -1,7 +1,7 @@
-<h2 mat-dialog-title fxLayoutAlign="start center" class="warn">
+<h2 mat-dialog-title fxLayoutAlign="start center">
   <span i18n>Edit Classroom Unit</span>
   <span fxFlex></span>
-  <mat-icon color="warn">warning</mat-icon>
+  <mat-icon color="warn" i18n-aria-label aria-label="Warning">warning</mat-icon>
 </h2>
 <mat-dialog-content>
   <div class="info-block">

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -236,29 +236,87 @@
           <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="1ae3dcf96b494406b6fd6fbd2f15f7259553bf4d">
-        <source>Current Password</source>
+      <trans-unit datatype="html" id="47c3500e23cf10b4e86b3c495687d5045fd2305c">
+        <source>Unlink Google Account</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/student/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="9b79b69a1ba8ba29e68a45acd0829da17da704ce">
-        <source>Current Password required</source>
+      <trans-unit datatype="html" id="2f576415d91ffa4e0d7228bcb11d24d0bd39af6d">
+        <source> Success! You have unlinked your Google account from WISE. To sign in to WISE in the future, please use your username and password you just created. </source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html</context>
+          <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="0315d84608647a2d4a2b2e7e509d10ad0ec78536">
-        <source>Current Password is incorrect</source>
+      <trans-unit datatype="html" id="bf62cb0d6eee6ef512c900e5e3661233d931be38">
+        <source>Your username is: <x equiv-text="{{username}}" id="INTERPOLATION"/></source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="8dd413cee2228118c536f503709329a4d1a395e2">
+        <source>Done</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
+          <context context-type="linenumber">85</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="31874c167522896bc9ac326873703ffde25ede7f">
+        <source>Create a WISE password:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="c7014c6360e94b236286b869c3fe0ea9911c0387">
         <source>New Password</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
           <context context-type="linenumber">22</context>
@@ -267,6 +325,10 @@
       <trans-unit datatype="html" id="ae26b4e37fa94304d1fa1b0c46b10ad979bcecfa">
         <source>New Password required</source>
         <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
           <context context-type="linenumber">29</context>
         </context-group>
@@ -274,12 +336,20 @@
       <trans-unit datatype="html" id="b81fbd1b5d0723eba41870071d02065674bdd565">
         <source>Confirm New Password</source>
         <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
           <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="4b4b336ca43da85eee55391d95fbc03d921353b5">
         <source>Confirm Password required</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
           <context context-type="linenumber">41</context>
@@ -304,8 +374,152 @@
       <trans-unit datatype="html" id="0a9dcaac5aadd48fe716eaff77ab9b21a8bef3af">
         <source>Passwords do not match</source>
         <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
           <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="d7b35c384aecd25a516200d6921836374613dfe7">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/edit-run-warning-dialog/edit-run-warning-dialog.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/student/add-project-dialog/add-project-dialog.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/student/team-sign-in-dialog/team-sign-in-dialog.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
+          <context context-type="linenumber">100</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="71c77bb8cecdf11ec3eead24dd1ba506573fa9cd">
+        <source>Submit</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/contact/contact-form/contact-form.component.html</context>
+          <context context-type="linenumber">112</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/forgot/student/forgot-student-password/forgot-student-password.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/forgot/teacher/forgot-teacher-username/forgot-teacher-username.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/forgot/student/forgot-student-password-security/forgot-student-password-security.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/forgot/teacher/forgot-teacher-password-verify/forgot-teacher-password-verify.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="dda42349db05eb9d7974af22e6923404d1613fed">
+        <source> If you remove the link to your Google account, you will be asked to create a WISE password. You will then need to sign in to WISE using your username and password in the future. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="3917c36094605496e0f2de91efef9c35dd8b1f9c">
+        <source>Note: You will no longer be able to sign in to this WISE account using Google. Do you want to continue?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="ac10a3d9b59575640797c1a8e6aea642cf5d5e77">
+        <source>Continue</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="1ae3dcf96b494406b6fd6fbd2f15f7259553bf4d">
+        <source>Current Password</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="9b79b69a1ba8ba29e68a45acd0829da17da704ce">
+        <source>Current Password required</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="0315d84608647a2d4a2b2e7e509d10ad0ec78536">
+        <source>Current Password is incorrect</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="5edf054f14aa57bc25a28cb7db01956fee53dac8">
@@ -323,8 +537,8 @@
           <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="1622b67543d6f79dc5e9730e121f7e21b3d034b1">
-        <source>This account was created using Google and doesn't use a WISE password. If you would like to unlink your Google account, please <x ctype="x-a" equiv-text="&lt;a&gt;" id="START_LINK"/>contact us<x ctype="x-a" equiv-text="&lt;/a&gt;" id="CLOSE_LINK"/>.</source>
+      <trans-unit datatype="html" id="d5a4847fca71b32d9a29901631e8c1f7ab8fd83b">
+        <source>This account was created using Google and doesn't use a WISE password.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
           <context context-type="linenumber">60</context>
@@ -1068,57 +1282,6 @@
           <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="d7b35c384aecd25a516200d6921836374613dfe7">
-        <source>Cancel</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
-          <context context-type="linenumber">11</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
-          <context context-type="linenumber">63</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html</context>
-          <context context-type="linenumber">15</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/edit-run-warning-dialog/edit-run-warning-dialog.component.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/student/add-project-dialog/add-project-dialog.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/student/team-sign-in-dialog/team-sign-in-dialog.component.html</context>
-          <context context-type="linenumber">68</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">100</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">62</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component.html</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-      </trans-unit>
       <trans-unit datatype="html" id="1979da7460819153e11d2078244645d94291b69c">
         <source>Copy</source>
         <context-group purpose="location">
@@ -1242,29 +1405,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
           <context context-type="linenumber">69</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit datatype="html" id="8dd413cee2228118c536f503709329a4d1a395e2">
-        <source>Done</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
-          <context context-type="linenumber">75</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/create-run-dialog/create-run-dialog.component.html</context>
-          <context context-type="linenumber">85</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">70</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/share-run-dialog/share-run-dialog.component.html</context>
-          <context context-type="linenumber">102</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="053c99466a9288207400b49f2ca907192b5bd44d">
@@ -2280,41 +2420,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/contact/contact-form/contact-form.component.html</context>
           <context context-type="linenumber">104</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit datatype="html" id="71c77bb8cecdf11ec3eead24dd1ba506573fa9cd">
-        <source>Submit</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">112</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/forgot/student/forgot-student-password/forgot-student-password.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/forgot/teacher/forgot-teacher-username/forgot-teacher-username.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/forgot/student/forgot-student-password-security/forgot-student-password-security.component.html</context>
-          <context context-type="linenumber">28</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.html</context>
-          <context context-type="linenumber">39</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/forgot/teacher/forgot-teacher-password-verify/forgot-teacher-password-verify.component.html</context>
-          <context context-type="linenumber">26</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="abc0c762d328168e523abf84749240e43593f8df">
@@ -5287,11 +5392,22 @@
         <source>Save Changes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">122</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="edb53ba7560c1571d41ff16d93805243e5264d70">
+        <source>This profile is linked to a Google account.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/student/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">125</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="2e1aeaf8d183e6846a0463a08c784f472184fcf0">

--- a/src/main/webapp/site/src/messages.xlf
+++ b/src/main/webapp/site/src/messages.xlf
@@ -236,23 +236,47 @@
           <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="47c3500e23cf10b4e86b3c495687d5045fd2305c">
-        <source>Unlink Google Account</source>
+      <trans-unit datatype="html" id="692e665f8177ee9150169dca0ff15418616cb3cb">
+        <source>Google logo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html</context>
-          <context context-type="linenumber">1</context>
+          <context context-type="linenumber">2</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
-          <context context-type="linenumber">1</context>
+          <context context-type="linenumber">2</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
-          <context context-type="linenumber">1</context>
+          <context context-type="linenumber">2</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/register/register-teacher/register-teacher.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/register/register-teacher-complete/register-teacher-complete.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/register/register-student-complete/register-student-complete.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/register/register-student/register-student.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/register/register-google-user-already-exists/register-google-user-already-exists.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/student/team-sign-in-dialog/team-sign-in-dialog.component.html</context>
+          <context context-type="linenumber">59</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/account/edit-profile/edit-profile.component.html</context>
@@ -260,28 +284,55 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">132</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="2f576415d91ffa4e0d7228bcb11d24d0bd39af6d">
-        <source> Success! You have unlinked your Google account from WISE. To sign in to WISE in the future, please use your username and password you just created. </source>
+      <trans-unit datatype="html" id="47c3500e23cf10b4e86b3c495687d5045fd2305c">
+        <source>Unlink Google Account</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/student/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">136</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="bf62cb0d6eee6ef512c900e5e3661233d931be38">
-        <source>Your username is: <x equiv-text="{{username}}" id="INTERPOLATION"/></source>
+      <trans-unit datatype="html" id="09031a48e6666b30516536554bd71ec9073bc906">
+        <source>Success! You have unlinked your Google account from WISE. To sign in to WISE in the future, please use your username and the password you just created.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html</context>
           <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="b3062cd2df40541e781d0e69c02c670cf3c38fa9">
+        <source>Your username is: <x ctype="x-span" equiv-text="&lt;span&gt;" id="START_TAG_SPAN"/><x equiv-text="{{ username }}" id="INTERPOLATION"/><x ctype="x-span" equiv-text="&lt;/span&gt;" id="CLOSE_TAG_SPAN"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html</context>
+          <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="8dd413cee2228118c536f503709329a4d1a395e2">
         <source>Done</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-success/unlink-google-account-success.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">12</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html</context>
@@ -308,14 +359,14 @@
         <source>Create a WISE password:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="c7014c6360e94b236286b869c3fe0ea9911c0387">
         <source>New Password</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">9</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
@@ -326,7 +377,7 @@
         <source>New Password required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">16</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
@@ -337,7 +388,7 @@
         <source>Confirm New Password</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">19</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
@@ -348,7 +399,7 @@
         <source>Confirm Password required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">26</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
@@ -375,7 +426,7 @@
         <source>Passwords do not match</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">27</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
@@ -386,11 +437,11 @@
         <source>Cancel</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">31</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">14</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
@@ -445,7 +496,7 @@
         <source>Submit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/contact/contact-form/contact-form.component.html</context>
@@ -480,18 +531,33 @@
           <context context-type="linenumber">26</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="dda42349db05eb9d7974af22e6923404d1613fed">
-        <source> If you remove the link to your Google account, you will be asked to create a WISE password. You will then need to sign in to WISE using your username and password in the future. </source>
+      <trans-unit datatype="html" id="a8059e31694578c1b0344a76a345357dd60e8f01">
+        <source>Warning</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/edit-run-warning-dialog/edit-run-warning-dialog.component.html</context>
           <context context-type="linenumber">4</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/help/teacher-faq/teacher-faq.component.html</context>
+          <context context-type="linenumber">85</context>
+        </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="3917c36094605496e0f2de91efef9c35dd8b1f9c">
-        <source>Note: You will no longer be able to sign in to this WISE account using Google. Do you want to continue?</source>
+      <trans-unit datatype="html" id="5d9fa1b5819208cfbc678e570f4bd34144bcfe81">
+        <source>To remove the link to your Google account, you will be asked to create a WISE password. In the future, you'll sign in to WISE using your username and password.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
-          <context context-type="linenumber">7</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="f021455ae88703603db9bb34ea44ab9170f37920">
+        <source>You will no longer be able to sign in to WISE using Google. Would you like to continue?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.html</context>
+          <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="ac10a3d9b59575640797c1a8e6aea642cf5d5e77">
@@ -537,8 +603,8 @@
           <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="d5a4847fca71b32d9a29901631e8c1f7ab8fd83b">
-        <source>This account was created using Google and doesn't use a WISE password.</source>
+      <trans-unit datatype="html" id="8454739bcb4cf4debfd509a35e466a828ea11363">
+        <source><x ctype="image" equiv-text="&lt;img/&gt;" id="TAG_IMG"/><x ctype="x-span" equiv-text="&lt;span&gt;" id="START_TAG_SPAN"/>This account was created using Google and doesn't use a WISE password.<x ctype="x-span" equiv-text="&lt;/span&gt;" id="CLOSE_TAG_SPAN"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/modules/shared/edit-password/edit-password.component.html</context>
           <context context-type="linenumber">60</context>
@@ -3943,13 +4009,6 @@
           <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="a8059e31694578c1b0344a76a345357dd60e8f01">
-        <source>Warning</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/help/teacher-faq/teacher-faq.component.html</context>
-          <context context-type="linenumber">85</context>
-        </context-group>
-      </trans-unit>
       <trans-unit datatype="html" id="4ad84d4f3bbc9a37b27cd1ff908aea5fa83dccf3">
         <source>If you move a student to a different period, they will lose all of their work.</source>
         <context-group purpose="location">
@@ -4675,33 +4734,6 @@
           <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
-      <trans-unit datatype="html" id="692e665f8177ee9150169dca0ff15418616cb3cb">
-        <source>Google logo</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/register/register-teacher/register-teacher.component.html</context>
-          <context context-type="linenumber">28</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/register/register-teacher-complete/register-teacher-complete.component.html</context>
-          <context context-type="linenumber">14</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/register/register-student-complete/register-student-complete.component.html</context>
-          <context context-type="linenumber">14</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/register/register-student/register-student.component.html</context>
-          <context context-type="linenumber">39</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/register/register-google-user-already-exists/register-google-user-already-exists.component.html</context>
-          <context context-type="linenumber">10</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/student/team-sign-in-dialog/team-sign-in-dialog.component.html</context>
-          <context context-type="linenumber">59</context>
-        </context-group>
-      </trans-unit>
       <trans-unit datatype="html" id="49ddce3277c9c81865f8d2278255426cdc9e94f2">
         <source>Sign up with Google</source>
         <context-group purpose="location">
@@ -5383,31 +5415,27 @@
           <context context-type="sourcefile">app/student/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">42</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">108</context>
-        </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="afa960379d26eb20fd22e6e10537c1c5ec74c5d1">
         <source>Save Changes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">57</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">125</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="edb53ba7560c1571d41ff16d93805243e5264d70">
         <source>This profile is linked to a Google account.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/student/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">58</context>
+          <context context-type="linenumber">65</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">125</context>
+          <context context-type="linenumber">133</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="2e1aeaf8d183e6846a0463a08c784f472184fcf0">
@@ -5906,6 +5934,13 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">107</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit datatype="html" id="2b2f9f56dbfbfb71056a8da8c94e8011d837766e">
+        <source> Language required </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/teacher/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">108</context>
         </context-group>
       </trans-unit>
       <trans-unit datatype="html" id="44fcb249525dd82d1fd32cae51412bcda7ffd765">

--- a/src/main/webapp/site/src/style/layout/_section.scss
+++ b/src/main/webapp/site/src/style/layout/_section.scss
@@ -20,7 +20,7 @@
 }
 
 .section__tab {
-  padding: 24px 0;
+  padding: 24px 4px;
 
   @media (min-width: breakpoint('sm.min')) {
     padding: 24px 16px;

--- a/src/test/java/org/wise/portal/presentation/web/controllers/user/GoogleUserAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/user/GoogleUserAPIControllerTest.java
@@ -1,0 +1,108 @@
+package org.wise.portal.presentation.web.controllers.user;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.HashMap;
+
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.wise.portal.presentation.web.exception.InvalidPasswordExcpetion;
+
+public class GoogleUserAPIControllerTest extends UserAPIControllerTest {
+
+  @TestSubject
+  private GoogleUserAPIController controller = new GoogleUserAPIController();
+
+  @Test
+  public void isGoogleIdExist_GoogleUserExists_ReturnTrue() {
+    expect(userService.retrieveUserByGoogleUserId(STUDENT1_GOOGLE_ID)).andReturn(student1);
+    replay(userService);
+    assertTrue(controller.isGoogleIdExist(STUDENT1_GOOGLE_ID));
+    verify(userService);
+  }
+
+  @Test
+  public void isGoogleIdExist_InvalidGoogleUserId_ReturnFalse() {
+    String invalidGoogleId = "google-id-not-exists-in-db";
+    expect(userService.retrieveUserByGoogleUserId(invalidGoogleId)).andReturn(null);
+    replay(userService);
+    assertFalse(controller.isGoogleIdExist(invalidGoogleId));
+    verify(userService);
+  }
+
+  @Test
+  public void isGoogleIdMatches_GoogleUserIdAndUserIdMatch_ReturnTrue() {
+    expect(userService.retrieveUserByGoogleUserId(STUDENT1_GOOGLE_ID)).andReturn(student1);
+    replay(userService);
+    assertTrue(controller.isGoogleIdMatches(STUDENT1_GOOGLE_ID, student1Id.toString()));
+    verify(userService);
+  }
+
+  @Test
+  public void isGoogleIdMatches_InvalidGoogleUserId_ReturnFalse() {
+    String invalidGoogleId = "google-id-not-exists-in-db";
+    expect(userService.retrieveUserByGoogleUserId(invalidGoogleId)).andReturn(null);
+    replay(userService);
+    assertFalse(controller.isGoogleIdMatches(invalidGoogleId, student1Id.toString()));
+    verify(userService);
+  }
+
+  @Test
+  public void isGoogleIdMatches_GoogleUserIdAndUserIdDoNotMatch_ReturnFalse() {
+    expect(userService.retrieveUserByGoogleUserId(STUDENT1_GOOGLE_ID)).andReturn(teacher1);
+    replay(userService);
+    assertFalse(controller.isGoogleIdMatches(STUDENT1_GOOGLE_ID, teacher1.toString()));
+    verify(userService);
+  }
+
+  @Test
+  public void getUserByGoogleId_GoogleUserExists_ReturnSuccessResponse() {
+    expect(userService.retrieveUserByGoogleUserId(STUDENT1_GOOGLE_ID)).andReturn(student1);
+    replay(userService);
+    HashMap<String, Object> response = controller.getUserByGoogleId(STUDENT1_GOOGLE_ID);
+    assertEquals("success", response.get("status"));
+    assertEquals(student1.getId(), response.get("userId"));
+    verify(userService);
+  }
+
+  @Test
+  public void getUserByGoogleId_InvalidGoogleUserId_ReturnErrorResponse() {
+    String invalidGoogleId = "google-id-not-exists-in-db";
+    expect(userService.retrieveUserByGoogleUserId(invalidGoogleId)).andReturn(null);
+    replay(userService);
+    HashMap<String, Object> response = controller.getUserByGoogleId(invalidGoogleId);
+    assertEquals("error", response.get("status"));
+    verify(userService);
+  }
+
+  @Test
+  public void unlinkGoogleAccount_InvalidNewPassword_ThrowException() {
+    expect(userService.retrieveUserByUsername(STUDENT_USERNAME)).andReturn(student1);
+    replay(userService);
+    String newPass = "";
+    try {
+      controller.unlinkGoogleAccount(studentAuth, newPass);
+      fail("InvalidPasswordException was expected");
+    } catch (Exception e) {
+    }
+  }
+
+  @Test
+  public void unlinkGoogleAccount_ValidNewPassword_ReturnUpdatedUserMap()
+      throws InvalidPasswordExcpetion {
+    String newPassword = "my new pass";
+    assertTrue(student1.getUserDetails().isGoogleUser());
+    expect(userService.retrieveUserByUsername(STUDENT_USERNAME)).andReturn(student1).times(2);
+    expect(userService.updateUserPassword(student1, newPassword)).andReturn(student1);
+    expect(appProperties.getProperty("send_email_enabled", "false")).andReturn("false");
+    replay(userService, appProperties);
+    controller.unlinkGoogleAccount(studentAuth, newPassword);
+    verify(userService, appProperties);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/user/UserAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/user/UserAPIControllerTest.java
@@ -144,68 +144,6 @@ public class UserAPIControllerTest extends APIControllerTest {
   }
 
   @Test
-  public void isGoogleIdExist_GoogleUserExists_ReturnTrue() {
-    expect(userService.retrieveUserByGoogleUserId(STUDENT1_GOOGLE_ID)).andReturn(student1);
-    replay(userService);
-    assertTrue(userAPIController.isGoogleIdExist(STUDENT1_GOOGLE_ID));
-    verify(userService);
-  }
-
-  @Test
-  public void isGoogleIdExist_InvalidGoogleUserId_ReturnFalse() {
-    String invalidGoogleId = "google-id-not-exists-in-db";
-    expect(userService.retrieveUserByGoogleUserId(invalidGoogleId)).andReturn(null);
-    replay(userService);
-    assertFalse(userAPIController.isGoogleIdExist(invalidGoogleId));
-    verify(userService);
-  }
-
-  @Test
-  public void isGoogleIdMatches_GoogleUserIdAndUserIdMatch_ReturnTrue() {
-    expect(userService.retrieveUserByGoogleUserId(STUDENT1_GOOGLE_ID)).andReturn(student1);
-    replay(userService);
-    assertTrue(userAPIController.isGoogleIdMatches(STUDENT1_GOOGLE_ID, student1Id.toString()));
-    verify(userService);
-  }
-
-  @Test
-  public void isGoogleIdMatches_InvalidGoogleUserId_ReturnFalse() {
-    String invalidGoogleId = "google-id-not-exists-in-db";
-    expect(userService.retrieveUserByGoogleUserId(invalidGoogleId)).andReturn(null);
-    replay(userService);
-    assertFalse(userAPIController.isGoogleIdMatches(invalidGoogleId, student1Id.toString()));
-    verify(userService);
-  }
-
-  @Test
-  public void isGoogleIdMatches_GoogleUserIdAndUserIdDoNotMatch_ReturnFalse() {
-    expect(userService.retrieveUserByGoogleUserId(STUDENT1_GOOGLE_ID)).andReturn(teacher1);
-    replay(userService);
-    assertFalse(userAPIController.isGoogleIdMatches(STUDENT1_GOOGLE_ID, teacher1.toString()));
-    verify(userService);
-  }
-
-  @Test
-  public void getUserByGoogleId_GoogleUserExists_ReturnSuccessResponse() {
-    expect(userService.retrieveUserByGoogleUserId(STUDENT1_GOOGLE_ID)).andReturn(student1);
-    replay(userService);
-    HashMap<String, Object> response = userAPIController.getUserByGoogleId(STUDENT1_GOOGLE_ID);
-    assertEquals("success", response.get("status"));
-    assertEquals(student1.getId(), response.get("userId"));
-    verify(userService);
-  }
-
-  @Test
-  public void getUserByGoogleId_InvalidGoogleUserId_ReturnErrorResponse() {
-    String invalidGoogleId = "google-id-not-exists-in-db";
-    expect(userService.retrieveUserByGoogleUserId(invalidGoogleId)).andReturn(null);
-    replay(userService);
-    HashMap<String, Object> response = userAPIController.getUserByGoogleId(invalidGoogleId);
-    assertEquals("error", response.get("status"));
-    verify(userService);
-  }
-
-  @Test
   public void isNameValid_InvalidName_ReturnFalse() {
     assertFalse(userAPIController.isNameValid(""));
     assertFalse(userAPIController.isNameValid("Spongebob!"));


### PR DESCRIPTION
**Description**
Teachers and students can now unlink Google account from their WISE accounts. The prototypes for the unlinking sequence can be found on issue #2870. Teachers will get a confirmation email. The change should reflect immediately without refreshing, so that the unlink button will disappear and you can go directly to editing the password after unlinking the account.

@breity please style as needed. I could not figure out how to style the student form properly so that the bottom div with the buttons fill the entire width.

I've also cleaned up some code and added tests. I think we can extract common functions in teacher/student edit-profile component, but that should be done in a separate task.

**Testing**
For testing purposes, I found it useful to remember the googleUserId in the user_details table before unlinking it, so that you can re-set the google id with this query:
```
update `user_details` SET `googleUserId` = 'GOOGLE_ID' WHERE (`id` = 'USER_ID');
```

**Test for students and teachers**
- you can unlink the google account via edit profile and edit password pages
- you can still edit other profile values

**Additional test for teachers**
- an email is sent to the teacher with the confirmation

Closes #2870