### PR TITLE
Add Match advanced authoring options back

### DIFF
--- a/src/main/webapp/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html
+++ b/src/main/webapp/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html
@@ -15,6 +15,14 @@
   </div>
   <div>
     <md-checkbox class='md-primary'
+                 ng-if='$ctrl.isNotebookEnabled()'
+                 ng-model='$ctrl.authoringComponentContent.importPrivateNotes'
+                 ng-change='$ctrl.componentChanged()'>
+      {{ ::'match.showPrivateNotesAsChoices' | translate }}
+    </md-checkbox>
+  </div>
+  <div>
+    <md-checkbox class='md-primary'
                  ng-model='$ctrl.authoringComponentContent.showSaveButton'
                  ng-change='$ctrl.componentChanged()'>
       {{ ::'SHOW_SAVE_BUTTON' | translate }}
@@ -25,14 +33,6 @@
                  ng-model='$ctrl.authoringComponentContent.showSubmitButton'
                  ng-change='$ctrl.componentChanged()'>
       {{ ::'SHOW_SUBMIT_BUTTON' | translate }}
-    </md-checkbox>
-  </div>
-  <div>
-    <md-checkbox class='md-primary'
-                 ng-if='$ctrl.isNotebookEnabled()'
-                 ng-model='$ctrl.authoringComponentContent.importPrivateNotes'
-                 ng-change='$ctrl.componentChanged()'>
-      {{ ::'match.showPrivateNotesAsChoices' | translate }}
     </md-checkbox>
   </div>
   <div>

--- a/src/main/webapp/wise5/components/match/edit-match-advanced/edit-match-advanced.component.ts
+++ b/src/main/webapp/wise5/components/match/edit-match-advanced/edit-match-advanced.component.ts
@@ -27,5 +27,5 @@ export const EditMatchAdvancedComponent = {
     componentId: '@'
   },
   controller: EditMatchAdvancedController,
-  templateUrl: 'wise5/components/label/edit-label-advanced/edit-label-advanced.component.html'
+  templateUrl: 'wise5/components/match/edit-match-advanced/edit-match-advanced.component.html'
 };


### PR DESCRIPTION
Make sure these Match advanced authoring options show up in the popup
- Student Can Create Choices
- Show Source Bucket on the Left and Target Buckets on the Right
- Show Private Notes As Choices

Closes #2937